### PR TITLE
Resolve LSTM config/feature asymmetry with XGBoost path

### DIFF
--- a/packages/odds-analytics/odds_analytics/feature_extraction.py
+++ b/packages/odds-analytics/odds_analytics/feature_extraction.py
@@ -593,6 +593,12 @@ class SequenceFeatureExtractor(FeatureExtractor):
             extractor = SequenceFeatureExtractor.from_config(config)
             ```
         """
+        if config.lookback_hours is None or config.timesteps is None:
+            raise ValueError(
+                "SequenceFeatureExtractor requires lookback_hours and timesteps "
+                "to be set in FeatureConfig (auto-populated from LSTMConfig "
+                "when using config-driven training)."
+            )
         return cls(
             lookback_hours=config.lookback_hours,
             timesteps=config.timesteps,

--- a/packages/odds-analytics/odds_analytics/feature_groups.py
+++ b/packages/odds-analytics/odds_analytics/feature_groups.py
@@ -492,7 +492,13 @@ class XGBoostAdapter:
 
 
 class LSTMAdapter:
-    """Sequence feature adapter for LSTM (and other recurrent) models."""
+    """Sequence feature adapter for LSTM (and other recurrent) models.
+
+    Produces a fixed 14-feature ``SequenceFeatures`` vector per timestep.
+    Unlike ``XGBoostAdapter``, this adapter does **not** compose features
+    from ``config.feature_groups`` — the sequence feature set is fixed and
+    determined entirely by ``SequenceFeatureExtractor``.
+    """
 
     def feature_names(self, config: FeatureConfig) -> list[str]:
         from odds_analytics.feature_extraction import SequenceFeatures

--- a/tests/unit/test_train_from_config.py
+++ b/tests/unit/test_train_from_config.py
@@ -8,6 +8,7 @@ from odds_analytics.ml_strategy_example import XGBoostStrategy
 from odds_analytics.training.config import (
     DataConfig,
     ExperimentConfig,
+    FeatureConfig,
     LSTMConfig,
     MLTrainingConfig,
     SearchSpace,
@@ -98,6 +99,7 @@ def sample_lstm_config():
                 lookback_hours=48,
                 timesteps=12,
             ),
+            features=FeatureConfig(adapter="lstm"),
         ),
     )
 
@@ -205,6 +207,7 @@ class TestXGBoostStrategyTrainFromConfig:
                     end_date=date(2024, 12, 31),
                 ),
                 model=LSTMConfig(),  # Wrong config type
+                features=FeatureConfig(adapter="lstm"),
             ),
         )
 

--- a/tests/unit/test_training_data_preparation.py
+++ b/tests/unit/test_training_data_preparation.py
@@ -239,6 +239,7 @@ class TestPrepareTrainingDataFromConfig:
                     lookback_hours=72,
                     timesteps=24,
                 ),
+                features=FeatureConfig(adapter="lstm"),
             ),
         )
 


### PR DESCRIPTION
## Summary

- **`FeatureConfig.lookback_hours`/`timesteps`** changed from `int` (default 72/24) to `int | None` (default `None`) — XGBoost never needs them
- **`TrainingConfig.sync_lstm_sequence_params`** validator auto-propagates values from `LSTMConfig` when `None`, raises `ValueError` on mismatch or wrong adapter type
- **`SequenceFeatureExtractor.from_config()`** null guard raises clear error if sequence params missing
- **`LSTMAdapter`** docstring documents fixed feature set (does not use `feature_groups`)

Closes #140

## Test plan

- [ ] CI passes (unit + integration tests)
- [ ] New tests: auto-propagation, mismatch raises, wrong adapter raises, XGBoost unaffected
- [ ] All existing LSTM test fixtures updated for new validator requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)