### PR TITLE
Fix dev deploy schedule verification after smoke test change

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -109,8 +109,8 @@ jobs:
       - name: Verify database writes
         run: uv run python scripts/ci/verify_database.py
 
-      - name: Verify schedule activation
-        run: bash scripts/verify-schedules.sh --rule-prefix odds-dev --jobs "${{ steps.deploy.outputs.jobs }}" --region ${{ env.AWS_REGION }}
+      - name: Verify schedule activation (check-health only — other rules stay disabled until their jobs run)
+        run: bash scripts/verify-schedules.sh --rule-prefix odds-dev --jobs check-health --region ${{ env.AWS_REGION }}
 
       - name: Deployment Summary
         if: success()


### PR DESCRIPTION
## Summary
- Dev deploy failed after #208 because `verify-schedules.sh` still checked all self-scheduling jobs, but only `check-health` was invoked in the smoke test
- Self-scheduling rules start `DISABLED` and only enable when their job runs — so `fetch-odds`, `fetch-scores`, `update-status` correctly stayed disabled in fresh dev infrastructure
- Scope dev verification to `check-health` only (prod left unchanged since rules persist across deploys)

## Test plan
- [ ] Dev deploy passes with scoped schedule verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)