### PR TITLE
Remove eager app import from odds_cli __init__

### DIFF
--- a/packages/odds-cli/odds_cli/__init__.py
+++ b/packages/odds-cli/odds_cli/__init__.py
@@ -1,9 +1,1 @@
-"""
-CLI interface for betting odds pipeline.
-
-Provides command-line interface for all pipeline operations.
-"""
-
-from odds_cli.main import app
-
-__all__ = ["app"]
+"""CLI interface for betting odds pipeline."""


### PR DESCRIPTION
## Summary

- Remove `from odds_cli.main import app` from `odds_cli/__init__.py`

`odds_cli/__init__.py` eagerly imported the CLI app, which triggered the full command import chain: `backtest.py` → `lstm_line_movement.py` → `import torch`. This caused `ModuleNotFoundError: No module named 'torch'` in Lambda after PR #197 added `odds-cli` to the Docker image.

The Lambda only needs `odds_cli.alerts.base` — it never uses the CLI app. All other consumers already import from `odds_cli.main` directly.

## Test plan

- [x] `from odds_cli.alerts.base import send_critical` works without torch
- [x] `from odds_cli.main import app` still works
- [x] `odds --help` CLI still works
- [ ] Prod deploy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)