### PR TITLE
Fix scraper Lambda — Chromium crashes without Docker-mode args

### DIFF
--- a/deployment/aws/Dockerfile.scraper
+++ b/deployment/aws/Dockerfile.scraper
@@ -68,6 +68,11 @@ RUN dnf install -y \
     gtk3 \
     && dnf clean all
 
+# Signal to OddsHarvester that it's running in a container so it uses
+# Docker-appropriate Chromium args (--no-sandbox, --disable-dev-shm-usage).
+# Lambda containers don't have /.dockerenv which is what OddsHarvester checks.
+RUN touch /.dockerenv
+
 # Copy compiled dependencies from builder
 COPY --from=builder /asset ${LAMBDA_TASK_ROOT}
 

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
@@ -139,7 +139,7 @@ def run_harvester_upcoming(spec: LeagueSpec) -> list[dict[str, Any]]:
 
         if result.returncode != 0:
             raise RuntimeError(
-                f"OddsHarvester exited with code {result.returncode}: {result.stderr[:500]}"
+                f"OddsHarvester exited with code {result.returncode}: {result.stderr[-2000:]}"
             )
 
         data = json.loads(tmp_path.read_text())

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py
@@ -93,7 +93,7 @@ def run_harvester_historic() -> list[dict[str, Any]]:
 
         if result.returncode != 0:
             raise RuntimeError(
-                f"OddsHarvester exited with code {result.returncode}: {result.stderr[:500]}"
+                f"OddsHarvester exited with code {result.returncode}: {result.stderr[-2000:]}"
             )
 
         data = json.loads(tmp_path.read_text())


### PR DESCRIPTION
## Summary
- Add `/.dockerenv` to scraper Dockerfile so OddsHarvester uses Docker-appropriate Chromium args (`--no-sandbox`, `--disable-dev-shm-usage`) in Lambda
- Capture last 2000 chars of stderr instead of first 500, so actual errors are visible in CloudWatch

**Root cause:** OddsHarvester checks `os.path.exists("/.dockerenv")` to detect containers. Lambda containers don't have this file, so Chromium launched without sandbox flags and hung on every invocation. The scraper has never successfully run in Lambda.

**Verified:** Without `/.dockerenv` → Chromium times out. With it → 18 EPL matches scraped successfully in Docker.

## Test plan
- [x] 88 existing unit tests pass
- [x] Docker build + local scrape succeeds with fix
- [x] Docker scrape fails without `/.dockerenv` (reproduces Lambda behavior)
- [ ] Deploy and verify first successful Lambda scrape in CloudWatch

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)