### PR TITLE
Update OddsHarvester to dismiss overlay modal and reduce click timeouts

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2815,7 +2815,7 @@ requires-dist = [
 [[package]]
 name = "oddsharvester"
 version = "0.1.0"
-source = { git = "https://github.com/Acusick1/OddsHarvester.git?branch=fix%2Ffractional-odds-and-unknown-bookmaker#a8c429261917368f7c1d100b11a2c4d13f35f5a3" }
+source = { git = "https://github.com/Acusick1/OddsHarvester.git?branch=fix%2Ffractional-odds-and-unknown-bookmaker#79c17d74693ba8d6a8c99c6233f32ab9d7ae42de" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "boto3" },


### PR DESCRIPTION
## Summary

- Bumps OddsHarvester fork to 79c17d7 which adds overlay modal dismissal and reduced click timeouts
- **Root cause**: OddsPortal's bookmaker promotional overlay (`div.overlay-bookie-modal`) intercepts all pointer events, causing every click to wait 30s before timing out. With 20 matches × 2 markets, this exceeds the 15-minute Lambda timeout
- **Fix**: `dismiss_overlay_modal()` clicks the SVG close button via synthetic JS event (sets modal to `display: none`), falls back to DOM removal. Called on every page load (listing page + each match page)
- **Also**: Reduced `element.click()` timeout from 30s to 5s in `_click_by_text` and bookmaker filter — if a click will succeed, 5s is plenty; if blocked by an unknown overlay, fail fast

Tested against live OddsPortal via Playwright: confirmed the close button click works and the DOM removal fallback works.

## Test plan
- [x] Verified modal dismissal against live OddsPortal (close button + DOM removal)
- [x] Verified clicks proceed normally after dismissal
- [x] Syntax validation on all changed OddsHarvester files

🤖 Generated with [Claude Code](https://claude.com/claude-code)