### PR TITLE
Wire OddsPortal scraper into CI/CD deploy pipeline

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -57,6 +57,14 @@ jobs:
           IMAGE_TAG="dev-$(git rev-parse --short HEAD)"
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
+      - name: Build and push scraper container image
+        id: build-scraper
+        run: |
+          cd deployment/aws
+          ./build_and_push_scraper.sh dev ${{ env.AWS_REGION }} ${{ secrets.AWS_ACCOUNT_ID }}
+          IMAGE_TAG="dev-$(git rev-parse --short HEAD)"
+          echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+
       - name: Terraform Init
         run: |
           cd deployment/aws/terraform
@@ -71,6 +79,8 @@ jobs:
             -var="database_url=$DATABASE_URL" \
             -var="odds_api_key=$ODDS_API_KEY" \
             -var="image_tag=${{ steps.build-image.outputs.image_tag }}" \
+            -var="enable_oddsportal_scraper=true" \
+            -var="scraper_image_tag=${{ steps.build-scraper.outputs.image_tag }}" \
             -out=tfplan
 
       - name: Clean up stale log group
@@ -116,6 +126,8 @@ jobs:
             -var="database_url=$DATABASE_URL" \
             -var="odds_api_key=$ODDS_API_KEY" \
             -var="image_tag=${{ steps.build-image.outputs.image_tag }}" \
+            -var="enable_oddsportal_scraper=true" \
+            -var="scraper_image_tag=${{ steps.build-scraper.outputs.image_tag }}" \
             -auto-approve
         continue-on-error: true
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -58,6 +58,14 @@ jobs:
           IMAGE_TAG="prod-$(git rev-parse --short HEAD)"
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
+      - name: Build and push scraper container image
+        id: build-scraper
+        run: |
+          cd deployment/aws
+          ./build_and_push_scraper.sh prod ${{ env.AWS_REGION }} ${{ secrets.AWS_ACCOUNT_ID }}
+          IMAGE_TAG="prod-$(git rev-parse --short HEAD)"
+          echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+
       - name: Terraform Init
         run: |
           cd deployment/aws/terraform
@@ -75,6 +83,8 @@ jobs:
             -var="database_url=$DATABASE_URL" \
             -var="odds_api_key=$ODDS_API_KEY" \
             -var="image_tag=${{ steps.build-image.outputs.image_tag }}" \
+            -var="enable_oddsportal_scraper=true" \
+            -var="scraper_image_tag=${{ steps.build-scraper.outputs.image_tag }}" \
             -out=tfplan
 
       - name: Deploy to Production

--- a/deployment/aws/build_and_push_scraper.sh
+++ b/deployment/aws/build_and_push_scraper.sh
@@ -60,6 +60,11 @@ echo -e "${YELLOW}Logging in to ECR...${NC}"
 aws ecr get-login-password --region "$AWS_REGION" | \
     docker login --username AWS --password-stdin "$ECR_URL"
 
+# Ensure ECR repository exists (not Terraform-managed, same as odds-scheduler ECR)
+echo -e "${YELLOW}Ensuring ECR repository exists...${NC}"
+aws ecr describe-repositories --repository-names "$ECR_REPOSITORY" --region "$AWS_REGION" 2>/dev/null || \
+    aws ecr create-repository --repository-name "$ECR_REPOSITORY" --region "$AWS_REGION" --image-tag-mutability MUTABLE
+
 # Build image
 echo -e "${YELLOW}Building Docker image (this may take a few minutes due to Playwright/Chromium)...${NC}"
 docker build \

--- a/deployment/aws/terraform/scraper.tf
+++ b/deployment/aws/terraform/scraper.tf
@@ -1,21 +1,8 @@
 # OddsPortal scraper Lambda — separate container image with Playwright + Chromium.
 # Gated by var.enable_oddsportal_scraper (default false).
 
-# ECR repository for scraper image
-resource "aws_ecr_repository" "scraper" {
-  count = var.enable_oddsportal_scraper ? 1 : 0
-
-  name                 = "odds-scraper"
-  image_tag_mutability = "MUTABLE"
-
-  image_scanning_configuration {
-    scan_on_push = false
-  }
-
-  lifecycle {
-    prevent_destroy = true
-  }
-}
+# ECR repository for scraper image is created by build_and_push_scraper.sh,
+# not managed by Terraform (same pattern as odds-scheduler ECR).
 
 # Lambda function — scraper
 resource "aws_lambda_function" "odds_scraper" {
@@ -85,5 +72,5 @@ output "scraper_function_arn" {
 
 output "scraper_ecr_url" {
   description = "ECR repository URL for scraper image"
-  value       = var.enable_oddsportal_scraper ? aws_ecr_repository.scraper[0].repository_url : null
+  value       = var.enable_oddsportal_scraper ? "${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.aws_region}.amazonaws.com/odds-scraper" : null
 }

--- a/deployment/aws/terraform/terraform.tfvars.example
+++ b/deployment/aws/terraform/terraform.tfvars.example
@@ -32,6 +32,9 @@ rule_prefix = "odds-dev"
 # Deploy Polymarket EventBridge rules (fetch + backfill)
 enable_polymarket = false
 
+# Deploy OddsPortal scraper Lambda (Playwright + Chromium container)
+enable_oddsportal_scraper = false
+
 # ============================================================================
 # Lambda Configuration
 # ============================================================================


### PR DESCRIPTION
## Summary
- Build scraper container image in both dev and prod deploy workflows
- Pass `enable_oddsportal_scraper` and `scraper_image_tag` vars to Terraform plan/apply/destroy
- Move scraper ECR repo ownership to `build_and_push_scraper.sh` (create-if-not-exists), fixing the chicken-and-egg where the push ran before Terraform created the repo

Replaces #183 which was reverted due to the ECR issue.

## Test plan
- [x] Dev deployment passed on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)