### PR TITLE
Run score-predictions on scheduler Lambda

### DIFF
--- a/deployment/aws/Dockerfile.lambda
+++ b/deployment/aws/Dockerfile.lambda
@@ -28,11 +28,14 @@ RUN uv build --wheel --out-dir /wheels ./packages/odds-core && \
     uv build --wheel --out-dir /wheels ./packages/odds-cli
 
 # Install from wheels to ensure actual file installation (not .pth references)
+# xgboost is needed for CLV model inference (score-predictions job) but lives
+# in a dependency group, not core deps, so it must be installed explicitly.
 RUN uv pip install \
     --python /var/lang/bin/python3.12 \
     --target /asset \
     --no-cache \
-    /wheels/*.whl
+    /wheels/*.whl \
+    xgboost
 
 # Remove unnecessary files to reduce image size
 RUN cd /asset && \

--- a/deployment/aws/terraform/eventbridge.tf
+++ b/deployment/aws/terraform/eventbridge.tf
@@ -67,6 +67,33 @@ resource "aws_lambda_permission" "allow_eventbridge_daily_digest" {
   ]
 }
 
+# Score predictions: runs CLV model inference after scraper has landed new snapshots.
+# Offset 15 min past the hour so the hourly scraper job has time to finish.
+resource "aws_cloudwatch_event_rule" "score_predictions" {
+  name                = format("%s-score-predictions", var.rule_prefix)
+  description         = "Hourly CLV model inference on new snapshots"
+  schedule_expression = "cron(15 * * * ? *)"
+  state               = "ENABLED"
+}
+
+resource "aws_cloudwatch_event_target" "score_predictions_target" {
+  rule      = aws_cloudwatch_event_rule.score_predictions.name
+  target_id = "1"
+  arn       = aws_lambda_function.odds_scheduler.arn
+
+  input = jsonencode({
+    job = "score-predictions"
+  })
+}
+
+resource "aws_lambda_permission" "allow_eventbridge_score_predictions" {
+  statement_id  = format("AllowEventBridgeScorePredictions-%s", var.rule_prefix)
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.odds_scheduler.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.score_predictions.arn
+}
+
 # Self-scheduling rules: pre-created by Terraform, schedule updated by Lambda at runtime.
 # Lambda's put_rule() updates the schedule_expression and sets State=ENABLED; Terraform
 # ignores those changes but owns the lifecycle (create/destroy).

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
@@ -333,15 +333,6 @@ async def main() -> None:
         total_errors=total_errors,
     )
 
-    # Score new snapshots against published model (best-effort)
-    if total_snapshots > 0:
-        try:
-            from odds_lambda.jobs.score_predictions import score_events
-
-            await score_events()
-        except Exception:
-            logger.error("score_predictions_failed_after_fetch", exc_info=True)
-
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary

- Add `xgboost` to the scheduler Lambda Docker image — the only missing dependency for CLV model inference
- Add an EventBridge rule to run `score-predictions` at `:15` past each hour (offset from the hourly scraper)
- Remove the inline `score_events()` call from `fetch_oddsportal` — scoring is now an independent scheduled job

## Test plan

- [ ] Build scheduler image locally, verify xgboost imports successfully
- [ ] `terraform plan` shows the new EventBridge rule/target/permission, no unexpected changes
- [ ] Deploy to dev and invoke `score-predictions` job manually via Lambda console
- [ ] Verify predictions land in the `prediction` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)