### PR TITLE
Add odds status coverage command (#257)

### DIFF
--- a/packages/odds-analytics/odds_analytics/standings_features.py
+++ b/packages/odds-analytics/odds_analytics/standings_features.py
@@ -24,6 +24,7 @@ __all__ = [
     "TeamRecord",
     "load_season_events_cache",
     "get_prior_events_from_cache",
+    "epl_season_key",
 ]
 
 logger = structlog.get_logger()
@@ -132,11 +133,11 @@ class TeamRecord:
 def epl_season_key(dt: datetime) -> str:
     """Derive EPL season string from a datetime.
 
-    EPL season runs Aug-May. A match in Jan 2025 -> '2024-25'.
-    A match in Aug 2024 -> '2024-25'.
+    EPL season runs Aug-Jul. A match in Jan 2025 -> '2024-25'.
+    A match in Aug 2024 -> '2024-25'. A match in Jul 2025 -> '2024-25'.
     """
     year = dt.year
-    if dt.month >= 7:
+    if dt.month >= 8:
         return f"{year}-{str(year + 1)[-2:]}"
     return f"{year - 1}-{str(year)[-2:]}"
 

--- a/packages/odds-cli/odds_cli/commands/status.py
+++ b/packages/odds-cli/odds_cli/commands/status.py
@@ -1,6 +1,7 @@
 """CLI commands for system status and monitoring."""
 
 import asyncio
+from collections import defaultdict
 from datetime import UTC, datetime, timedelta
 
 import typer
@@ -307,15 +308,12 @@ def show_coverage(
 
 
 async def _show_coverage(sport: str) -> None:
-    from collections import defaultdict
-
     console.print(f"\n[bold blue]Snapshot Coverage — {sport}[/bold blue]\n")
 
     try:
         async with async_session_maker() as session:
             reader = OddsReader(session)
-            coverage_rows = await reader.get_snapshot_coverage(sport_key=sport)
-            season_event_counts = await reader.get_season_event_counts(sport_key=sport)
+            coverage_rows, season_event_counts = await reader.get_snapshot_coverage(sport_key=sport)
 
         if not coverage_rows:
             console.print("[yellow]No snapshot data found[/yellow]\n")

--- a/packages/odds-cli/odds_cli/commands/status.py
+++ b/packages/odds-cli/odds_cli/commands/status.py
@@ -298,6 +298,9 @@ _TIER_BUCKETS = ["72h+", "24-72h", "12-24h", "3-12h", "<3h"]
 # Preferred display order for sources
 _SOURCE_ORDER = ["football_data_uk", "oddsportal", "odds_api"]
 
+# Abbreviated display names for column headers
+_SOURCE_DISPLAY = {"football_data_uk": "fduk", "oddsportal": "op", "odds_api": "api"}
+
 
 @app.command("coverage")
 def show_coverage(
@@ -336,8 +339,9 @@ async def _show_coverage(sport: str) -> None:
         table.add_column("Season", style="cyan", no_wrap=True)
         table.add_column("Events", justify="right", style="white")
         for source in sources_present:
+            display = _SOURCE_DISPLAY.get(source, source)
             for bucket in _TIER_BUCKETS:
-                table.add_column(f"{source}\n{bucket}", justify="right")
+                table.add_column(f"{display}\n{bucket}", justify="right")
 
         totals: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
         total_event_count = 0

--- a/packages/odds-cli/odds_cli/commands/status.py
+++ b/packages/odds-cli/odds_cli/commands/status.py
@@ -289,3 +289,82 @@ async def _show_events(days: int, team: str | None):
     except Exception as e:
         console.print(f"\n[bold red]✗ Failed to get events: {str(e)}[/bold red]")
         raise typer.Exit(code=1) from e
+
+
+# Ordered tier buckets for consistent column display
+_TIER_BUCKETS = ["72h+", "24-72h", "12-24h", "3-12h", "<3h"]
+
+# Preferred display order for sources
+_SOURCE_ORDER = ["football_data_uk", "oddsportal", "odds_api"]
+
+
+@app.command("coverage")
+def show_coverage(
+    sport: str = typer.Option("soccer_epl", "--sport", help="Sport key to filter"),
+):
+    """Show snapshot coverage by season, source, and tier bucket."""
+    asyncio.run(_show_coverage(sport))
+
+
+async def _show_coverage(sport: str) -> None:
+    from collections import defaultdict
+
+    console.print(f"\n[bold blue]Snapshot Coverage — {sport}[/bold blue]\n")
+
+    try:
+        async with async_session_maker() as session:
+            reader = OddsReader(session)
+            coverage_rows = await reader.get_snapshot_coverage(sport_key=sport)
+            season_event_counts = await reader.get_season_event_counts(sport_key=sport)
+
+        if not coverage_rows:
+            console.print("[yellow]No snapshot data found[/yellow]\n")
+            return
+
+        # data[season][source][bucket] = distinct_event_count
+        data: dict[str, dict[str, dict[str, int]]] = defaultdict(
+            lambda: defaultdict(lambda: defaultdict(int))
+        )
+        for season, source, bucket, count in coverage_rows:
+            data[season][source][bucket] = count
+
+        seasons = sorted(data.keys())
+        sources_present = sorted(
+            {src for season_data in data.values() for src in season_data},
+            key=lambda s: _SOURCE_ORDER.index(s) if s in _SOURCE_ORDER else len(_SOURCE_ORDER),
+        )
+
+        table = Table(show_header=True)
+        table.add_column("Season", style="cyan", no_wrap=True)
+        table.add_column("Events", justify="right", style="white")
+        for source in sources_present:
+            for bucket in _TIER_BUCKETS:
+                table.add_column(f"{source}\n{bucket}", justify="right")
+
+        totals: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+        total_event_count = 0
+
+        for season in seasons:
+            event_count = season_event_counts.get(season, 0)
+            total_event_count += event_count
+            cells: list[str] = [season, str(event_count)]
+            for source in sources_present:
+                for bucket in _TIER_BUCKETS:
+                    val = data[season][source].get(bucket, 0)
+                    totals[source][bucket] += val
+                    cells.append(str(val) if val > 0 else "-")
+            table.add_row(*cells)
+
+        total_cells: list[str] = ["Total", str(total_event_count)]
+        for source in sources_present:
+            for bucket in _TIER_BUCKETS:
+                val = totals[source].get(bucket, 0)
+                total_cells.append(str(val) if val > 0 else "-")
+        table.add_row(*total_cells, style="bold")
+
+        console.print(table)
+        console.print()
+
+    except Exception as e:
+        console.print(f"\n[bold red]✗ Failed to get coverage: {str(e)}[/bold red]")
+        raise typer.Exit(code=1) from e

--- a/packages/odds-lambda/odds_lambda/storage/readers.py
+++ b/packages/odds-lambda/odds_lambda/storage/readers.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from datetime import UTC, datetime, timedelta
 
 import structlog
+from odds_analytics.standings_features import epl_season_key
 from odds_core.models import DataQualityLog, Event, EventStatus, FetchLog, Odds, OddsSnapshot
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,16 +14,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from odds_lambda.fetch_tier import FetchTier
 
 logger = structlog.get_logger()
-
-
-def _season_from_date(year: int, month: int) -> str:
-    """Return the Aug–Jul season label for a given year and month.
-
-    Aug 2024–Jul 2025 maps to "2024-25".
-    """
-    if month >= 8:
-        return f"{year}-{str(year + 1)[-2:]}"
-    return f"{year - 1}-{str(year)[-2:]}"
 
 
 class OddsReader:
@@ -683,7 +674,7 @@ class OddsReader:
         season_events: dict[str, set[str]] = defaultdict(set)
 
         for commence_time, api_request_id, hours_until_commence, event_id in rows:
-            season = _season_from_date(commence_time.year, commence_time.month)
+            season = epl_season_key(commence_time)
 
             if api_request_id is None:
                 source = "odds_api"

--- a/packages/odds-lambda/odds_lambda/storage/readers.py
+++ b/packages/odds-lambda/odds_lambda/storage/readers.py
@@ -678,7 +678,7 @@ class OddsReader:
 
             if api_request_id is None:
                 source = "odds_api"
-            elif api_request_id.startswith("oddsportal_live"):
+            elif api_request_id.startswith("oddsportal"):
                 source = "oddsportal"
             elif api_request_id == "football_data_uk":
                 source = "football_data_uk"

--- a/packages/odds-lambda/odds_lambda/storage/readers.py
+++ b/packages/odds-lambda/odds_lambda/storage/readers.py
@@ -15,6 +15,16 @@ from odds_lambda.fetch_tier import FetchTier
 logger = structlog.get_logger()
 
 
+def _season_from_date(year: int, month: int) -> str:
+    """Return the Aug–Jul season label for a given year and month.
+
+    Aug 2024–Jul 2025 maps to "2024-25".
+    """
+    if month >= 8:
+        return f"{year}-{str(year + 1)[-2:]}"
+    return f"{year - 1}-{str(year)[-2:]}"
+
+
 class OddsReader:
     """Handles all read operations from the database."""
 
@@ -624,11 +634,13 @@ class OddsReader:
     async def get_snapshot_coverage(
         self,
         sport_key: str = "soccer_epl",
-    ) -> list[tuple[str, str, str, int]]:
+    ) -> tuple[list[tuple[str, str, str, int]], dict[str, int]]:
         """
         Query snapshot coverage grouped by season, source, and tier bucket.
 
-        Returns distinct event counts per (season, source, tier) cell.
+        Returns distinct event counts per (season, source, tier) cell, plus a
+        per-season total of distinct events (for the Events column in the CLI table).
+
         Tier buckets are derived from hours_until_commence:
           - "72h+"   : >= 72 hours
           - "24-72h" : 24 to < 72 hours
@@ -647,7 +659,9 @@ class OddsReader:
             sport_key: Sport key to filter on
 
         Returns:
-            List of (season, source, tier_bucket, distinct_event_count) tuples, sorted by season
+            Tuple of:
+              - List of (season, source, tier_bucket, distinct_event_count), sorted by season
+              - Dict mapping season label to distinct event count across all sources
         """
         query = (
             select(
@@ -666,14 +680,10 @@ class OddsReader:
         rows = result.all()
 
         counts: dict[tuple[str, str, str], set[str]] = defaultdict(set)
+        season_events: dict[str, set[str]] = defaultdict(set)
 
         for commence_time, api_request_id, hours_until_commence, event_id in rows:
-            year = commence_time.year
-            month = commence_time.month
-            if month >= 8:
-                season = f"{year}-{str(year + 1)[-2:]}"
-            else:
-                season = f"{year - 1}-{str(year)[-2:]}"
+            season = _season_from_date(commence_time.year, commence_time.month)
 
             if api_request_id is None:
                 source = "odds_api"
@@ -697,51 +707,14 @@ class OddsReader:
                 bucket = "<3h"
 
             counts[(season, source, bucket)].add(event_id)
+            season_events[season].add(event_id)
 
-        return [
+        coverage = [
             (season, source, bucket, len(event_ids))
             for (season, source, bucket), event_ids in sorted(counts.items())
         ]
-
-    async def get_season_event_counts(
-        self,
-        sport_key: str = "soccer_epl",
-    ) -> dict[str, int]:
-        """
-        Return the count of distinct events per season for a given sport.
-
-        Season is an Aug–Jul window: Aug 2024–Jul 2025 = "2024-25".
-        Only events with at least one snapshot (hours_until_commence not null) are counted,
-        consistent with get_snapshot_coverage.
-
-        Args:
-            sport_key: Sport key to filter on
-
-        Returns:
-            Mapping of season label to distinct event count
-        """
-        query = (
-            select(Event.commence_time, Event.id)
-            .join(OddsSnapshot, OddsSnapshot.event_id == Event.id)
-            .where(Event.sport_key == sport_key)
-            .where(OddsSnapshot.hours_until_commence.isnot(None))
-            .distinct()
-        )
-
-        result = await self.session.execute(query)
-        rows = result.all()
-
-        season_events: dict[str, set[str]] = defaultdict(set)
-        for commence_time, event_id in rows:
-            year = commence_time.year
-            month = commence_time.month
-            if month >= 8:
-                season = f"{year}-{str(year + 1)[-2:]}"
-            else:
-                season = f"{year - 1}-{str(year)[-2:]}"
-            season_events[season].add(event_id)
-
-        return {season: len(ids) for season, ids in season_events.items()}
+        season_totals = {season: len(ids) for season, ids in season_events.items()}
+        return coverage, season_totals
 
     async def get_games_by_date(
         self, target_date: datetime, status: EventStatus | None = EventStatus.FINAL

--- a/packages/odds-lambda/odds_lambda/storage/readers.py
+++ b/packages/odds-lambda/odds_lambda/storage/readers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from datetime import UTC, datetime, timedelta
 
 import structlog
@@ -619,6 +620,128 @@ class OddsReader:
 
         result = await self.session.execute(query)
         return list(result.scalars().all())
+
+    async def get_snapshot_coverage(
+        self,
+        sport_key: str = "soccer_epl",
+    ) -> list[tuple[str, str, str, int]]:
+        """
+        Query snapshot coverage grouped by season, source, and tier bucket.
+
+        Returns distinct event counts per (season, source, tier) cell.
+        Tier buckets are derived from hours_until_commence:
+          - "72h+"   : >= 72 hours
+          - "24-72h" : 24 to < 72 hours
+          - "12-24h" : 12 to < 24 hours
+          - "3-12h"  : 3 to < 12 hours
+          - "<3h"    : < 3 hours
+
+        Source is normalised from api_request_id:
+          - "oddsportal_live_*" -> "oddsportal"
+          - "football_data_uk"  -> "football_data_uk"
+          - anything else       -> "odds_api"
+
+        Season is an Aug–Jul window: Aug 2024–Jul 2025 = "2024-25".
+
+        Args:
+            sport_key: Sport key to filter on
+
+        Returns:
+            List of (season, source, tier_bucket, distinct_event_count) tuples, sorted by season
+        """
+        query = (
+            select(
+                Event.commence_time,
+                OddsSnapshot.api_request_id,
+                OddsSnapshot.hours_until_commence,
+                OddsSnapshot.event_id,
+            )
+            .join(OddsSnapshot, OddsSnapshot.event_id == Event.id)
+            .where(Event.sport_key == sport_key)
+            .where(OddsSnapshot.hours_until_commence.isnot(None))
+            .distinct()
+        )
+
+        result = await self.session.execute(query)
+        rows = result.all()
+
+        counts: dict[tuple[str, str, str], set[str]] = defaultdict(set)
+
+        for commence_time, api_request_id, hours_until_commence, event_id in rows:
+            year = commence_time.year
+            month = commence_time.month
+            if month >= 8:
+                season = f"{year}-{str(year + 1)[-2:]}"
+            else:
+                season = f"{year - 1}-{str(year)[-2:]}"
+
+            if api_request_id is None:
+                source = "odds_api"
+            elif api_request_id.startswith("oddsportal_live"):
+                source = "oddsportal"
+            elif api_request_id == "football_data_uk":
+                source = "football_data_uk"
+            else:
+                source = "odds_api"
+
+            h = hours_until_commence
+            if h >= 72:
+                bucket = "72h+"
+            elif h >= 24:
+                bucket = "24-72h"
+            elif h >= 12:
+                bucket = "12-24h"
+            elif h >= 3:
+                bucket = "3-12h"
+            else:
+                bucket = "<3h"
+
+            counts[(season, source, bucket)].add(event_id)
+
+        return [
+            (season, source, bucket, len(event_ids))
+            for (season, source, bucket), event_ids in sorted(counts.items())
+        ]
+
+    async def get_season_event_counts(
+        self,
+        sport_key: str = "soccer_epl",
+    ) -> dict[str, int]:
+        """
+        Return the count of distinct events per season for a given sport.
+
+        Season is an Aug–Jul window: Aug 2024–Jul 2025 = "2024-25".
+        Only events with at least one snapshot (hours_until_commence not null) are counted,
+        consistent with get_snapshot_coverage.
+
+        Args:
+            sport_key: Sport key to filter on
+
+        Returns:
+            Mapping of season label to distinct event count
+        """
+        query = (
+            select(Event.commence_time, Event.id)
+            .join(OddsSnapshot, OddsSnapshot.event_id == Event.id)
+            .where(Event.sport_key == sport_key)
+            .where(OddsSnapshot.hours_until_commence.isnot(None))
+            .distinct()
+        )
+
+        result = await self.session.execute(query)
+        rows = result.all()
+
+        season_events: dict[str, set[str]] = defaultdict(set)
+        for commence_time, event_id in rows:
+            year = commence_time.year
+            month = commence_time.month
+            if month >= 8:
+                season = f"{year}-{str(year + 1)[-2:]}"
+            else:
+                season = f"{year - 1}-{str(year)[-2:]}"
+            season_events[season].add(event_id)
+
+        return {season: len(ids) for season, ids in season_events.items()}
 
     async def get_games_by_date(
         self, target_date: datetime, status: EventStatus | None = EventStatus.FINAL

--- a/tests/unit/test_snapshot_coverage.py
+++ b/tests/unit/test_snapshot_coverage.py
@@ -1,0 +1,244 @@
+"""Unit tests for OddsReader.get_snapshot_coverage."""
+
+from datetime import UTC, datetime
+
+import pytest
+from odds_core.models import Event, EventStatus, OddsSnapshot
+from odds_lambda.storage.readers import OddsReader, _season_from_date
+
+
+def _make_event(event_id: str, commence_time: datetime) -> Event:
+    return Event(
+        id=event_id,
+        sport_key="soccer_epl",
+        sport_title="EPL",
+        commence_time=commence_time,
+        home_team="Arsenal",
+        away_team="Chelsea",
+        status=EventStatus.FINAL,
+    )
+
+
+def _make_snapshot(
+    event_id: str,
+    hours_until_commence: float,
+    api_request_id: str | None = None,
+    snapshot_time: datetime | None = None,
+) -> OddsSnapshot:
+    if snapshot_time is None:
+        snapshot_time = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
+    return OddsSnapshot(
+        event_id=event_id,
+        snapshot_time=snapshot_time,
+        raw_data={},
+        bookmaker_count=1,
+        api_request_id=api_request_id,
+        hours_until_commence=hours_until_commence,
+    )
+
+
+class TestSeasonFromDate:
+    def test_august_is_new_season(self):
+        assert _season_from_date(2024, 8) == "2024-25"
+
+    def test_july_is_prior_season(self):
+        assert _season_from_date(2025, 7) == "2024-25"
+
+    def test_january_is_current_year_minus_one(self):
+        assert _season_from_date(2024, 1) == "2023-24"
+
+    def test_boundary_month_7_vs_8(self):
+        assert _season_from_date(2023, 7) == "2022-23"
+        assert _season_from_date(2023, 8) == "2023-24"
+
+
+class TestGetSnapshotCoverage:
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_no_data(self, pglite_async_session):
+        reader = OddsReader(pglite_async_session)
+        coverage, season_totals = await reader.get_snapshot_coverage(sport_key="soccer_epl")
+        assert coverage == []
+        assert season_totals == {}
+
+    @pytest.mark.asyncio
+    async def test_source_normalisation_oddsportal(self, pglite_async_session):
+        event = _make_event("e1", datetime(2025, 1, 15, 15, 0, tzinfo=UTC))
+        snapshot = _make_snapshot(
+            "e1", hours_until_commence=10.0, api_request_id="oddsportal_live_epl"
+        )
+        pglite_async_session.add(event)
+        pglite_async_session.add(snapshot)
+        await pglite_async_session.commit()
+
+        reader = OddsReader(pglite_async_session)
+        coverage, _ = await reader.get_snapshot_coverage(sport_key="soccer_epl")
+
+        assert len(coverage) == 1
+        _, source, _, _ = coverage[0]
+        assert source == "oddsportal"
+
+    @pytest.mark.asyncio
+    async def test_source_normalisation_football_data_uk(self, pglite_async_session):
+        event = _make_event("e1", datetime(2025, 1, 15, 15, 0, tzinfo=UTC))
+        snapshot = _make_snapshot(
+            "e1", hours_until_commence=10.0, api_request_id="football_data_uk"
+        )
+        pglite_async_session.add(event)
+        pglite_async_session.add(snapshot)
+        await pglite_async_session.commit()
+
+        reader = OddsReader(pglite_async_session)
+        coverage, _ = await reader.get_snapshot_coverage(sport_key="soccer_epl")
+
+        _, source, _, _ = coverage[0]
+        assert source == "football_data_uk"
+
+    @pytest.mark.asyncio
+    async def test_source_normalisation_unknown_falls_back_to_odds_api(self, pglite_async_session):
+        event = _make_event("e1", datetime(2025, 1, 15, 15, 0, tzinfo=UTC))
+        snapshot = _make_snapshot(
+            "e1", hours_until_commence=10.0, api_request_id="some_other_source"
+        )
+        pglite_async_session.add(event)
+        pglite_async_session.add(snapshot)
+        await pglite_async_session.commit()
+
+        reader = OddsReader(pglite_async_session)
+        coverage, _ = await reader.get_snapshot_coverage(sport_key="soccer_epl")
+
+        _, source, _, _ = coverage[0]
+        assert source == "odds_api"
+
+    @pytest.mark.asyncio
+    async def test_source_normalisation_none_falls_back_to_odds_api(self, pglite_async_session):
+        event = _make_event("e1", datetime(2025, 1, 15, 15, 0, tzinfo=UTC))
+        snapshot = _make_snapshot("e1", hours_until_commence=10.0, api_request_id=None)
+        pglite_async_session.add(event)
+        pglite_async_session.add(snapshot)
+        await pglite_async_session.commit()
+
+        reader = OddsReader(pglite_async_session)
+        coverage, _ = await reader.get_snapshot_coverage(sport_key="soccer_epl")
+
+        _, source, _, _ = coverage[0]
+        assert source == "odds_api"
+
+    @pytest.mark.asyncio
+    async def test_tier_bucket_boundaries(self, pglite_async_session):
+        event = _make_event("e1", datetime(2025, 1, 15, 15, 0, tzinfo=UTC))
+        pglite_async_session.add(event)
+
+        snapshots = [
+            _make_snapshot("e1", 72.0, snapshot_time=datetime(2025, 1, 10, 12, 0, tzinfo=UTC)),
+            _make_snapshot("e1", 24.0, snapshot_time=datetime(2025, 1, 13, 12, 0, tzinfo=UTC)),
+            _make_snapshot("e1", 12.0, snapshot_time=datetime(2025, 1, 14, 12, 0, tzinfo=UTC)),
+            _make_snapshot("e1", 3.0, snapshot_time=datetime(2025, 1, 15, 8, 0, tzinfo=UTC)),
+            _make_snapshot("e1", 0.5, snapshot_time=datetime(2025, 1, 15, 14, 0, tzinfo=UTC)),
+        ]
+        for s in snapshots:
+            pglite_async_session.add(s)
+        await pglite_async_session.commit()
+
+        reader = OddsReader(pglite_async_session)
+        coverage, _ = await reader.get_snapshot_coverage(sport_key="soccer_epl")
+
+        buckets = {bucket for _, _, bucket, _ in coverage}
+        assert buckets == {"72h+", "24-72h", "12-24h", "3-12h", "<3h"}
+
+    @pytest.mark.asyncio
+    async def test_events_column_counts_distinct_events_not_snapshots(self, pglite_async_session):
+        event = _make_event("e1", datetime(2025, 1, 15, 15, 0, tzinfo=UTC))
+        pglite_async_session.add(event)
+
+        # Two snapshots for the same event in the same bucket
+        for i in range(3):
+            pglite_async_session.add(
+                _make_snapshot(
+                    "e1",
+                    hours_until_commence=10.0,
+                    snapshot_time=datetime(2025, 1, 15, i, 0, tzinfo=UTC),
+                )
+            )
+        await pglite_async_session.commit()
+
+        reader = OddsReader(pglite_async_session)
+        coverage, season_totals = await reader.get_snapshot_coverage(sport_key="soccer_epl")
+
+        # Only 1 distinct event, regardless of snapshot count
+        assert len(coverage) == 1
+        _, _, _, event_count = coverage[0]
+        assert event_count == 1
+        assert season_totals["2024-25"] == 1
+
+    @pytest.mark.asyncio
+    async def test_season_totals_count_distinct_events_across_sources(self, pglite_async_session):
+        event = _make_event("e1", datetime(2025, 1, 15, 15, 0, tzinfo=UTC))
+        pglite_async_session.add(event)
+
+        # Same event covered by two different sources
+        pglite_async_session.add(
+            _make_snapshot("e1", hours_until_commence=10.0, api_request_id="oddsportal_live_epl")
+        )
+        pglite_async_session.add(
+            _make_snapshot(
+                "e1",
+                hours_until_commence=10.0,
+                api_request_id="football_data_uk",
+                snapshot_time=datetime(2025, 1, 15, 13, 0, tzinfo=UTC),
+            )
+        )
+        await pglite_async_session.commit()
+
+        reader = OddsReader(pglite_async_session)
+        coverage, season_totals = await reader.get_snapshot_coverage(sport_key="soccer_epl")
+
+        # Two source×bucket cells but only 1 distinct event for the season
+        assert len(coverage) == 2
+        assert season_totals["2024-25"] == 1
+
+    @pytest.mark.asyncio
+    async def test_season_boundary_august_starts_new_season(self, pglite_async_session):
+        jul_event = _make_event("e_jul", datetime(2024, 7, 31, 15, 0, tzinfo=UTC))
+        aug_event = _make_event("e_aug", datetime(2024, 8, 1, 15, 0, tzinfo=UTC))
+        pglite_async_session.add(jul_event)
+        pglite_async_session.add(aug_event)
+        pglite_async_session.add(_make_snapshot("e_jul", hours_until_commence=10.0))
+        pglite_async_session.add(
+            _make_snapshot(
+                "e_aug",
+                hours_until_commence=10.0,
+                snapshot_time=datetime(2024, 8, 1, 12, 0, tzinfo=UTC),
+            )
+        )
+        await pglite_async_session.commit()
+
+        reader = OddsReader(pglite_async_session)
+        _, season_totals = await reader.get_snapshot_coverage(sport_key="soccer_epl")
+
+        assert "2023-24" in season_totals  # July game
+        assert "2024-25" in season_totals  # August game
+        assert season_totals["2023-24"] == 1
+        assert season_totals["2024-25"] == 1
+
+    @pytest.mark.asyncio
+    async def test_ignores_events_without_hours_until_commence(self, pglite_async_session):
+        event = _make_event("e1", datetime(2025, 1, 15, 15, 0, tzinfo=UTC))
+        pglite_async_session.add(event)
+        # Snapshot with no hours_until_commence
+        pglite_async_session.add(
+            OddsSnapshot(
+                event_id="e1",
+                snapshot_time=datetime(2025, 1, 15, 12, 0, tzinfo=UTC),
+                raw_data={},
+                bookmaker_count=1,
+                api_request_id=None,
+                hours_until_commence=None,
+            )
+        )
+        await pglite_async_session.commit()
+
+        reader = OddsReader(pglite_async_session)
+        coverage, season_totals = await reader.get_snapshot_coverage(sport_key="soccer_epl")
+
+        assert coverage == []
+        assert season_totals == {}

--- a/tests/unit/test_snapshot_coverage.py
+++ b/tests/unit/test_snapshot_coverage.py
@@ -3,8 +3,9 @@
 from datetime import UTC, datetime
 
 import pytest
+from odds_analytics.standings_features import epl_season_key
 from odds_core.models import Event, EventStatus, OddsSnapshot
-from odds_lambda.storage.readers import OddsReader, _season_from_date
+from odds_lambda.storage.readers import OddsReader
 
 
 def _make_event(event_id: str, commence_time: datetime) -> Event:
@@ -37,19 +38,19 @@ def _make_snapshot(
     )
 
 
-class TestSeasonFromDate:
+class TestEplSeasonKey:
     def test_august_is_new_season(self):
-        assert _season_from_date(2024, 8) == "2024-25"
+        assert epl_season_key(datetime(2024, 8, 1, tzinfo=UTC)) == "2024-25"
 
     def test_july_is_prior_season(self):
-        assert _season_from_date(2025, 7) == "2024-25"
+        assert epl_season_key(datetime(2025, 7, 31, tzinfo=UTC)) == "2024-25"
 
     def test_january_is_current_year_minus_one(self):
-        assert _season_from_date(2024, 1) == "2023-24"
+        assert epl_season_key(datetime(2024, 1, 15, tzinfo=UTC)) == "2023-24"
 
     def test_boundary_month_7_vs_8(self):
-        assert _season_from_date(2023, 7) == "2022-23"
-        assert _season_from_date(2023, 8) == "2023-24"
+        assert epl_season_key(datetime(2023, 7, 31, tzinfo=UTC)) == "2022-23"
+        assert epl_season_key(datetime(2023, 8, 1, tzinfo=UTC)) == "2023-24"
 
 
 class TestGetSnapshotCoverage:

--- a/tests/unit/test_standings_features.py
+++ b/tests/unit/test_standings_features.py
@@ -173,9 +173,9 @@ class TestEplSeasonKey:
         dt = datetime(2025, 6, 1, 15, 0, tzinfo=UTC)
         assert epl_season_key(dt) == "2024-25"
 
-    def test_july_new_season(self) -> None:
+    def test_july_prior_season(self) -> None:
         dt = datetime(2025, 7, 1, 15, 0, tzinfo=UTC)
-        assert epl_season_key(dt) == "2025-26"
+        assert epl_season_key(dt) == "2024-25"
 
 
 class TestBuildLeagueTable:


### PR DESCRIPTION
## Summary

- Adds `odds status coverage [--sport SPORT_KEY]` CLI command that shows a Rich table of snapshot coverage broken down by season × source × tier bucket (time before kickoff)
- Adds `OddsReader.get_snapshot_coverage()` returning both coverage rows and per-season distinct event counts in a single DB round-trip (no redundant queries)
- Fixes `epl_season_key` season boundary from `month >= 7` to `month >= 8` (EPL runs Aug–Jul; July is end-of-season, not start) and consolidates season derivation to use this single function
- Source names abbreviated in column headers (`football_data_uk` → `fduk`, `oddsportal` → `op`, `odds_api` → `api`) for readability
- Adds 13 unit tests covering source normalisation, tier bucket boundaries, season boundary, distinct-event counting, and cross-source deduplication

## Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)