### PR TITLE
Add odds-cli to Lambda Docker image

### DIFF
--- a/deployment/aws/Dockerfile.lambda
+++ b/deployment/aws/Dockerfile.lambda
@@ -19,11 +19,13 @@ COPY pyproject.toml uv.lock ./
 COPY packages/odds-core ./packages/odds-core
 COPY packages/odds-lambda ./packages/odds-lambda
 COPY packages/odds-analytics ./packages/odds-analytics
+COPY packages/odds-cli ./packages/odds-cli
 
 # Build wheels first to ensure packages are properly copied, not referenced via .pth
 RUN uv build --wheel --out-dir /wheels ./packages/odds-core && \
     uv build --wheel --out-dir /wheels ./packages/odds-lambda && \
-    uv build --wheel --out-dir /wheels ./packages/odds-analytics
+    uv build --wheel --out-dir /wheels ./packages/odds-analytics && \
+    uv build --wheel --out-dir /wheels ./packages/odds-cli
 
 # Install from wheels to ensure actual file installation (not .pth references)
 RUN uv pip install \


### PR DESCRIPTION
## Summary

- Add `odds-cli` package to `Dockerfile.lambda` build and install steps

The scheduler Lambda imports `odds_cli.alerts.base` in error-handling paths across `lambda_handler.py` and multiple job modules. These imports were previously unreachable because `ALERT_ENABLED` defaulted to `false`. PR #196 added `ALERT_ENABLED=true` to the Lambda env, exposing the `ModuleNotFoundError` on the `fetch-odds` job.

## Test plan

- [ ] Prod deploy succeeds (all Lambda test invocations pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)