### PR TITLE
Add critical and warning validation tiers

### DIFF
--- a/packages/odds-analytics/odds_analytics/gap_backfill_planner.py
+++ b/packages/odds-analytics/odds_analytics/gap_backfill_planner.py
@@ -111,9 +111,10 @@ class GapBackfillPlanner:
         }
 
         for report in reports:
-            # Process each incomplete game in the report
+            # Process each game with any missing tiers (for backfill purposes)
+            # Note: is_complete only checks critical tiers; backfill should fill all gaps
             for game_report in report.game_reports:
-                if not game_report.is_complete:
+                if len(game_report.tiers_missing) > 0:
                     # Calculate missing snapshots for this game
                     missing_snapshot_count = await self._calculate_missing_snapshots(
                         game_report.event_id,


### PR DESCRIPTION
Prevents daily validation workflows from failing when only lower-priority tier data is missing. Critical tiers (PREGAME, CLOSING) must be present for validation success, while warning tiers (OPENING, EARLY, SHARP) only generate warnings.

Changes:
- Add CRITICAL_TIERS and WARNING_TIERS constants
- Extend TierCoverageReport with critical_tiers_missing, warning_tiers_missing, and has_tier_warnings properties
- Modify is_complete to check only critical tiers
- Add games_with_warnings tracking to DailyValidationReport
- Update CLI exit codes: return 0 for warnings-only, 1 for critical failures
- Display critical issues in red, warnings in yellow
- Include warning information in JSON output
- Update GapBackfillPlanner to find all missing tiers for backfill purposes
- Add comprehensive tests for new validation behavior

Closes #58