### PR TITLE
Add ODDS_API_KEY env var to scraper Lambda

### DIFF
--- a/deployment/aws/terraform/scraper.tf
+++ b/deployment/aws/terraform/scraper.tf
@@ -19,6 +19,7 @@ resource "aws_lambda_function" "odds_scraper" {
     variables = {
       SCHEDULER_BACKEND = "aws"
       DATABASE_URL      = var.database_url
+      ODDS_API_KEY      = var.odds_api_key
       LOG_LEVEL         = "INFO"
     }
   }


### PR DESCRIPTION
Settings() requires it at import time even though the scraper doesn't use the Odds API. Without it the Lambda fails with a Pydantic validation error on startup.