### PR TITLE
Remove execution and redundant features from tabular pipeline

### DIFF
--- a/packages/odds-analytics/odds_analytics/polymarket_features.py
+++ b/packages/odds-analytics/odds_analytics/polymarket_features.py
@@ -89,28 +89,15 @@ class CrossSourceFeatures:
     """
     Features comparing Polymarket prices against sportsbook odds.
 
-    Captures divergence, direction, and relative pricing signals between
-    the two market types. All fields optional.
+    Focused on divergence signals relevant to line movement prediction.
+    All fields optional.
     """
 
     # PM vs SB consensus probability divergence
     pm_sb_prob_divergence: float | None = None  # pm_home_prob - sb_consensus_prob
-    pm_sb_divergence_abs: float | None = None  # abs(divergence)
-    pm_sb_divergence_direction: float | None = None  # +1 if PM higher, -1 if lower, 0 if equal
-
-    # PM spread vs SB market hold (relative liquidity cost)
-    pm_spread_vs_sb_hold: float | None = None  # pm_spread - sb_avg_market_hold
 
     # PM vs sharp bookmaker divergence
     pm_sharp_divergence: float | None = None  # pm_home_prob - sharp_prob
-    pm_sharp_divergence_abs: float | None = None
-
-    # PM midpoint vs SB consensus (using order book midpoint if available)
-    pm_mid_vs_sb_consensus: float | None = None  # pm_midpoint - sb_consensus_prob
-
-    # PM-SB convergence rate (change in divergence per hour)
-    # None when insufficient historical cross-source data
-    pm_sb_convergence_rate: float | None = None
 
     def to_array(self) -> np.ndarray:
         """Convert to numpy array. None → np.nan."""
@@ -294,27 +281,10 @@ class CrossSourceFeatureExtractor:
 
         # PM vs SB consensus divergence
         if sb_features.consensus_prob is not None:
-            divergence = pm_features.pm_home_prob - sb_features.consensus_prob
-            result.pm_sb_prob_divergence = divergence
-            result.pm_sb_divergence_abs = abs(divergence)
-            result.pm_sb_divergence_direction = (
-                1.0 if divergence > 0 else -1.0 if divergence < 0 else 0.0
-            )
-
-        # PM spread vs SB market hold
-        if pm_features.pm_spread is not None and sb_features.avg_market_hold is not None:
-            result.pm_spread_vs_sb_hold = pm_features.pm_spread - sb_features.avg_market_hold
+            result.pm_sb_prob_divergence = pm_features.pm_home_prob - sb_features.consensus_prob
 
         # PM vs sharp divergence
         if sb_features.sharp_prob is not None:
-            sharp_div = pm_features.pm_home_prob - sb_features.sharp_prob
-            result.pm_sharp_divergence = sharp_div
-            result.pm_sharp_divergence_abs = abs(sharp_div)
-
-        # PM midpoint vs SB consensus
-        if pm_features.pm_midpoint is not None and sb_features.consensus_prob is not None:
-            result.pm_mid_vs_sb_consensus = pm_features.pm_midpoint - sb_features.consensus_prob
-
-        # pm_sb_convergence_rate: not computed in v1 (requires historical cross-source data)
+            result.pm_sharp_divergence = pm_features.pm_home_prob - sb_features.sharp_prob
 
         return result

--- a/tests/unit/test_feature_extraction.py
+++ b/tests/unit/test_feature_extraction.py
@@ -202,7 +202,6 @@ class TestTabularFeatureExtractor:
 
         assert features.consensus_prob is not None
         assert 0 < features.consensus_prob < 1
-        assert features.opponent_consensus_prob is not None
 
     def test_extract_features_includes_sharp_features(self, sample_event, sample_odds_snapshot):
         """Test that sharp bookmaker features are extracted."""
@@ -212,8 +211,6 @@ class TestTabularFeatureExtractor:
         )
 
         assert features.sharp_prob is not None
-        assert features.sharp_market_hold is not None
-        assert features.sharp_market_hold > 0  # Should have some vig
 
     def test_extract_features_includes_retail_sharp_diff(self, sample_event, sample_odds_snapshot):
         """Test that retail vs sharp differences are calculated."""
@@ -223,17 +220,6 @@ class TestTabularFeatureExtractor:
         )
 
         assert features.retail_sharp_diff is not None
-
-    def test_extract_features_includes_best_odds(self, sample_event, sample_odds_snapshot):
-        """Test that best available odds are found."""
-        extractor = TabularFeatureExtractor()
-        features = extractor.extract_features(
-            sample_event, sample_odds_snapshot, market="h2h", outcome=sample_event.home_team
-        )
-
-        assert features.best_available_odds is not None
-        assert features.best_available_decimal is not None
-        assert features.best_available_decimal > 1.0
 
     def test_extract_features_empty_odds(self, sample_event):
         """Test that extract_features handles empty odds gracefully."""
@@ -289,7 +275,7 @@ class TestTabularFeatureExtractor:
         assert vector[names.index("consensus_prob")] == 0.55
 
         # Optional fields that are None should be NaN
-        assert np.isnan(vector[names.index("opponent_consensus_prob")])
+        assert np.isnan(vector[names.index("sharp_prob")])
 
     def test_create_feature_vector_uses_get_feature_names_by_default(
         self, sample_event, sample_odds_snapshot

--- a/tests/unit/test_ml_strategy_example.py
+++ b/tests/unit/test_ml_strategy_example.py
@@ -131,7 +131,6 @@ class TestTabularFeatureExtractor:
 
         assert features.consensus_prob is not None
         assert 0 < features.consensus_prob < 1
-        assert features.opponent_consensus_prob is not None
 
     def test_extract_features_includes_sharp_features(self, sample_event, sample_odds_snapshot):
         """Test that sharp bookmaker features are extracted."""
@@ -141,8 +140,6 @@ class TestTabularFeatureExtractor:
         )
 
         assert features.sharp_prob is not None
-        assert features.sharp_market_hold is not None
-        assert features.sharp_market_hold > 0  # Should have some vig
 
     def test_extract_features_includes_retail_sharp_diff(self, sample_event, sample_odds_snapshot):
         """Test that retail vs sharp differences are calculated."""
@@ -152,17 +149,6 @@ class TestTabularFeatureExtractor:
         )
 
         assert features.retail_sharp_diff is not None
-
-    def test_extract_features_includes_best_odds(self, sample_event, sample_odds_snapshot):
-        """Test that best available odds are found."""
-        extractor = TabularFeatureExtractor()
-        features = extractor.extract_features(
-            sample_event, sample_odds_snapshot, market="h2h", outcome=sample_event.home_team
-        )
-
-        assert features.best_available_odds is not None
-        assert features.best_available_decimal is not None
-        assert features.best_available_decimal > 1.0
 
     def test_extract_features_empty_odds(self, sample_event):
         """Test that extract_features handles empty odds gracefully."""


### PR DESCRIPTION
## Summary
- **TabularFeatures** pruned from 14 → 4 fields: removed line shopping (execution data), market hold (market structure), and redundant opponent-side/format pairs. Retained `consensus_prob`, `sharp_prob`, `retail_sharp_diff`, `num_bookmakers` — the features relevant to line movement prediction.
- **CrossSourceFeatures** pruned from 8 → 2 fields: removed redundant transforms (abs, direction), execution data (spread vs hold), and unimplemented fields. Retained `pm_sb_prob_divergence` and `pm_sharp_divergence`.
- Extraction logic simplified accordingly — no more market hold computation, line shopping, or opponent-side extraction.

## Context
Research into CLV delta prediction (see `experiments/RESEARCH_clv_prediction_features.md`) found that our feature set conflated ML features with execution data and included heavy redundancy (140 collinear pairs). Line shopping features tell you *where* to bet, not *where lines will move*. Market hold describes vig structure, not movement direction. Opponent-side features are derivable from the outcome side + hold.

## Test plan
- [x] All 1094 tests pass (1 pre-existing failure in `test_config.py` unrelated)
- [x] Ruff check + format clean
- [x] Verified no remaining references to removed fields in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)