### PR TITLE
Add hyperparameter configuration support for ML

### DIFF
--- a/packages/odds-analytics/odds_analytics/lstm_strategy.py
+++ b/packages/odds-analytics/odds_analytics/lstm_strategy.py
@@ -68,7 +68,7 @@ Example:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import structlog
@@ -78,7 +78,7 @@ from odds_core.models import Event, Odds
 from sqlalchemy.ext.asyncio import AsyncSession
 
 if TYPE_CHECKING:
-    from odds_analytics.training.config import MLTrainingConfig, SearchSpace
+    from odds_analytics.training.config import MLTrainingConfig
 
 from odds_analytics.backtesting import (
     BacktestConfig,
@@ -412,7 +412,7 @@ class LSTMStrategy(BettingStrategy):
             >>> strategy = LSTMStrategy()
             >>> history = await strategy.train_from_config(config, events, session)
         """
-        from odds_analytics.training.config import LSTMConfig
+        from odds_analytics.training.config import LSTMConfig, resolve_search_spaces
 
         # Validate strategy type
         if config.training.strategy_type not in ("lstm", "lstm_line_movement"):
@@ -465,9 +465,7 @@ class LSTMStrategy(BettingStrategy):
         }
 
         if config.tuning and config.tuning.search_spaces:
-            resolved_params = self._resolve_search_spaces(
-                resolved_params, config.tuning.search_spaces
-            )
+            resolved_params = resolve_search_spaces(resolved_params, config.tuning.search_spaces)
             # Re-apply resolved architecture params
             self.params["hidden_size"] = resolved_params["hidden_size"]
             self.params["num_layers"] = resolved_params["num_layers"]
@@ -515,84 +513,6 @@ class LSTMStrategy(BettingStrategy):
         )
 
         return history
-
-    def _resolve_search_spaces(
-        self,
-        params: dict[str, Any],
-        search_spaces: dict[str, SearchSpace],
-    ) -> dict[str, Any]:
-        """
-        Resolve search spaces to concrete values using midpoints.
-
-        When Optuna is not available, this method converts search space
-        definitions to concrete values using the midpoint of the range
-        (for int/float types) or the first choice (for categorical types).
-
-        Args:
-            params: Current parameter dictionary
-            search_spaces: Search space definitions from tuning config
-
-        Returns:
-            Updated parameters with resolved values
-        """
-        resolved = params.copy()
-
-        for param_name, space in search_spaces.items():
-            if param_name not in resolved:
-                logger.warning(
-                    "unknown_search_space_param",
-                    param_name=param_name,
-                    message=f"Search space defined for unknown parameter '{param_name}'",
-                )
-                continue
-
-            if space.type == "int":
-                # Use midpoint for integer parameters
-                midpoint = int((space.low + space.high) / 2)
-                if space.step:
-                    # Round to nearest step
-                    midpoint = int(round(midpoint / space.step) * space.step)
-                resolved[param_name] = midpoint
-                logger.debug(
-                    "resolved_search_space",
-                    param_name=param_name,
-                    value=midpoint,
-                    space_type="int",
-                    low=space.low,
-                    high=space.high,
-                )
-
-            elif space.type == "float":
-                if space.log:
-                    # Use geometric mean for log-scale parameters
-                    import math
-
-                    midpoint = math.exp((math.log(space.low) + math.log(space.high)) / 2)
-                else:
-                    # Use arithmetic mean for linear-scale parameters
-                    midpoint = (space.low + space.high) / 2
-                resolved[param_name] = midpoint
-                logger.debug(
-                    "resolved_search_space",
-                    param_name=param_name,
-                    value=midpoint,
-                    space_type="float",
-                    log_scale=space.log,
-                )
-
-            elif space.type == "categorical":
-                # Use first choice for categorical parameters
-                if space.choices:
-                    resolved[param_name] = space.choices[0]
-                    logger.debug(
-                        "resolved_search_space",
-                        param_name=param_name,
-                        value=space.choices[0],
-                        space_type="categorical",
-                        choices=space.choices,
-                    )
-
-        return resolved
 
     async def evaluate_opportunity(
         self,

--- a/packages/odds-analytics/odds_analytics/training/config.py
+++ b/packages/odds-analytics/odds_analytics/training/config.py
@@ -34,12 +34,16 @@ Example usage:
 from __future__ import annotations
 
 import json
+import math
 from datetime import date
 from pathlib import Path
 from typing import Any, Literal
 
+import structlog
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+logger = structlog.get_logger()
 
 __all__ = [
     "ExperimentConfig",
@@ -52,6 +56,7 @@ __all__ = [
     "TuningConfig",
     "TrackingConfig",
     "MLTrainingConfig",
+    "resolve_search_spaces",
 ]
 
 
@@ -927,3 +932,94 @@ class MLTrainingConfig(BaseModel):
         """
         data = cls._preprocess_model_config(data)
         return cls.model_validate(data)
+
+
+# =============================================================================
+# Utility Functions
+# =============================================================================
+
+
+def resolve_search_spaces(
+    params: dict[str, Any],
+    search_spaces: dict[str, SearchSpace],
+) -> dict[str, Any]:
+    """
+    Resolve search spaces to concrete values using midpoints.
+
+    When Optuna is not available, this function converts search space
+    definitions to concrete values using the midpoint of the range
+    (for int/float types) or the first choice (for categorical types).
+
+    Args:
+        params: Current parameter dictionary
+        search_spaces: Search space definitions from tuning config
+
+    Returns:
+        Updated parameters with resolved values
+
+    Example:
+        >>> params = {"n_estimators": 100, "learning_rate": 0.1}
+        >>> search_spaces = {
+        ...     "n_estimators": SearchSpace(type="int", low=50, high=150),
+        ...     "learning_rate": SearchSpace(type="float", low=0.01, high=0.3, log=True),
+        ... }
+        >>> resolved = resolve_search_spaces(params, search_spaces)
+        >>> resolved["n_estimators"]  # 100 (midpoint of 50-150)
+        >>> resolved["learning_rate"]  # ~0.055 (geometric mean)
+    """
+    resolved = params.copy()
+
+    for param_name, space in search_spaces.items():
+        if param_name not in resolved:
+            logger.warning(
+                "unknown_search_space_param",
+                param_name=param_name,
+                message=f"Search space defined for unknown parameter '{param_name}'",
+            )
+            continue
+
+        if space.type == "int":
+            # Use midpoint for integer parameters
+            midpoint = int((space.low + space.high) / 2)
+            if space.step:
+                # Round to nearest step
+                midpoint = int(round(midpoint / space.step) * space.step)
+            resolved[param_name] = midpoint
+            logger.debug(
+                "resolved_search_space",
+                param_name=param_name,
+                value=midpoint,
+                space_type="int",
+                low=space.low,
+                high=space.high,
+            )
+
+        elif space.type == "float":
+            if space.log:
+                # Use geometric mean for log-scale parameters
+                midpoint = math.exp((math.log(space.low) + math.log(space.high)) / 2)
+            else:
+                # Use arithmetic mean for linear-scale parameters
+                midpoint = (space.low + space.high) / 2
+            resolved[param_name] = midpoint
+            logger.debug(
+                "resolved_search_space",
+                param_name=param_name,
+                value=midpoint,
+                space_type="float",
+                log_scale=space.log,
+            )
+
+        elif space.type == "categorical":
+            # Use first choice for categorical parameters
+            if space.choices:
+                resolved[param_name] = space.choices[0]
+                logger.debug(
+                    "resolved_search_space",
+                    param_name=param_name,
+                    value=space.choices[0],
+                    space_type="categorical",
+                    choices=space.choices,
+                )
+
+    return resolved


### PR DESCRIPTION
Implement configuration-based hyperparameter support for ML strategy classes, enabling flexible model training setup without hardcoding values.

Changes:
- Add train_from_config() to XGBoostStrategy (ml_strategy_example.py)
- Add train_from_config() to XGBoostLineMovementStrategy
- Add train_from_config() to LSTMStrategy (async version)
- Add _resolve_search_spaces() helper to convert search spaces to concrete values using midpoints when Optuna is not available
- Comprehensive logging of all hyperparameters for experiment tracking
- Validation with clear error messages for invalid config types
- Add unit tests covering:
  - Configuration extraction from nested structures
  - Search space resolution (int, float, categorical)
  - Error handling for invalid parameters
  - Both XGBoost and LSTM paths

Closes #68