### PR TITLE
Add rest/schedule features to CLV prediction pipeline

### DIFF
--- a/packages/odds-analytics/odds_analytics/schedule_features.py
+++ b/packages/odds-analytics/odds_analytics/schedule_features.py
@@ -1,0 +1,143 @@
+"""Rest and schedule feature extraction for CLV prediction.
+
+Provides a RestScheduleFeatures dataclass and extractor that converts NBA
+game log data into ML-ready rest and schedule features. Back-to-back games
+and rest asymmetry are well-established predictive signals in sports analytics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from datetime import date
+
+import numpy as np
+from odds_core.game_log_models import NbaTeamGameLog
+from odds_core.models import Event
+
+__all__ = [
+    "RestScheduleFeatures",
+    "extract_rest_features",
+]
+
+
+@dataclass
+class RestScheduleFeatures:
+    """Rest and schedule features for a single event.
+
+    All fields optional (None -> np.nan). Days rest counts calendar days
+    between game dates: back-to-back (consecutive days) = 1.
+    """
+
+    home_days_rest: float | None = None
+    away_days_rest: float | None = None
+    rest_advantage: float | None = None
+    home_is_b2b: float | None = None
+    away_is_b2b: float | None = None
+
+    def to_array(self) -> np.ndarray:
+        """Convert to numpy array. None -> np.nan."""
+        return np.array(
+            [
+                getattr(self, f.name) if getattr(self, f.name) is not None else np.nan
+                for f in fields(self)
+            ],
+            dtype=np.float64,
+        )
+
+    @classmethod
+    def get_feature_names(cls) -> list[str]:
+        return [f.name for f in fields(cls)]
+
+
+def _identify_teams(
+    event_logs: list[NbaTeamGameLog],
+) -> tuple[str | None, str | None]:
+    """Identify home and away team abbreviations from matchup strings.
+
+    NBA matchup format: 'BOS vs. NYK' (home) or 'NYK @ BOS' (away).
+    """
+    home_abbrev: str | None = None
+    away_abbrev: str | None = None
+    for log in event_logs:
+        if " vs. " in log.matchup:
+            home_abbrev = log.team_abbreviation
+        elif " @ " in log.matchup:
+            away_abbrev = log.team_abbreviation
+    return home_abbrev, away_abbrev
+
+
+def _find_previous_game(
+    all_logs: list[NbaTeamGameLog],
+    team_abbreviation: str,
+    current_game_date: date,
+) -> NbaTeamGameLog | None:
+    """Find the most recent game for a team before current_game_date."""
+    prior = [
+        g
+        for g in all_logs
+        if g.team_abbreviation == team_abbreviation and g.game_date < current_game_date
+    ]
+    if not prior:
+        return None
+    return max(prior, key=lambda g: g.game_date)
+
+
+def extract_rest_features(
+    game_logs: list[NbaTeamGameLog],
+    event: Event,
+) -> RestScheduleFeatures:
+    """Extract rest/schedule features from pre-loaded game logs.
+
+    Takes game logs for both teams (event's own logs + prior games) and
+    computes rest features. Schedule data is public knowledge, so there
+    is no look-ahead bias concern.
+
+    Args:
+        game_logs: Event's game logs + prior games for each team.
+        event: Sportsbook event (provides event_id for filtering).
+
+    Returns:
+        RestScheduleFeatures, or all-None if no game logs available.
+    """
+    if not game_logs:
+        return RestScheduleFeatures()
+
+    event_logs = [g for g in game_logs if g.event_id == event.id]
+    if not event_logs:
+        return RestScheduleFeatures()
+
+    current_game_date = event_logs[0].game_date
+    home_abbrev, away_abbrev = _identify_teams(event_logs)
+
+    home_days_rest: float | None = None
+    away_days_rest: float | None = None
+
+    if home_abbrev:
+        prev = _find_previous_game(game_logs, home_abbrev, current_game_date)
+        if prev:
+            home_days_rest = float((current_game_date - prev.game_date).days)
+
+    if away_abbrev:
+        prev = _find_previous_game(game_logs, away_abbrev, current_game_date)
+        if prev:
+            away_days_rest = float((current_game_date - prev.game_date).days)
+
+    rest_advantage: float | None = None
+    if home_days_rest is not None and away_days_rest is not None:
+        rest_advantage = home_days_rest - away_days_rest
+
+    home_is_b2b: float | None = None
+    if home_days_rest is not None:
+        home_is_b2b = 1.0 if home_days_rest == 1.0 else 0.0
+
+    away_is_b2b: float | None = None
+    if away_days_rest is not None:
+        away_is_b2b = 1.0 if away_days_rest == 1.0 else 0.0
+
+    return RestScheduleFeatures(
+        home_days_rest=home_days_rest,
+        away_days_rest=away_days_rest,
+        rest_advantage=rest_advantage,
+        home_is_b2b=home_is_b2b,
+        away_is_b2b=away_is_b2b,
+    )

--- a/packages/odds-analytics/odds_analytics/training/config.py
+++ b/packages/odds-analytics/odds_analytics/training/config.py
@@ -572,7 +572,7 @@ class FeatureConfig(BaseModel):
     feature_groups: tuple[str, ...] = Field(
         default=("tabular",),
         min_length=1,
-        description="Feature groups to compose. Available: tabular, trajectory, polymarket, injuries",
+        description="Feature groups to compose. Available: tabular, trajectory, polymarket, injuries, rest",
     )
 
     # Trajectory feature configuration

--- a/packages/odds-lambda/odds_lambda/storage/game_log_reader.py
+++ b/packages/odds-lambda/odds_lambda/storage/game_log_reader.py
@@ -44,6 +44,25 @@ class GameLogReader:
         result = await self.session.execute(query)
         return list(result.scalars().all())
 
+    async def get_team_previous_game(
+        self, team_abbreviation: str, before_date: date
+    ) -> NbaTeamGameLog | None:
+        """Get the most recent game for a team before a given date.
+
+        Uses the (team_abbreviation, game_date) index for efficient lookup.
+        """
+        query = (
+            select(NbaTeamGameLog)
+            .where(
+                NbaTeamGameLog.team_abbreviation == team_abbreviation,
+                NbaTeamGameLog.game_date < before_date,
+            )
+            .order_by(NbaTeamGameLog.game_date.desc())
+            .limit(1)
+        )
+        result = await self.session.execute(query)
+        return result.scalars().first()
+
     async def get_pipeline_stats(self) -> GameLogPipelineStats:
         """Aggregate pipeline health statistics."""
         # Total rows

--- a/tests/unit/test_schedule_features.py
+++ b/tests/unit/test_schedule_features.py
@@ -1,0 +1,353 @@
+"""Unit tests for rest/schedule feature extraction."""
+
+from datetime import UTC, date, datetime
+
+import numpy as np
+from odds_analytics.schedule_features import RestScheduleFeatures, extract_rest_features
+from odds_core.game_log_models import NbaTeamGameLog
+from odds_core.models import Event
+
+
+def _make_event(
+    event_id: str = "test_event_1",
+    home_team: str = "Los Angeles Lakers",
+    away_team: str = "Boston Celtics",
+    commence_time: datetime | None = None,
+) -> Event:
+    if commence_time is None:
+        commence_time = datetime(2025, 1, 15, 0, 30, tzinfo=UTC)
+    return Event(
+        id=event_id,
+        sport_key="basketball_nba",
+        sport_title="NBA",
+        home_team=home_team,
+        away_team=away_team,
+        commence_time=commence_time,
+    )
+
+
+def _make_game_log(
+    team_abbreviation: str = "LAL",
+    game_date: date = date(2025, 1, 15),
+    matchup: str = "LAL vs. BOS",
+    event_id: str | None = "test_event_1",
+    nba_game_id: str = "0022400100",
+    team_id: int = 1610612747,
+    season: str = "2024-25",
+) -> NbaTeamGameLog:
+    return NbaTeamGameLog(
+        nba_game_id=nba_game_id,
+        team_id=team_id,
+        team_abbreviation=team_abbreviation,
+        game_date=game_date,
+        matchup=matchup,
+        season=season,
+        event_id=event_id,
+    )
+
+
+class TestRestScheduleFeaturesDataclass:
+    def test_get_feature_names(self) -> None:
+        names = RestScheduleFeatures.get_feature_names()
+        assert names == [
+            "home_days_rest",
+            "away_days_rest",
+            "rest_advantage",
+            "home_is_b2b",
+            "away_is_b2b",
+        ]
+
+    def test_to_array_all_none(self) -> None:
+        features = RestScheduleFeatures()
+        arr = features.to_array()
+        assert arr.shape == (5,)
+        assert np.all(np.isnan(arr))
+
+    def test_to_array_with_values(self) -> None:
+        features = RestScheduleFeatures(
+            home_days_rest=2.0,
+            away_days_rest=1.0,
+            rest_advantage=1.0,
+            home_is_b2b=0.0,
+            away_is_b2b=1.0,
+        )
+        arr = features.to_array()
+        assert arr.shape == (5,)
+        np.testing.assert_array_equal(arr, [2.0, 1.0, 1.0, 0.0, 1.0])
+
+    def test_to_array_partial_none(self) -> None:
+        features = RestScheduleFeatures(home_days_rest=3.0)
+        arr = features.to_array()
+        assert arr[0] == 3.0
+        assert np.isnan(arr[1])
+
+    def test_feature_count_matches_names(self) -> None:
+        assert len(RestScheduleFeatures.get_feature_names()) == len(
+            RestScheduleFeatures().to_array()
+        )
+
+
+class TestExtractRestFeatures:
+    def test_empty_logs_returns_all_none(self) -> None:
+        event = _make_event()
+        features = extract_rest_features([], event)
+        assert np.all(np.isnan(features.to_array()))
+
+    def test_no_event_logs_returns_all_none(self) -> None:
+        """Game logs exist but none linked to this event."""
+        event = _make_event(event_id="test_event_1")
+        unlinked_log = _make_game_log(event_id="other_event")
+        features = extract_rest_features([unlinked_log], event)
+        assert np.all(np.isnan(features.to_array()))
+
+    def test_no_prior_game_returns_none_for_rest(self) -> None:
+        """Season opener — event game log exists but no prior game."""
+        event = _make_event()
+        event_log_home = _make_game_log(
+            team_abbreviation="LAL",
+            game_date=date(2025, 1, 15),
+            matchup="LAL vs. BOS",
+            event_id="test_event_1",
+        )
+        event_log_away = _make_game_log(
+            team_abbreviation="BOS",
+            game_date=date(2025, 1, 15),
+            matchup="BOS @ LAL",
+            event_id="test_event_1",
+            nba_game_id="0022400100",
+            team_id=1610612738,
+        )
+        features = extract_rest_features([event_log_home, event_log_away], event)
+        assert np.all(np.isnan(features.to_array()))
+
+    def test_normal_rest(self) -> None:
+        """Home team rested 3 days, away team rested 2 days."""
+        event = _make_event()
+        game_logs = [
+            # Event's own game logs (Jan 15)
+            _make_game_log(
+                team_abbreviation="LAL",
+                game_date=date(2025, 1, 15),
+                matchup="LAL vs. BOS",
+                event_id="test_event_1",
+            ),
+            _make_game_log(
+                team_abbreviation="BOS",
+                game_date=date(2025, 1, 15),
+                matchup="BOS @ LAL",
+                event_id="test_event_1",
+                nba_game_id="0022400100",
+                team_id=1610612738,
+            ),
+            # LAL previous game (Jan 12 → 3 days rest)
+            _make_game_log(
+                team_abbreviation="LAL",
+                game_date=date(2025, 1, 12),
+                matchup="LAL vs. GSW",
+                event_id=None,
+                nba_game_id="0022400090",
+            ),
+            # BOS previous game (Jan 13 → 2 days rest)
+            _make_game_log(
+                team_abbreviation="BOS",
+                game_date=date(2025, 1, 13),
+                matchup="BOS @ MIA",
+                event_id=None,
+                nba_game_id="0022400095",
+                team_id=1610612738,
+            ),
+        ]
+        features = extract_rest_features(game_logs, event)
+        assert features.home_days_rest == 3.0
+        assert features.away_days_rest == 2.0
+        assert features.rest_advantage == 1.0
+        assert features.home_is_b2b == 0.0
+        assert features.away_is_b2b == 0.0
+
+    def test_back_to_back(self) -> None:
+        """Both teams on B2B (played yesterday)."""
+        event = _make_event()
+        game_logs = [
+            _make_game_log(
+                team_abbreviation="LAL",
+                game_date=date(2025, 1, 15),
+                matchup="LAL vs. BOS",
+                event_id="test_event_1",
+            ),
+            _make_game_log(
+                team_abbreviation="BOS",
+                game_date=date(2025, 1, 15),
+                matchup="BOS @ LAL",
+                event_id="test_event_1",
+                nba_game_id="0022400100",
+                team_id=1610612738,
+            ),
+            # LAL played yesterday (Jan 14 → 1 day = B2B)
+            _make_game_log(
+                team_abbreviation="LAL",
+                game_date=date(2025, 1, 14),
+                matchup="LAL @ PHX",
+                event_id=None,
+                nba_game_id="0022400098",
+            ),
+            # BOS played yesterday (Jan 14 → 1 day = B2B)
+            _make_game_log(
+                team_abbreviation="BOS",
+                game_date=date(2025, 1, 14),
+                matchup="BOS vs. NYK",
+                event_id=None,
+                nba_game_id="0022400099",
+                team_id=1610612738,
+            ),
+        ]
+        features = extract_rest_features(game_logs, event)
+        assert features.home_days_rest == 1.0
+        assert features.away_days_rest == 1.0
+        assert features.rest_advantage == 0.0
+        assert features.home_is_b2b == 1.0
+        assert features.away_is_b2b == 1.0
+
+    def test_asymmetric_rest(self) -> None:
+        """Home on B2B, away well-rested → negative rest advantage."""
+        event = _make_event()
+        game_logs = [
+            _make_game_log(
+                team_abbreviation="LAL",
+                game_date=date(2025, 1, 15),
+                matchup="LAL vs. BOS",
+                event_id="test_event_1",
+            ),
+            _make_game_log(
+                team_abbreviation="BOS",
+                game_date=date(2025, 1, 15),
+                matchup="BOS @ LAL",
+                event_id="test_event_1",
+                nba_game_id="0022400100",
+                team_id=1610612738,
+            ),
+            # LAL B2B (1 day)
+            _make_game_log(
+                team_abbreviation="LAL",
+                game_date=date(2025, 1, 14),
+                matchup="LAL @ PHX",
+                event_id=None,
+                nba_game_id="0022400098",
+            ),
+            # BOS well rested (4 days)
+            _make_game_log(
+                team_abbreviation="BOS",
+                game_date=date(2025, 1, 11),
+                matchup="BOS vs. MIA",
+                event_id=None,
+                nba_game_id="0022400085",
+                team_id=1610612738,
+            ),
+        ]
+        features = extract_rest_features(game_logs, event)
+        assert features.home_days_rest == 1.0
+        assert features.away_days_rest == 4.0
+        assert features.rest_advantage == -3.0
+        assert features.home_is_b2b == 1.0
+        assert features.away_is_b2b == 0.0
+
+    def test_only_home_has_prior_game(self) -> None:
+        """Away team has no prior game (e.g. season opener)."""
+        event = _make_event()
+        game_logs = [
+            _make_game_log(
+                team_abbreviation="LAL",
+                game_date=date(2025, 1, 15),
+                matchup="LAL vs. BOS",
+                event_id="test_event_1",
+            ),
+            _make_game_log(
+                team_abbreviation="BOS",
+                game_date=date(2025, 1, 15),
+                matchup="BOS @ LAL",
+                event_id="test_event_1",
+                nba_game_id="0022400100",
+                team_id=1610612738,
+            ),
+            # Only LAL has a prior game
+            _make_game_log(
+                team_abbreviation="LAL",
+                game_date=date(2025, 1, 12),
+                matchup="LAL vs. GSW",
+                event_id=None,
+                nba_game_id="0022400090",
+            ),
+        ]
+        features = extract_rest_features(game_logs, event)
+        assert features.home_days_rest == 3.0
+        assert features.away_days_rest is None
+        assert features.rest_advantage is None
+        assert features.home_is_b2b == 0.0
+        assert features.away_is_b2b is None
+
+    def test_uses_most_recent_prior_game(self) -> None:
+        """When multiple prior games exist, picks the most recent."""
+        event = _make_event()
+        game_logs = [
+            _make_game_log(
+                team_abbreviation="LAL",
+                game_date=date(2025, 1, 15),
+                matchup="LAL vs. BOS",
+                event_id="test_event_1",
+            ),
+            _make_game_log(
+                team_abbreviation="BOS",
+                game_date=date(2025, 1, 15),
+                matchup="BOS @ LAL",
+                event_id="test_event_1",
+                nba_game_id="0022400100",
+                team_id=1610612738,
+            ),
+            # LAL older game (Jan 10)
+            _make_game_log(
+                team_abbreviation="LAL",
+                game_date=date(2025, 1, 10),
+                matchup="LAL vs. DEN",
+                event_id=None,
+                nba_game_id="0022400080",
+            ),
+            # LAL more recent game (Jan 13) — should use this one
+            _make_game_log(
+                team_abbreviation="LAL",
+                game_date=date(2025, 1, 13),
+                matchup="LAL @ SAC",
+                event_id=None,
+                nba_game_id="0022400092",
+            ),
+        ]
+        features = extract_rest_features(game_logs, event)
+        assert features.home_days_rest == 2.0  # Jan 15 - Jan 13
+
+    def test_not_b2b_with_two_days_rest(self) -> None:
+        """2 days between games is not B2B."""
+        event = _make_event()
+        game_logs = [
+            _make_game_log(
+                team_abbreviation="LAL",
+                game_date=date(2025, 1, 15),
+                matchup="LAL vs. BOS",
+                event_id="test_event_1",
+            ),
+            _make_game_log(
+                team_abbreviation="BOS",
+                game_date=date(2025, 1, 15),
+                matchup="BOS @ LAL",
+                event_id="test_event_1",
+                nba_game_id="0022400100",
+                team_id=1610612738,
+            ),
+            _make_game_log(
+                team_abbreviation="LAL",
+                game_date=date(2025, 1, 13),
+                matchup="LAL @ PHX",
+                event_id=None,
+                nba_game_id="0022400092",
+            ),
+        ]
+        features = extract_rest_features(game_logs, event)
+        assert features.home_days_rest == 2.0
+        assert features.home_is_b2b == 0.0


### PR DESCRIPTION
## Summary
- Create `RestScheduleFeatures` dataclass (5 fields: home/away days_rest, rest_advantage, home/away is_b2b) following `InjuryFeatures` pattern
- Add `GameLogReader.get_team_previous_game()` for efficient prior game lookup using the `(team_abbreviation, game_date)` index
- Wire into pipeline: `game_logs` field in `EventDataBundle`, `"rest"` feature group in `XGBoostAdapter` with NaN-fill when unavailable
- Add `"rest"` to `FeatureConfig.feature_groups` options

## Test plan
- [x] 14 unit tests: dataclass serialization, normal rest, B2B, asymmetric rest, season opener (no prior game), most recent prior game selection
- [x] 2 integration tests: full pipeline with `feature_groups=("tabular", "rest")`, events without game logs not dropped (NaN-filled)
- [x] All 1158 existing tests pass
- [x] `ruff check --fix && ruff format` clean

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)