### PR TITLE
Wire OddsPortal scraper into CI/CD deploy pipeline

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -57,6 +57,14 @@ jobs:
           IMAGE_TAG="dev-$(git rev-parse --short HEAD)"
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
+      - name: Build and push scraper container image
+        id: build-scraper
+        run: |
+          cd deployment/aws
+          ./build_and_push_scraper.sh dev ${{ env.AWS_REGION }} ${{ secrets.AWS_ACCOUNT_ID }}
+          IMAGE_TAG="dev-$(git rev-parse --short HEAD)"
+          echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+
       - name: Terraform Init
         run: |
           cd deployment/aws/terraform
@@ -71,6 +79,8 @@ jobs:
             -var="database_url=$DATABASE_URL" \
             -var="odds_api_key=$ODDS_API_KEY" \
             -var="image_tag=${{ steps.build-image.outputs.image_tag }}" \
+            -var="enable_oddsportal_scraper=true" \
+            -var="scraper_image_tag=${{ steps.build-scraper.outputs.image_tag }}" \
             -out=tfplan
 
       - name: Clean up stale log group
@@ -116,6 +126,8 @@ jobs:
             -var="database_url=$DATABASE_URL" \
             -var="odds_api_key=$ODDS_API_KEY" \
             -var="image_tag=${{ steps.build-image.outputs.image_tag }}" \
+            -var="enable_oddsportal_scraper=true" \
+            -var="scraper_image_tag=${{ steps.build-scraper.outputs.image_tag }}" \
             -auto-approve
         continue-on-error: true
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -58,6 +58,14 @@ jobs:
           IMAGE_TAG="prod-$(git rev-parse --short HEAD)"
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
+      - name: Build and push scraper container image
+        id: build-scraper
+        run: |
+          cd deployment/aws
+          ./build_and_push_scraper.sh prod ${{ env.AWS_REGION }} ${{ secrets.AWS_ACCOUNT_ID }}
+          IMAGE_TAG="prod-$(git rev-parse --short HEAD)"
+          echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+
       - name: Terraform Init
         run: |
           cd deployment/aws/terraform
@@ -75,6 +83,8 @@ jobs:
             -var="database_url=$DATABASE_URL" \
             -var="odds_api_key=$ODDS_API_KEY" \
             -var="image_tag=${{ steps.build-image.outputs.image_tag }}" \
+            -var="enable_oddsportal_scraper=true" \
+            -var="scraper_image_tag=${{ steps.build-scraper.outputs.image_tag }}" \
             -out=tfplan
 
       - name: Deploy to Production

--- a/deployment/aws/terraform/scraper.tf
+++ b/deployment/aws/terraform/scraper.tf
@@ -12,9 +12,6 @@ resource "aws_ecr_repository" "scraper" {
     scan_on_push = false
   }
 
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 # Lambda function — scraper

--- a/deployment/aws/terraform/terraform.tfvars.example
+++ b/deployment/aws/terraform/terraform.tfvars.example
@@ -32,6 +32,9 @@ rule_prefix = "odds-dev"
 # Deploy Polymarket EventBridge rules (fetch + backfill)
 enable_polymarket = false
 
+# Deploy OddsPortal scraper Lambda (Playwright + Chromium container)
+enable_oddsportal_scraper = false
+
 # ============================================================================
 # Lambda Configuration
 # ============================================================================


### PR DESCRIPTION
Build scraper container image and pass enable_oddsportal_scraper + scraper_image_tag vars to Terraform in both dev and prod workflows. Remove prevent_destroy from scraper ECR repo so dev destroy step works.