### PR TITLE
Add metadata and versioning to model persistence

### DIFF
--- a/packages/odds-analytics/pyproject.toml
+++ b/packages/odds-analytics/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "numpy>=1.24.0",
     "scikit-learn>=1.3.0",
     "torch>=2.0.0",
+    "joblib>=1.3.0",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -2349,6 +2349,7 @@ name = "odds-analytics"
 version = "0.1.0"
 source = { editable = "packages/odds-analytics" }
 dependencies = [
+    { name = "joblib" },
     { name = "numpy" },
     { name = "odds-core" },
     { name = "odds-lambda" },
@@ -2367,6 +2368,7 @@ ml = [
 
 [package.metadata]
 requires-dist = [
+    { name = "joblib", specifier = ">=1.3.0" },
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "odds-core", editable = "packages/odds-core" },
     { name = "odds-lambda", editable = "packages/odds-lambda" },


### PR DESCRIPTION
- Migrate XGBoost from pickle to joblib serialization
- Save YAML config files alongside model files for both XGBoost and LSTM
- Add backward compatibility support for loading old pickle format models
- Config files include model type, timestamp, parameters, and architecture
- Add comprehensive unit tests for save/load cycles with config files
- Add joblib dependency to odds-analytics

Closes #72