### PR TITLE
Add feature extraction parameters to training config

### DIFF
--- a/packages/odds-analytics/odds_analytics/training/config.py
+++ b/packages/odds-analytics/odds_analytics/training/config.py
@@ -413,6 +413,26 @@ class FeatureConfig(BaseModel):
         description="Hours before game for closing line snapshot",
     )
 
+    # Sequence model configuration (LSTM)
+    lookback_hours: int = Field(
+        default=72,
+        ge=1,
+        le=168,
+        description="Hours of historical data to use for sequence models",
+    )
+    timesteps: int = Field(
+        default=24,
+        ge=1,
+        le=168,
+        description="Number of sequence timesteps for LSTM models",
+    )
+
+    # Feature processing
+    normalize: bool = Field(
+        default=False,
+        description="Whether to normalize features before model input",
+    )
+
     @model_validator(mode="after")
     def validate_timing(self) -> FeatureConfig:
         """Ensure opening is before closing."""


### PR DESCRIPTION
- Add lookback_hours, timesteps, and normalize fields to FeatureConfig
- Implement from_config factory methods for TabularFeatureExtractor and SequenceFeatureExtractor to enable configuration-driven instantiation
- Update prepare_training_data_from_config to use factory methods
- Add comprehensive unit tests for config → extractor → features pipeline