### PR TITLE
Fix health check false positives from exchange/sharp vig validation

### DIFF
--- a/packages/odds-lambda/odds_lambda/storage/validators.py
+++ b/packages/odds-lambda/odds_lambda/storage/validators.py
@@ -16,27 +16,19 @@ class OddsValidator:
     # Validation thresholds
     MIN_ODDS = -10000
     MAX_ODDS = 10000
-    MIN_VIG_PERCENT = 2.0  # Minimum expected vig for retail bookmakers
-    MIN_VIG_PERCENT_SHARP = 1.0  # Lower floor for sharp bookmakers
+    MIN_VIG_PERCENT = 2.0  # Minimum expected vig for non-exchange bookmakers
     MAX_VIG_PERCENT = 15.0  # Maximum reasonable vig/juice
     MAX_SPREAD_MOVEMENT = 10.0  # Maximum point spread change
     MAX_TOTAL_MOVEMENT = 20.0  # Maximum total points change
 
-    # Bookmaker classifications for vig validation.
-    # These are The Odds API / production bookmaker keys, distinct from the
-    # OddsPortal display-name mapping in oddsportal_common.py.
+    # Exchange bookmakers legitimately operate near 0% vig, so the vig floor
+    # check is skipped for them. These are The Odds API / production keys,
+    # distinct from the OddsPortal display-name mapping in oddsportal_common.py.
     EXCHANGE_BOOKMAKERS: set[str] = {
         "betfair_exchange",
         "betdaq",
         "smarkets",
         "matchbook",
-    }
-    SHARP_BOOKMAKERS: set[str] = {
-        "pinnacle",
-        "onexbet",
-        "onexbetir",
-        "1xbetir",
-        "betinasia",
     }
 
     @staticmethod
@@ -188,8 +180,8 @@ class OddsValidator:
         Validate vig/juice for two-way markets.
 
         Exchange bookmakers (Betfair, Betdaq, etc.) legitimately operate near 0% vig,
-        so only negative vig and excessive vig are flagged. Sharp bookmakers use a
-        lower floor than retail.
+        so only negative vig and excessive vig are checked. All other bookmakers use
+        the standard MIN_VIG_PERCENT floor.
 
         Args:
             outcomes: List of outcome dictionaries
@@ -220,15 +212,7 @@ class OddsValidator:
                     f"{bookmaker} {market}: Negative vig ({vig_percent:.2f}%), "
                     "possible arbitrage or data error"
                 )
-            elif bookmaker in cls.EXCHANGE_BOOKMAKERS:
-                pass  # Any non-negative vig is normal for exchanges
-            elif bookmaker in cls.SHARP_BOOKMAKERS:
-                if vig_percent < cls.MIN_VIG_PERCENT_SHARP:
-                    warnings.append(
-                        f"{bookmaker} {market}: Vig below sharp threshold "
-                        f"({vig_percent:.2f}% < {cls.MIN_VIG_PERCENT_SHARP}%)"
-                    )
-            elif vig_percent < cls.MIN_VIG_PERCENT:
+            elif bookmaker not in cls.EXCHANGE_BOOKMAKERS and vig_percent < cls.MIN_VIG_PERCENT:
                 warnings.append(
                     f"{bookmaker} {market}: Vig too low ({vig_percent:.2f}%), "
                     "possible arbitrage or data error"

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -105,25 +105,6 @@ class TestOddsValidator:
                     f"Unexpected warning for {bookmaker} at {price}: {warnings}"
                 )
 
-    def test_validate_vig_sharp_bookmaker_threshold(self):
-        """Sharp bookmakers use a lower vig floor than retail."""
-        # -101/-101: vig ~0.5%, below sharp threshold of 1.0%
-        outcomes = [{"price": -101}, {"price": -101}]
-        for bookmaker in OddsValidator.SHARP_BOOKMAKERS:
-            warnings = OddsValidator.validate_vig(outcomes, bookmaker, "totals")
-            assert len(warnings) == 1, f"Expected warning for {bookmaker}"
-            assert "sharp threshold" in warnings[0]
-
-        # -102/-102: vig ~0.99%, still below 1.0% threshold
-        outcomes = [{"price": -102}, {"price": -102}]
-        warnings = OddsValidator.validate_vig(outcomes, "pinnacle", "totals")
-        assert len(warnings) == 1
-
-        # -103/-103: vig ~1.46%, above sharp threshold — no warning
-        outcomes = [{"price": -103}, {"price": -103}]
-        warnings = OddsValidator.validate_vig(outcomes, "pinnacle", "totals")
-        assert len(warnings) == 0
-
     def test_validate_vig_wrong_number_of_outcomes(self):
         """Test vig validation skips non-two-way markets."""
         outcomes = [


### PR DESCRIPTION
## Summary
- **Exchange bookmakers skip vig floor check**: Betfair Exchange, Betdaq, Smarkets, and Matchbook have legitimately low vig (0.8–1.7%) — the validator no longer warns on these
- **Vig warnings decoupled from snapshot validity**: vig anomalies are now informational warnings, not errors. They no longer set `is_valid=False` or produce `severity="error"` in `DataQualityLog`, so the health check stops firing false-positive alerts
- Genuine data errors (negative vig, excessive vig >15%, out-of-range prices, missing fields) still produce errors as before
- New tests: exchange low-vig no-warning, negative vig across all types, excessive vig for exchanges, vig warning doesn't invalidate snapshot

## Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)