### PR TITLE
Add alert configuration fields for monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,25 @@ ALERT_ENABLED=false
 # Discord webhook URL (optional)
 DISCORD_WEBHOOK_URL=
 
+# Quota monitoring thresholds (fractions between 0-1)
+# Warning threshold for API quota (default: 0.2 = 20% remaining)
+QUOTA_WARNING_THRESHOLD=0.2
+
+# Critical threshold for API quota (default: 0.1 = 10% remaining)
+QUOTA_CRITICAL_THRESHOLD=0.1
+
+# Failure tracking threshold
+# Number of consecutive failures before alert (default: 3)
+CONSECUTIVE_FAILURES_THRESHOLD=3
+
+# Data staleness monitoring
+# Hours without new data before alert (default: 2)
+STALE_DATA_HOURS=2
+
+# Alert rate limiting
+# Minimum minutes between identical alerts (default: 30)
+ALERT_RATE_LIMIT_MINUTES=30
+
 # =============================================================================
 # LOGGING
 # =============================================================================

--- a/packages/odds-core/odds_core/config.py
+++ b/packages/odds-core/odds_core/config.py
@@ -104,6 +104,34 @@ class AlertConfig(BaseSettings):
     discord_webhook_url: str | None = Field(default=None, description="Discord webhook URL")
     alert_enabled: bool = Field(default=False, description="Enable alerts")
 
+    # Quota monitoring thresholds
+    quota_warning_threshold: float = Field(
+        default=0.2,
+        description="Trigger warning when API quota falls below this fraction (0-1)",
+    )
+    quota_critical_threshold: float = Field(
+        default=0.1,
+        description="Trigger critical alert when API quota falls below this fraction (0-1)",
+    )
+
+    # Failure tracking thresholds
+    consecutive_failures_threshold: int = Field(
+        default=3,
+        description="Number of consecutive failures before triggering alert",
+    )
+
+    # Data staleness monitoring
+    stale_data_hours: int = Field(
+        default=2,
+        description="Hours without new data before triggering stale data alert",
+    )
+
+    # Alert rate limiting
+    alert_rate_limit_minutes: int = Field(
+        default=30,
+        description="Minimum minutes between identical alerts to prevent spam",
+    )
+
 
 class LoggingConfig(BaseSettings):
     """Logging configuration."""


### PR DESCRIPTION
Extends AlertConfig class with configurable thresholds to enable fine-tuned control over when alerts are triggered.

New fields added:
- quota_warning_threshold (float, default 0.2): Alert at 20% quota
- quota_critical_threshold (float, default 0.1): Critical at 10% quota
- consecutive_failures_threshold (int, default 3): Failures before alert
- stale_data_hours (int, default 2): Hours before stale data alert
- alert_rate_limit_minutes (int, default 30): Min time between alerts

All fields include proper type hints, sensible production-ready defaults, and descriptive documentation. Environment variables documented in .env.example with clear comments.

Changes are backward compatible - all fields have defaults and will function without new environment variables.

Resolves #47