### PR TITLE
Build odds-mcp FastMCP server for betting agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ htmlcov/
 # Config files and data
 *.csv
 *.json
+!.mcp.json
 
 # ESPN fixture data (regenerated via scripts/ingest_espn_fixtures.py)
 data/espn_fixtures/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "odds": {
+      "type": "stdio",
+      "command": "uv",
+      "args": ["run", "fastmcp", "run", "packages/odds-mcp/odds_mcp/server.py"]
+    }
+  }
+}

--- a/packages/odds-cli/odds_cli/commands/copy_from_prod.py
+++ b/packages/odds-cli/odds_cli/commands/copy_from_prod.py
@@ -15,7 +15,7 @@ console = Console()
 def copy_from_production(
     start: str = typer.Argument(..., help="Start date (YYYY-MM-DD)"),
     end: str = typer.Argument(..., help="End date (YYYY-MM-DD)"),
-    sport: str = typer.Option("basketball_nba", "--sport", "-s", help="Sport to copy"),
+    sport: str = typer.Option("soccer_epl", "--sport", "-s", help="Sport to copy"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Perform dry run without writing data"),
     skip_existing: bool = typer.Option(
         True, "--skip-existing/--overwrite", help="Skip existing events"
@@ -24,22 +24,15 @@ def copy_from_production(
     local_url: str | None = typer.Option(None, "--local-url", help="Local database URL"),
 ):
     """
-    Copy completed games from production database to local database.
-
-    This performs a selective merge, copying only completed games with results
-    while preserving existing local data.
+    Copy events, snapshots, and predictions from production to local database.
 
     Examples:
-        # Copy October-November 2025 data (dry run first)
-        odds copy from-prod 2025-10-23 2025-11-07 --dry-run
+        odds copy from-prod 2025-08-01 2026-04-10
 
-        # Actually copy the data
-        odds copy from-prod 2025-10-23 2025-11-07
+        odds copy from-prod 2025-08-01 2026-04-10 --dry-run
 
-        # Copy with overwrite
-        odds copy from-prod 2025-10-23 2025-11-07 --overwrite
+        odds copy from-prod 2025-08-01 2026-04-10 --overwrite
     """
-    # Validate dates
     try:
         datetime.strptime(start, "%Y-%m-%d")
         datetime.strptime(end, "%Y-%m-%d")

--- a/packages/odds-lambda/odds_lambda/copy_from_production.py
+++ b/packages/odds-lambda/odds_lambda/copy_from_production.py
@@ -1,8 +1,7 @@
 """
-Copy completed games from production database to local database.
+Copy data from production database to local database.
 
-This script performs a selective merge, copying only completed games with results
-from the production database while preserving existing local data.
+Replicates events, snapshots, and predictions for a given sport and date range.
 """
 
 from __future__ import annotations
@@ -11,9 +10,11 @@ import os
 from datetime import UTC, datetime
 
 import structlog
-from odds_core.models import Event, EventStatus
+from odds_core.models import Event
+from odds_core.prediction_models import Prediction
 from rich.console import Console
 from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, TimeElapsedColumn
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from odds_lambda.storage.readers import OddsReader
@@ -24,7 +25,7 @@ console = Console()
 
 
 class ProductionDataCopier:
-    """Handles copying data from production to local database."""
+    """Copies events, snapshots, and predictions from production to local."""
 
     def __init__(
         self,
@@ -53,22 +54,23 @@ class ProductionDataCopier:
             "events_copied": 0,
             "events_skipped": 0,
             "snapshots_copied": 0,
+            "predictions_copied": 0,
             "errors": 0,
         }
 
-    async def copy_completed_games(
+    async def copy_events(
         self,
         start_date: datetime,
         end_date: datetime,
-        sport_key: str = "basketball_nba",
+        sport_key: str,
     ) -> dict:
         """
-        Copy completed games from production to local.
+        Copy all events, snapshots, and predictions from production to local.
 
         Args:
             start_date: Start of date range
             end_date: End of date range
-            sport_key: Sport to copy (default: basketball_nba)
+            sport_key: Sport to copy
 
         Returns:
             Dictionary with copy statistics
@@ -80,7 +82,6 @@ class ProductionDataCopier:
         console.print(f"  Skip existing: {self.skip_existing}")
         console.print()
 
-        # Query production for completed games
         async with self.prod_session_maker() as prod_session:
             prod_reader = OddsReader(prod_session)
 
@@ -89,22 +90,14 @@ class ProductionDataCopier:
                 start_date=start_date,
                 end_date=end_date,
                 sport_key=sport_key,
-                status=EventStatus.FINAL,
             )
 
-            # Filter to only events with scores
-            events_with_scores = [
-                e for e in events if e.home_score is not None and e.away_score is not None
-            ]
+            self.stats["total_events"] = len(events)
 
-            self.stats["total_events"] = len(events_with_scores)
+            console.print(f"[green]Found {len(events)} events in production[/green]")
 
-            console.print(
-                f"[green]Found {len(events_with_scores)} completed games in production[/green]"
-            )
-
-            if not events_with_scores:
-                console.print("[yellow]No completed games found in date range[/yellow]")
+            if not events:
+                console.print("[yellow]No events found matching criteria[/yellow]")
                 return self.stats
 
             # Copy each event with progress tracking
@@ -116,11 +109,11 @@ class ProductionDataCopier:
                 console=console,
             ) as progress:
                 task = progress.add_task(
-                    description="Copying games...",
-                    total=len(events_with_scores),
+                    description="Copying events...",
+                    total=len(events),
                 )
 
-                for event in events_with_scores:
+                for event in events:
                     try:
                         await self._copy_event(event, prod_reader, progress, task)
                     except Exception as e:
@@ -212,6 +205,12 @@ class ProductionDataCopier:
                         )
                         self.stats["snapshots_copied"] += 1
 
+                # Copy predictions
+                pred_count = await self._copy_predictions(
+                    event.id, prod_session_snapshot, local_session
+                )
+                self.stats["predictions_copied"] += pred_count
+
                 await local_session.commit()
 
                 logger.info(
@@ -220,13 +219,54 @@ class ProductionDataCopier:
                     snapshot_count=len(snapshots),
                 )
 
-    def _print_summary(self):
+    async def _copy_predictions(
+        self,
+        event_id: str,
+        prod_session: AsyncSession,
+        local_session: AsyncSession,
+    ) -> int:
+        """Copy predictions for an event from prod to local.
+
+        Uses ON CONFLICT DO NOTHING to skip duplicates (matches the
+        uq_prediction_event_snap_model constraint).
+
+        Returns:
+            Number of predictions copied.
+        """
+        result = await prod_session.execute(
+            select(Prediction).where(Prediction.event_id == event_id)
+        )
+        predictions = list(result.scalars().all())
+
+        copied = 0
+        for pred in predictions:
+            new_pred = Prediction(
+                event_id=pred.event_id,
+                snapshot_id=pred.snapshot_id,
+                model_name=pred.model_name,
+                model_version=pred.model_version,
+                predicted_clv=pred.predicted_clv,
+                created_at=pred.created_at,
+            )
+            local_session.add(new_pred)
+            try:
+                await local_session.flush()
+                copied += 1
+            except Exception:
+                # Duplicate — unique constraint violation
+                await local_session.rollback()
+
+        return copied
+
+    def _print_summary(self) -> None:
         """Print summary statistics."""
         console.print("\n[bold]Copy Summary:[/bold]")
         console.print(f"  Total events found: {self.stats['total_events']}")
         console.print(f"  Events copied: [green]{self.stats['events_copied']}[/green]")
         console.print(f"  Events skipped: [yellow]{self.stats['events_skipped']}[/yellow]")
         console.print(f"  Snapshots copied: [green]{self.stats['snapshots_copied']}[/green]")
+
+        console.print(f"  Predictions copied: [green]{self.stats['predictions_copied']}[/green]")
 
         if self.stats["errors"] > 0:
             console.print(f"  Errors: [red]{self.stats['errors']}[/red]")
@@ -242,19 +282,19 @@ async def copy_from_prod(
     end_date: str,
     prod_url: str | None = None,
     local_url: str | None = None,
-    sport: str = "basketball_nba",
+    sport: str = "soccer_epl",
     dry_run: bool = False,
     skip_existing: bool = True,
 ):
     """
-    Copy completed games from production to local database.
+    Copy all events, snapshots, and predictions from production to local database.
 
     Args:
         start_date: Start date (YYYY-MM-DD)
         end_date: End date (YYYY-MM-DD)
-        prod_url: Production database URL (defaults to DATABASE_URL or PROD_DATABASE_URL)
+        prod_url: Production database URL (defaults to PROD_DATABASE_URL)
         local_url: Local database URL (defaults to LOCAL_DATABASE_URL)
-        sport: Sport key (default: basketball_nba)
+        sport: Sport key (default: soccer_epl)
         dry_run: If True, don't actually write to database
         skip_existing: If True, skip events that already exist locally
     """
@@ -295,7 +335,7 @@ async def copy_from_prod(
             skip_existing=skip_existing,
         )
 
-        await copier.copy_completed_games(
+        await copier.copy_events(
             start_date=start_dt,
             end_date=end_dt,
             sport_key=sport,

--- a/packages/odds-mcp/odds_mcp/__init__.py
+++ b/packages/odds-mcp/odds_mcp/__init__.py
@@ -1,0 +1,1 @@
+"""FastMCP server exposing betting pipeline tools for AI agents."""

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -4,17 +4,17 @@ Thin wrappers over existing DB queries, jobs, and paper trading logic.
 All tools are stateless and use async_session_maker() for DB access.
 """
 
-from __future__ import annotations
-
+import math
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, Literal
 
 import structlog
 from fastmcp import FastMCP
 from odds_core.database import async_session_maker
-from odds_core.models import Event, EventStatus, OddsSnapshot
+from odds_core.models import Event, EventStatus, Odds, OddsSnapshot
 from odds_core.paper_trade_models import PaperTrade
 from odds_core.prediction_models import Prediction
+from odds_lambda.jobs.fetch_oddsportal import LEAGUE_SPECS
 from odds_lambda.paper_trading import (
     get_open_trades,
     get_portfolio_summary,
@@ -34,32 +34,69 @@ mcp = FastMCP(
     ),
 )
 
+# Build league lookup from canonical LEAGUE_SPECS
+_LEAGUE_SPEC_BY_NAME: dict[str, Any] = {spec.league: spec for spec in LEAGUE_SPECS}
+
+# Hybrid sharp reference matching production defaults
+_DEFAULT_SHARP_BOOKMAKERS = ["pinnacle", "betfair_exchange"]
+_DEFAULT_RETAIL_BOOKMAKERS = ["fanduel", "draftkings", "betmgm"]
+
 
 def _event_to_dict(event: Event) -> dict[str, Any]:
     """Serialize an Event to a JSON-safe dict."""
     return {
         "id": event.id,
         "sport_key": event.sport_key,
+        "sport_title": event.sport_title,
         "home_team": event.home_team,
         "away_team": event.away_team,
         "commence_time": event.commence_time.isoformat(),
         "status": event.status.value,
         "home_score": event.home_score,
         "away_score": event.away_score,
+        "completed_at": event.completed_at.isoformat() if event.completed_at else None,
     }
 
 
-def _snapshot_to_dict(snapshot: OddsSnapshot) -> dict[str, Any]:
-    """Serialize an OddsSnapshot to a JSON-safe dict."""
+def _odds_to_dict(odds: Odds) -> dict[str, Any]:
+    """Serialize an Odds object to a JSON-safe dict."""
     return {
+        "bookmaker_key": odds.bookmaker_key,
+        "bookmaker_title": odds.bookmaker_title,
+        "market_key": odds.market_key,
+        "outcome_name": odds.outcome_name,
+        "price": odds.price,
+        "point": odds.point,
+    }
+
+
+def _snapshot_to_dict(
+    snapshot: OddsSnapshot,
+    *,
+    include_raw_data: bool = False,
+    extracted_odds: list[Odds] | None = None,
+) -> dict[str, Any]:
+    """Serialize an OddsSnapshot to a JSON-safe dict.
+
+    Args:
+        snapshot: The snapshot to serialize.
+        include_raw_data: If True, include the full raw_data blob (for single-snapshot views).
+        extracted_odds: If provided, include structured odds instead of raw_data.
+    """
+    result: dict[str, Any] = {
         "id": snapshot.id,
         "event_id": snapshot.event_id,
         "snapshot_time": snapshot.snapshot_time.isoformat(),
+        "created_at": snapshot.created_at.isoformat(),
         "bookmaker_count": snapshot.bookmaker_count,
         "fetch_tier": snapshot.fetch_tier,
         "hours_until_commence": snapshot.hours_until_commence,
-        "raw_data": snapshot.raw_data,
     }
+    if include_raw_data:
+        result["raw_data"] = snapshot.raw_data
+    if extracted_odds is not None:
+        result["odds"] = [_odds_to_dict(o) for o in extracted_odds]
+    return result
 
 
 def _trade_to_dict(trade: PaperTrade) -> dict[str, Any]:
@@ -83,9 +120,21 @@ def _trade_to_dict(trade: PaperTrade) -> dict[str, Any]:
     }
 
 
-# ---------------------------------------------------------------------------
-# Tool 1: get_upcoming_fixtures
-# ---------------------------------------------------------------------------
+def _safe_float(val: Any) -> float | None:
+    """Convert numpy/float values, returning None for NaN."""
+    try:
+        f = float(val)
+        return None if math.isnan(f) else round(f, 6)
+    except (TypeError, ValueError):
+        return None
+
+
+def _resolve_sport_meta(league: str) -> tuple[str, str]:
+    """Map league name to pipeline sport_key and sport_title using LEAGUE_SPECS."""
+    spec = _LEAGUE_SPEC_BY_NAME.get(league)
+    if spec is not None:
+        return spec.sport_key, spec.sport_title
+    return f"football_{league.replace('-', '_')}", league.title()
 
 
 @mcp.tool()
@@ -118,11 +167,6 @@ async def get_upcoming_fixtures(
     return [_event_to_dict(e) for e in events]
 
 
-# ---------------------------------------------------------------------------
-# Tool 2: get_current_odds
-# ---------------------------------------------------------------------------
-
-
 @mcp.tool()
 async def get_current_odds(event_id: str) -> dict[str, Any]:
     """Get the latest odds snapshot for an event, showing current bookmaker prices.
@@ -131,7 +175,7 @@ async def get_current_odds(event_id: str) -> dict[str, Any]:
         event_id: Event identifier.
 
     Returns:
-        Dict with event info and the latest snapshot's raw bookmaker odds data.
+        Dict with event info and the latest snapshot including full raw bookmaker odds data.
     """
     async with async_session_maker() as session:
         reader = OddsReader(session)
@@ -149,18 +193,16 @@ async def get_current_odds(event_id: str) -> dict[str, Any]:
 
     return {
         "event": _event_to_dict(event),
-        "snapshot": _snapshot_to_dict(snapshot),
+        "snapshot": _snapshot_to_dict(snapshot, include_raw_data=True),
     }
-
-
-# ---------------------------------------------------------------------------
-# Tool 3: get_odds_history
-# ---------------------------------------------------------------------------
 
 
 @mcp.tool()
 async def get_odds_history(event_id: str) -> dict[str, Any]:
     """Get the full odds movement timeline for an event (all snapshots).
+
+    Returns structured bookmaker odds per snapshot instead of raw JSON blobs
+    to keep response size manageable.
 
     Args:
         event_id: Event identifier.
@@ -168,6 +210,8 @@ async def get_odds_history(event_id: str) -> dict[str, Any]:
     Returns:
         Dict with event info and chronologically ordered list of snapshots.
     """
+    from odds_analytics.sequence_loader import extract_odds_from_snapshot
+
     async with async_session_maker() as session:
         reader = OddsReader(session)
         event = await reader.get_event_by_id(event_id)
@@ -176,16 +220,16 @@ async def get_odds_history(event_id: str) -> dict[str, Any]:
 
         snapshots = await reader.get_snapshots_for_event(event_id)
 
+    serialized = []
+    for s in snapshots:
+        odds = extract_odds_from_snapshot(s, event_id, market="h2h")
+        serialized.append(_snapshot_to_dict(s, extracted_odds=odds))
+
     return {
         "event": _event_to_dict(event),
         "snapshot_count": len(snapshots),
-        "snapshots": [_snapshot_to_dict(s) for s in snapshots],
+        "snapshots": serialized,
     }
-
-
-# ---------------------------------------------------------------------------
-# Tool 4: refresh_scrape
-# ---------------------------------------------------------------------------
 
 
 @mcp.tool()
@@ -221,7 +265,7 @@ async def refresh_scrape(
         stats = await ingest_league(spec)
     except Exception as e:
         logger.error("refresh_scrape_failed", league=league, error=str(e), exc_info=True)
-        return {"error": str(e)}
+        return {"error": str(e), "error_type": type(e).__name__}
 
     return {
         "league": stats.league,
@@ -232,20 +276,6 @@ async def refresh_scrape(
         "snapshots_stored": stats.snapshots_stored,
         "errors": stats.errors,
     }
-
-
-def _resolve_sport_meta(league: str) -> tuple[str, str]:
-    """Map league name to pipeline sport_key and sport_title."""
-    mapping: dict[str, tuple[str, str]] = {
-        "england-premier-league": ("soccer_epl", "EPL"),
-        "nba": ("basketball_nba", "NBA"),
-    }
-    return mapping.get(league, (f"football_{league.replace('-', '_')}", league.title()))
-
-
-# ---------------------------------------------------------------------------
-# Tool 5: get_model_prediction
-# ---------------------------------------------------------------------------
 
 
 @mcp.tool()
@@ -262,8 +292,8 @@ async def get_model_prediction(event_id: str) -> dict[str, Any]:
         Dict with event info and list of prediction records.
     """
     async with async_session_maker() as session:
-        event_result = await session.execute(select(Event).where(Event.id == event_id))
-        event = event_result.scalar_one_or_none()
+        reader = OddsReader(session)
+        event = await reader.get_event_by_id(event_id)
         if event is None:
             return {"error": f"Event '{event_id}' not found"}
 
@@ -291,13 +321,13 @@ async def get_model_prediction(event_id: str) -> dict[str, Any]:
     }
 
 
-# ---------------------------------------------------------------------------
-# Tool 6: get_event_features
-# ---------------------------------------------------------------------------
-
-
 @mcp.tool()
-async def get_event_features(event_id: str) -> dict[str, Any]:
+async def get_event_features(
+    event_id: str,
+    outcome: Literal["home", "away"] = "home",
+    sharp_bookmakers: list[str] | None = None,
+    retail_bookmakers: list[str] | None = None,
+) -> dict[str, Any]:
     """Get the feature vector for an event's latest snapshot.
 
     Extracts tabular features (bookmaker odds, implied probabilities,
@@ -306,6 +336,9 @@ async def get_event_features(event_id: str) -> dict[str, Any]:
 
     Args:
         event_id: Event identifier.
+        outcome: Which outcome to extract features for ("home" or "away").
+        sharp_bookmakers: Sharp bookmaker keys (default: ["pinnacle", "betfair_exchange"]).
+        retail_bookmakers: Retail bookmaker keys (default: ["fanduel", "draftkings", "betmgm"]).
 
     Returns:
         Dict with event info and feature name/value pairs.
@@ -324,9 +357,16 @@ async def get_event_features(event_id: str) -> dict[str, Any]:
                 "message": "No snapshots available for feature extraction",
             }
 
-    # Feature extraction is sync and doesn't need a session
+    outcome_name = event.home_team if outcome == "home" else event.away_team
+
     try:
-        features = _extract_features_for_event(event, snapshot)
+        features = _extract_features_for_event(
+            event,
+            snapshot,
+            outcome_name=outcome_name,
+            sharp_bookmakers=sharp_bookmakers or _DEFAULT_SHARP_BOOKMAKERS,
+            retail_bookmakers=retail_bookmakers or _DEFAULT_RETAIL_BOOKMAKERS,
+        )
     except Exception as e:
         logger.error("feature_extraction_failed", event_id=event_id, error=str(e), exc_info=True)
         return {
@@ -342,7 +382,14 @@ async def get_event_features(event_id: str) -> dict[str, Any]:
     }
 
 
-def _extract_features_for_event(event: Event, snapshot: OddsSnapshot) -> dict[str, float | None]:
+def _extract_features_for_event(
+    event: Event,
+    snapshot: OddsSnapshot,
+    *,
+    outcome_name: str,
+    sharp_bookmakers: list[str],
+    retail_bookmakers: list[str],
+) -> dict[str, float | None]:
     """Extract feature dict from an event and its latest snapshot."""
     from odds_analytics.backtesting import BacktestEvent
     from odds_analytics.feature_extraction import TabularFeatureExtractor
@@ -362,11 +409,14 @@ def _extract_features_for_event(event: Event, snapshot: OddsSnapshot) -> dict[st
         status=event.status,
     )
 
-    extractor = TabularFeatureExtractor()
+    extractor = TabularFeatureExtractor(
+        sharp_bookmakers=sharp_bookmakers,
+        retail_bookmakers=retail_bookmakers,
+    )
     tab_feats = extractor.extract_features(
         event=backtest_event,
         odds_data=odds,
-        outcome=event.home_team,
+        outcome=outcome_name,
         market="h2h",
     )
 
@@ -382,22 +432,6 @@ def _extract_features_for_event(event: Event, snapshot: OddsSnapshot) -> dict[st
     features["hours_until_event"] = round(hours_until, 2)
 
     return features
-
-
-def _safe_float(val: Any) -> float | None:
-    """Convert numpy/float values, returning None for NaN."""
-    import math
-
-    try:
-        f = float(val)
-        return None if math.isnan(f) else round(f, 6)
-    except (TypeError, ValueError):
-        return None
-
-
-# ---------------------------------------------------------------------------
-# Tool 7: paper_bet
-# ---------------------------------------------------------------------------
 
 
 @mcp.tool()
@@ -429,13 +463,14 @@ async def paper_bet(
         Dict with the placed trade details.
     """
     async with async_session_maker() as session:
-        # Validate event exists
         event_result = await session.execute(select(Event).where(Event.id == event_id))
         event = event_result.scalar_one_or_none()
         if event is None:
             return {"error": f"Event '{event_id}' not found"}
 
-        # Compute bankroll from portfolio if not provided
+        if event.status != EventStatus.SCHEDULED:
+            return {"error": f"Event is '{event.status.value}', not 'scheduled'. Cannot place bet."}
+
         if bankroll is None:
             portfolio = await get_portfolio_summary(session)
             bankroll = portfolio.current_bankroll
@@ -454,18 +489,13 @@ async def paper_bet(
                 confidence=confidence,
             )
             await session.commit()
-        except ValueError as e:
-            return {"error": str(e)}
+        except Exception as e:
+            return {"error": str(e), "error_type": type(e).__name__}
 
     return {
         "status": "placed",
         "trade": _trade_to_dict(trade),
     }
-
-
-# ---------------------------------------------------------------------------
-# Tool 8: get_portfolio
-# ---------------------------------------------------------------------------
 
 
 @mcp.tool()
@@ -499,11 +529,6 @@ async def get_portfolio(initial_bankroll: float = 1000.0) -> dict[str, Any]:
     }
 
 
-# ---------------------------------------------------------------------------
-# Tool 9: settle_bets
-# ---------------------------------------------------------------------------
-
-
 @mcp.tool()
 async def settle_bets() -> dict[str, Any]:
     """Settle all paper trades whose events have final scores.
@@ -518,10 +543,11 @@ async def settle_bets() -> dict[str, Any]:
         settled = await settle_trades(session)
         await session.commit()
 
-    total_pnl = sum(t.pnl for t in settled if t.pnl is not None)
+        total_pnl = sum(t.pnl for t in settled if t.pnl is not None)
+        serialized = [_trade_to_dict(t) for t in settled]
 
     return {
         "settled_count": len(settled),
         "total_pnl": total_pnl,
-        "settled_trades": [_trade_to_dict(t) for t in settled],
+        "settled_trades": serialized,
     }

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -10,6 +10,9 @@ from typing import Any, Literal
 
 import structlog
 from fastmcp import FastMCP
+from odds_analytics.backtesting import BacktestEvent
+from odds_analytics.feature_extraction import TabularFeatureExtractor
+from odds_analytics.sequence_loader import extract_odds_from_snapshot
 from odds_core.database import async_session_maker
 from odds_core.models import Event, EventStatus, Odds, OddsSnapshot
 from odds_core.paper_trade_models import PaperTrade
@@ -37,9 +40,11 @@ mcp = FastMCP(
 # Build league lookup from canonical LEAGUE_SPECS
 _LEAGUE_SPEC_BY_NAME: dict[str, Any] = {spec.league: spec for spec in LEAGUE_SPECS}
 
-# Hybrid sharp reference matching production defaults
+# Hybrid sharp reference matching production defaults.
+# Duplicated from feature_extraction.py DEFAULT_SHARP_BOOKMAKERS / DEFAULT_RETAIL_BOOKMAKERS
+# with EPL-specific overrides — keep in sync.
 _DEFAULT_SHARP_BOOKMAKERS = ["pinnacle", "betfair_exchange"]
-_DEFAULT_RETAIL_BOOKMAKERS = ["fanduel", "draftkings", "betmgm"]
+_DEFAULT_RETAIL_BOOKMAKERS = ["bet365", "betway", "betfred"]
 
 
 def _event_to_dict(event: Event) -> dict[str, Any]:
@@ -168,14 +173,18 @@ async def get_upcoming_fixtures(
 
 
 @mcp.tool()
-async def get_current_odds(event_id: str) -> dict[str, Any]:
+async def get_current_odds(
+    event_id: str,
+    include_raw_data: bool = False,
+) -> dict[str, Any]:
     """Get the latest odds snapshot for an event, showing current bookmaker prices.
 
     Args:
         event_id: Event identifier.
+        include_raw_data: If True, also include the full raw_data JSON blob.
 
     Returns:
-        Dict with event info and the latest snapshot including full raw bookmaker odds data.
+        Dict with event info and the latest snapshot with structured odds.
     """
     async with async_session_maker() as session:
         reader = OddsReader(session)
@@ -191,9 +200,12 @@ async def get_current_odds(event_id: str) -> dict[str, Any]:
                 "message": "No odds snapshots available for this event",
             }
 
+    odds = extract_odds_from_snapshot(snapshot, event_id, market="h2h")
     return {
         "event": _event_to_dict(event),
-        "snapshot": _snapshot_to_dict(snapshot, include_raw_data=True),
+        "snapshot": _snapshot_to_dict(
+            snapshot, include_raw_data=include_raw_data, extracted_odds=odds
+        ),
     }
 
 
@@ -210,8 +222,6 @@ async def get_odds_history(event_id: str) -> dict[str, Any]:
     Returns:
         Dict with event info and chronologically ordered list of snapshots.
     """
-    from odds_analytics.sequence_loader import extract_odds_from_snapshot
-
     async with async_session_maker() as session:
         reader = OddsReader(session)
         event = await reader.get_event_by_id(event_id)
@@ -279,9 +289,10 @@ async def refresh_scrape(
 
 
 @mcp.tool()
-async def get_model_prediction(event_id: str) -> dict[str, Any]:
-    """Get CLV model predictions for an event.
+async def get_predictions(event_id: str) -> dict[str, Any]:
+    """Get pre-scored CLV predictions for an event.
 
+    Reads predictions stored by the scoring pipeline (not on-demand inference).
     Returns all predictions (one per snapshot scored) for the given event,
     ordered by creation time. If no predictions exist, returns an empty list.
 
@@ -328,17 +339,18 @@ async def get_event_features(
     sharp_bookmakers: list[str] | None = None,
     retail_bookmakers: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Get the feature vector for an event's latest snapshot.
+    """Get tabular features for an event's latest snapshot.
 
-    Extracts tabular features (bookmaker odds, implied probabilities,
-    market consensus) plus hours_until_event. Uses the same feature
-    extraction pipeline as the scoring job.
+    Extracts tabular features only (bookmaker odds, implied probabilities,
+    market consensus) plus hours_until_event. Does not include other feature
+    groups (standings, schedule, match_stats) which require additional data
+    sources not available via this tool.
 
     Args:
         event_id: Event identifier.
         outcome: Which outcome to extract features for ("home" or "away").
         sharp_bookmakers: Sharp bookmaker keys (default: ["pinnacle", "betfair_exchange"]).
-        retail_bookmakers: Retail bookmaker keys (default: ["fanduel", "draftkings", "betmgm"]).
+        retail_bookmakers: Retail bookmaker keys (default: ["bet365", "betway", "betfred"]).
 
     Returns:
         Dict with event info and feature name/value pairs.
@@ -391,10 +403,6 @@ def _extract_features_for_event(
     retail_bookmakers: list[str],
 ) -> dict[str, float | None]:
     """Extract feature dict from an event and its latest snapshot."""
-    from odds_analytics.backtesting import BacktestEvent
-    from odds_analytics.feature_extraction import TabularFeatureExtractor
-    from odds_analytics.sequence_loader import extract_odds_from_snapshot
-
     odds = extract_odds_from_snapshot(snapshot, event.id, market="h2h")
     if not odds:
         return {"error": "No h2h odds data in snapshot"}
@@ -489,7 +497,10 @@ async def paper_bet(
                 confidence=confidence,
             )
             await session.commit()
+        except ValueError as e:
+            return {"error": str(e), "error_type": "ValueError"}
         except Exception as e:
+            logger.error("paper_bet_failed", event_id=event_id, error=str(e), exc_info=True)
             return {"error": str(e), "error_type": type(e).__name__}
 
     return {

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -1,0 +1,527 @@
+"""FastMCP server exposing betting pipeline tools for AI agents.
+
+Thin wrappers over existing DB queries, jobs, and paper trading logic.
+All tools are stateless and use async_session_maker() for DB access.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import structlog
+from fastmcp import FastMCP
+from odds_core.database import async_session_maker
+from odds_core.models import Event, EventStatus, OddsSnapshot
+from odds_core.paper_trade_models import PaperTrade
+from odds_core.prediction_models import Prediction
+from odds_lambda.paper_trading import (
+    get_open_trades,
+    get_portfolio_summary,
+    place_trade,
+    settle_trades,
+)
+from odds_lambda.storage.readers import OddsReader
+from sqlalchemy import select
+
+logger = structlog.get_logger()
+
+mcp = FastMCP(
+    "odds-mcp",
+    instructions=(
+        "Betting odds pipeline tools. Use these to inspect fixtures, odds, predictions, "
+        "and manage paper trades for EPL football. All times are UTC."
+    ),
+)
+
+
+def _event_to_dict(event: Event) -> dict[str, Any]:
+    """Serialize an Event to a JSON-safe dict."""
+    return {
+        "id": event.id,
+        "sport_key": event.sport_key,
+        "home_team": event.home_team,
+        "away_team": event.away_team,
+        "commence_time": event.commence_time.isoformat(),
+        "status": event.status.value,
+        "home_score": event.home_score,
+        "away_score": event.away_score,
+    }
+
+
+def _snapshot_to_dict(snapshot: OddsSnapshot) -> dict[str, Any]:
+    """Serialize an OddsSnapshot to a JSON-safe dict."""
+    return {
+        "id": snapshot.id,
+        "event_id": snapshot.event_id,
+        "snapshot_time": snapshot.snapshot_time.isoformat(),
+        "bookmaker_count": snapshot.bookmaker_count,
+        "fetch_tier": snapshot.fetch_tier,
+        "hours_until_commence": snapshot.hours_until_commence,
+        "raw_data": snapshot.raw_data,
+    }
+
+
+def _trade_to_dict(trade: PaperTrade) -> dict[str, Any]:
+    """Serialize a PaperTrade to a JSON-safe dict."""
+    return {
+        "id": trade.id,
+        "event_id": trade.event_id,
+        "market": trade.market,
+        "selection": trade.selection,
+        "bookmaker": trade.bookmaker,
+        "odds": trade.odds,
+        "stake": trade.stake,
+        "reasoning": trade.reasoning,
+        "confidence": trade.confidence,
+        "bankroll_before": trade.bankroll_before,
+        "bankroll_after": trade.bankroll_after,
+        "placed_at": trade.placed_at.isoformat() if trade.placed_at else None,
+        "settled_at": trade.settled_at.isoformat() if trade.settled_at else None,
+        "result": trade.result.value if trade.result else None,
+        "pnl": trade.pnl,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool 1: get_upcoming_fixtures
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def get_upcoming_fixtures(
+    league: str = "soccer_epl",
+    days_ahead: int = 7,
+) -> list[dict[str, Any]]:
+    """Get upcoming scheduled fixtures for a league.
+
+    Args:
+        league: Sport key (e.g. "soccer_epl").
+        days_ahead: How many days ahead to look (1-30).
+
+    Returns:
+        List of fixture dicts with id, teams, commence_time, status.
+    """
+    days_ahead = max(1, min(days_ahead, 30))
+    now = datetime.now(UTC)
+    end = now + timedelta(days=days_ahead)
+
+    async with async_session_maker() as session:
+        reader = OddsReader(session)
+        events = await reader.get_events_by_date_range(
+            start_date=now,
+            end_date=end,
+            sport_key=league,
+            status=EventStatus.SCHEDULED,
+        )
+
+    return [_event_to_dict(e) for e in events]
+
+
+# ---------------------------------------------------------------------------
+# Tool 2: get_current_odds
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def get_current_odds(event_id: str) -> dict[str, Any]:
+    """Get the latest odds snapshot for an event, showing current bookmaker prices.
+
+    Args:
+        event_id: Event identifier.
+
+    Returns:
+        Dict with event info and the latest snapshot's raw bookmaker odds data.
+    """
+    async with async_session_maker() as session:
+        reader = OddsReader(session)
+        event = await reader.get_event_by_id(event_id)
+        if event is None:
+            return {"error": f"Event '{event_id}' not found"}
+
+        snapshot = await reader.get_latest_snapshot(event_id)
+        if snapshot is None:
+            return {
+                "event": _event_to_dict(event),
+                "snapshot": None,
+                "message": "No odds snapshots available for this event",
+            }
+
+    return {
+        "event": _event_to_dict(event),
+        "snapshot": _snapshot_to_dict(snapshot),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool 3: get_odds_history
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def get_odds_history(event_id: str) -> dict[str, Any]:
+    """Get the full odds movement timeline for an event (all snapshots).
+
+    Args:
+        event_id: Event identifier.
+
+    Returns:
+        Dict with event info and chronologically ordered list of snapshots.
+    """
+    async with async_session_maker() as session:
+        reader = OddsReader(session)
+        event = await reader.get_event_by_id(event_id)
+        if event is None:
+            return {"error": f"Event '{event_id}' not found"}
+
+        snapshots = await reader.get_snapshots_for_event(event_id)
+
+    return {
+        "event": _event_to_dict(event),
+        "snapshot_count": len(snapshots),
+        "snapshots": [_snapshot_to_dict(s) for s in snapshots],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool 4: refresh_scrape
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def refresh_scrape(
+    league: str = "england-premier-league",
+    market: str = "1x2",
+) -> dict[str, Any]:
+    """Trigger an on-demand OddsPortal scrape for a league and market.
+
+    This runs the full scrape-and-ingest pipeline: scrapes OddsPortal,
+    converts odds, matches/creates events, and stores snapshots.
+
+    Args:
+        league: OddsHarvester league name (e.g. "england-premier-league").
+        market: Market to scrape (e.g. "1x2", "over_under_2_5").
+
+    Returns:
+        Dict with ingestion statistics (matches scraped, events matched, etc).
+    """
+    from odds_lambda.jobs.fetch_oddsportal import LeagueSpec, ingest_league
+
+    sport_key, sport_title = _resolve_sport_meta(league)
+
+    spec = LeagueSpec(
+        sport="football",
+        league=league,
+        sport_key=sport_key,
+        sport_title=sport_title,
+        markets=[market],
+    )
+
+    try:
+        stats = await ingest_league(spec)
+    except Exception as e:
+        logger.error("refresh_scrape_failed", league=league, error=str(e), exc_info=True)
+        return {"error": str(e)}
+
+    return {
+        "league": stats.league,
+        "matches_scraped": stats.matches_scraped,
+        "matches_converted": stats.matches_converted,
+        "events_matched": stats.events_matched,
+        "events_created": stats.events_created,
+        "snapshots_stored": stats.snapshots_stored,
+        "errors": stats.errors,
+    }
+
+
+def _resolve_sport_meta(league: str) -> tuple[str, str]:
+    """Map league name to pipeline sport_key and sport_title."""
+    mapping: dict[str, tuple[str, str]] = {
+        "england-premier-league": ("soccer_epl", "EPL"),
+        "nba": ("basketball_nba", "NBA"),
+    }
+    return mapping.get(league, (f"football_{league.replace('-', '_')}", league.title()))
+
+
+# ---------------------------------------------------------------------------
+# Tool 5: get_model_prediction
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def get_model_prediction(event_id: str) -> dict[str, Any]:
+    """Get CLV model predictions for an event.
+
+    Returns all predictions (one per snapshot scored) for the given event,
+    ordered by creation time. If no predictions exist, returns an empty list.
+
+    Args:
+        event_id: Event identifier.
+
+    Returns:
+        Dict with event info and list of prediction records.
+    """
+    async with async_session_maker() as session:
+        event_result = await session.execute(select(Event).where(Event.id == event_id))
+        event = event_result.scalar_one_or_none()
+        if event is None:
+            return {"error": f"Event '{event_id}' not found"}
+
+        pred_result = await session.execute(
+            select(Prediction)
+            .where(Prediction.event_id == event_id)
+            .order_by(Prediction.created_at)
+        )
+        predictions = list(pred_result.scalars().all())
+
+    return {
+        "event": _event_to_dict(event),
+        "prediction_count": len(predictions),
+        "predictions": [
+            {
+                "id": p.id,
+                "snapshot_id": p.snapshot_id,
+                "model_name": p.model_name,
+                "model_version": p.model_version,
+                "predicted_clv": p.predicted_clv,
+                "created_at": p.created_at.isoformat(),
+            }
+            for p in predictions
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool 6: get_event_features
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def get_event_features(event_id: str) -> dict[str, Any]:
+    """Get the feature vector for an event's latest snapshot.
+
+    Extracts tabular features (bookmaker odds, implied probabilities,
+    market consensus) plus hours_until_event. Uses the same feature
+    extraction pipeline as the scoring job.
+
+    Args:
+        event_id: Event identifier.
+
+    Returns:
+        Dict with event info and feature name/value pairs.
+    """
+    async with async_session_maker() as session:
+        reader = OddsReader(session)
+        event = await reader.get_event_by_id(event_id)
+        if event is None:
+            return {"error": f"Event '{event_id}' not found"}
+
+        snapshot = await reader.get_latest_snapshot(event_id)
+        if snapshot is None:
+            return {
+                "event": _event_to_dict(event),
+                "features": None,
+                "message": "No snapshots available for feature extraction",
+            }
+
+    # Feature extraction is sync and doesn't need a session
+    try:
+        features = _extract_features_for_event(event, snapshot)
+    except Exception as e:
+        logger.error("feature_extraction_failed", event_id=event_id, error=str(e), exc_info=True)
+        return {
+            "event": _event_to_dict(event),
+            "features": None,
+            "message": f"Feature extraction failed: {e}",
+        }
+
+    return {
+        "event": _event_to_dict(event),
+        "snapshot_time": snapshot.snapshot_time.isoformat(),
+        "features": features,
+    }
+
+
+def _extract_features_for_event(event: Event, snapshot: OddsSnapshot) -> dict[str, float | None]:
+    """Extract feature dict from an event and its latest snapshot."""
+    from odds_analytics.backtesting import BacktestEvent
+    from odds_analytics.feature_extraction import TabularFeatureExtractor
+    from odds_analytics.sequence_loader import extract_odds_from_snapshot
+
+    odds = extract_odds_from_snapshot(snapshot, event.id, market="h2h")
+    if not odds:
+        return {"error": "No h2h odds data in snapshot"}
+
+    backtest_event = BacktestEvent(
+        id=event.id,
+        commence_time=event.commence_time,
+        home_team=event.home_team,
+        away_team=event.away_team,
+        home_score=0,
+        away_score=0,
+        status=event.status,
+    )
+
+    extractor = TabularFeatureExtractor()
+    tab_feats = extractor.extract_features(
+        event=backtest_event,
+        odds_data=odds,
+        outcome=event.home_team,
+        market="h2h",
+    )
+
+    feature_names = extractor.get_feature_names()
+    feature_array = tab_feats.to_array()
+
+    features = {
+        f"tab_{name}": _safe_float(val)
+        for name, val in zip(feature_names, feature_array, strict=True)
+    }
+
+    hours_until = (event.commence_time - snapshot.snapshot_time).total_seconds() / 3600
+    features["hours_until_event"] = round(hours_until, 2)
+
+    return features
+
+
+def _safe_float(val: Any) -> float | None:
+    """Convert numpy/float values, returning None for NaN."""
+    import math
+
+    try:
+        f = float(val)
+        return None if math.isnan(f) else round(f, 6)
+    except (TypeError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Tool 7: paper_bet
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def paper_bet(
+    event_id: str,
+    market: str,
+    selection: str,
+    odds: int,
+    stake: float,
+    reasoning: str = "",
+    bookmaker: str = "best_available",
+    confidence: float | None = None,
+    bankroll: float | None = None,
+) -> dict[str, Any]:
+    """Place a paper (simulated) bet on an event.
+
+    Args:
+        event_id: Event identifier.
+        market: Market type (e.g. "h2h").
+        selection: "home", "draw", or "away".
+        odds: American odds at time of placement (e.g. -110, +150).
+        stake: Stake amount.
+        reasoning: Why this bet is being placed.
+        bookmaker: Bookmaker key (default "best_available").
+        confidence: Agent confidence score (0.0 to 1.0, optional).
+        bankroll: Current bankroll. If omitted, computed from portfolio state.
+
+    Returns:
+        Dict with the placed trade details.
+    """
+    async with async_session_maker() as session:
+        # Validate event exists
+        event_result = await session.execute(select(Event).where(Event.id == event_id))
+        event = event_result.scalar_one_or_none()
+        if event is None:
+            return {"error": f"Event '{event_id}' not found"}
+
+        # Compute bankroll from portfolio if not provided
+        if bankroll is None:
+            portfolio = await get_portfolio_summary(session)
+            bankroll = portfolio.current_bankroll
+
+        try:
+            trade = await place_trade(
+                session,
+                event_id=event_id,
+                market=market,
+                selection=selection,
+                bookmaker=bookmaker,
+                odds=odds,
+                stake=stake,
+                bankroll=bankroll,
+                reasoning=reasoning or None,
+                confidence=confidence,
+            )
+            await session.commit()
+        except ValueError as e:
+            return {"error": str(e)}
+
+    return {
+        "status": "placed",
+        "trade": _trade_to_dict(trade),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool 8: get_portfolio
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def get_portfolio(initial_bankroll: float = 1000.0) -> dict[str, Any]:
+    """Get paper trading portfolio summary: open bets, P&L, bankroll.
+
+    Args:
+        initial_bankroll: Starting bankroll for ROI calculation.
+
+    Returns:
+        Dict with portfolio metrics and list of open trades.
+    """
+    async with async_session_maker() as session:
+        portfolio = await get_portfolio_summary(session, initial_bankroll=initial_bankroll)
+        open_trades = await get_open_trades(session)
+
+    return {
+        "current_bankroll": portfolio.current_bankroll,
+        "total_trades": portfolio.total_trades,
+        "settled_trades": portfolio.settled_trades,
+        "open_trades": portfolio.open_trades,
+        "total_pnl": portfolio.total_pnl,
+        "total_staked": portfolio.total_staked,
+        "roi": round(portfolio.roi, 2),
+        "record": {
+            "wins": portfolio.win_count,
+            "losses": portfolio.loss_count,
+            "pushes": portfolio.push_count,
+        },
+        "open_trade_details": [_trade_to_dict(t) for t in open_trades],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool 9: settle_bets
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def settle_bets() -> dict[str, Any]:
+    """Settle all paper trades whose events have final scores.
+
+    Idempotent: only settles trades that haven't been settled yet.
+    Determines win/loss by comparing selection against actual match result.
+
+    Returns:
+        Dict with count of settled trades and their details.
+    """
+    async with async_session_maker() as session:
+        settled = await settle_trades(session)
+        await session.commit()
+
+    total_pnl = sum(t.pnl for t in settled if t.pnl is not None)
+
+    return {
+        "settled_count": len(settled),
+        "total_pnl": total_pnl,
+        "settled_trades": [_trade_to_dict(t) for t in settled],
+    }

--- a/packages/odds-mcp/pyproject.toml
+++ b/packages/odds-mcp/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "odds-mcp"
+version = "0.1.0"
+description = "FastMCP server exposing betting pipeline tools for AI agents"
+authors = [{name = "Andrew"}]
+requires-python = ">=3.12"
+dependencies = [
+    "odds-core",
+    "odds-lambda",
+    "odds-analytics",
+    "fastmcp>=2.0.0",
+]
+
+[tool.uv.sources]
+odds-core = { workspace = true }
+odds-lambda = { workspace = true }
+odds-analytics = { workspace = true }
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["odds_mcp"]

--- a/packages/odds-mcp/tests/test_server.py
+++ b/packages/odds-mcp/tests/test_server.py
@@ -1,0 +1,329 @@
+"""Unit tests for MCP server serialization helpers and error paths."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from odds_core.models import Event, EventStatus, OddsSnapshot
+from odds_core.paper_trade_models import PaperTrade, TradeResult
+
+
+class TestEventToDict:
+    def _make_event(self, **overrides: object) -> Event:
+        defaults = {
+            "id": "evt-1",
+            "sport_key": "soccer_epl",
+            "sport_title": "EPL",
+            "home_team": "Arsenal",
+            "away_team": "Chelsea",
+            "commence_time": datetime(2026, 4, 12, 15, 0, tzinfo=UTC),
+            "status": EventStatus.SCHEDULED,
+            "home_score": None,
+            "away_score": None,
+            "completed_at": None,
+        }
+        defaults.update(overrides)
+        event = MagicMock(spec=Event)
+        for k, v in defaults.items():
+            setattr(event, k, v)
+        return event
+
+    def test_basic_fields(self) -> None:
+        from odds_mcp.server import _event_to_dict
+
+        event = self._make_event()
+        result = _event_to_dict(event)
+        assert result["id"] == "evt-1"
+        assert result["sport_key"] == "soccer_epl"
+        assert result["sport_title"] == "EPL"
+        assert result["home_team"] == "Arsenal"
+        assert result["away_team"] == "Chelsea"
+        assert result["status"] == "scheduled"
+        assert result["home_score"] is None
+        assert result["away_score"] is None
+        assert result["completed_at"] is None
+        assert "commence_time" in result
+
+    def test_completed_event(self) -> None:
+        from odds_mcp.server import _event_to_dict
+
+        completed = datetime(2026, 4, 12, 17, 0, tzinfo=UTC)
+        event = self._make_event(
+            status=EventStatus.FINAL,
+            home_score=2,
+            away_score=1,
+            completed_at=completed,
+        )
+        result = _event_to_dict(event)
+        assert result["status"] == "final"
+        assert result["home_score"] == 2
+        assert result["completed_at"] == completed.isoformat()
+
+
+class TestSnapshotToDict:
+    def _make_snapshot(self, **overrides: object) -> OddsSnapshot:
+        defaults = {
+            "id": 42,
+            "event_id": "evt-1",
+            "snapshot_time": datetime(2026, 4, 12, 10, 0, tzinfo=UTC),
+            "created_at": datetime(2026, 4, 12, 10, 1, tzinfo=UTC),
+            "bookmaker_count": 5,
+            "fetch_tier": "early",
+            "hours_until_commence": 5.0,
+            "raw_data": {"bookmakers": [{"key": "bet365"}]},
+        }
+        defaults.update(overrides)
+        snap = MagicMock(spec=OddsSnapshot)
+        for k, v in defaults.items():
+            setattr(snap, k, v)
+        return snap
+
+    def test_excludes_raw_data_by_default(self) -> None:
+        from odds_mcp.server import _snapshot_to_dict
+
+        snap = self._make_snapshot()
+        result = _snapshot_to_dict(snap)
+        assert "raw_data" not in result
+        assert result["id"] == 42
+        assert result["created_at"] is not None
+        assert result["fetch_tier"] == "early"
+
+    def test_includes_raw_data_when_requested(self) -> None:
+        from odds_mcp.server import _snapshot_to_dict
+
+        snap = self._make_snapshot()
+        result = _snapshot_to_dict(snap, include_raw_data=True)
+        assert "raw_data" in result
+        assert result["raw_data"]["bookmakers"][0]["key"] == "bet365"
+
+    def test_includes_extracted_odds(self) -> None:
+        from odds_mcp.server import _snapshot_to_dict
+
+        odds_obj = MagicMock()
+        odds_obj.bookmaker_key = "bet365"
+        odds_obj.bookmaker_title = "Bet365"
+        odds_obj.market_key = "h2h"
+        odds_obj.outcome_name = "Arsenal"
+        odds_obj.price = -110
+        odds_obj.point = None
+
+        snap = self._make_snapshot()
+        result = _snapshot_to_dict(snap, extracted_odds=[odds_obj])
+        assert len(result["odds"]) == 1
+        assert result["odds"][0]["bookmaker_key"] == "bet365"
+        assert result["odds"][0]["price"] == -110
+
+
+class TestTradeToDict:
+    def test_serialization(self) -> None:
+        from odds_mcp.server import _trade_to_dict
+
+        trade = MagicMock(spec=PaperTrade)
+        trade.id = 1
+        trade.event_id = "evt-1"
+        trade.market = "h2h"
+        trade.selection = "home"
+        trade.bookmaker = "bet365"
+        trade.odds = -110
+        trade.stake = 10.0
+        trade.reasoning = "good value"
+        trade.confidence = 0.8
+        trade.bankroll_before = 1000.0
+        trade.bankroll_after = None
+        trade.placed_at = datetime(2026, 4, 12, 10, 0, tzinfo=UTC)
+        trade.settled_at = None
+        trade.result = None
+        trade.pnl = None
+
+        result = _trade_to_dict(trade)
+        assert result["id"] == 1
+        assert result["odds"] == -110
+        assert result["result"] is None
+        assert result["settled_at"] is None
+
+    def test_settled_trade(self) -> None:
+        from odds_mcp.server import _trade_to_dict
+
+        trade = MagicMock(spec=PaperTrade)
+        trade.id = 2
+        trade.event_id = "evt-1"
+        trade.market = "h2h"
+        trade.selection = "home"
+        trade.bookmaker = "bet365"
+        trade.odds = -110
+        trade.stake = 10.0
+        trade.reasoning = None
+        trade.confidence = None
+        trade.bankroll_before = 1000.0
+        trade.bankroll_after = 1009.09
+        trade.placed_at = datetime(2026, 4, 12, 10, 0, tzinfo=UTC)
+        trade.settled_at = datetime(2026, 4, 12, 17, 0, tzinfo=UTC)
+        trade.result = TradeResult.WIN
+        trade.pnl = 9.09
+
+        result = _trade_to_dict(trade)
+        assert result["result"] == "win"
+        assert result["pnl"] == 9.09
+
+
+class TestSafeFloat:
+    def test_normal_float(self) -> None:
+        from odds_mcp.server import _safe_float
+
+        assert _safe_float(1.23456789) == 1.234568
+
+    def test_nan(self) -> None:
+        from odds_mcp.server import _safe_float
+
+        assert _safe_float(float("nan")) is None
+
+    def test_none(self) -> None:
+        from odds_mcp.server import _safe_float
+
+        assert _safe_float(None) is None
+
+    def test_string(self) -> None:
+        from odds_mcp.server import _safe_float
+
+        assert _safe_float("not a number") is None
+
+
+class TestResolveSportMeta:
+    def test_known_league(self) -> None:
+        from odds_mcp.server import _resolve_sport_meta
+
+        sport_key, sport_title = _resolve_sport_meta("england-premier-league")
+        assert sport_key == "soccer_epl"
+        assert sport_title == "EPL"
+
+    def test_unknown_league_fallback(self) -> None:
+        from odds_mcp.server import _resolve_sport_meta
+
+        sport_key, sport_title = _resolve_sport_meta("spain-la-liga")
+        assert sport_key == "football_spain_la_liga"
+        assert sport_title == "Spain-La-Liga"
+
+
+class TestGetUpcomingFixtures:
+    @pytest.mark.asyncio
+    async def test_returns_fixtures(self) -> None:
+        from odds_mcp.server import get_upcoming_fixtures
+
+        mock_event = MagicMock(spec=Event)
+        mock_event.id = "evt-1"
+        mock_event.sport_key = "soccer_epl"
+        mock_event.sport_title = "EPL"
+        mock_event.home_team = "Arsenal"
+        mock_event.away_team = "Chelsea"
+        mock_event.commence_time = datetime(2026, 4, 12, 15, 0, tzinfo=UTC)
+        mock_event.status = EventStatus.SCHEDULED
+        mock_event.home_score = None
+        mock_event.away_score = None
+        mock_event.completed_at = None
+
+        mock_reader = AsyncMock()
+        mock_reader.get_events_by_date_range = AsyncMock(return_value=[mock_event])
+
+        with (
+            patch("odds_mcp.server.async_session_maker") as mock_session_maker,
+            patch("odds_mcp.server.OddsReader", return_value=mock_reader),
+        ):
+            mock_session_maker.return_value.__aenter__ = AsyncMock()
+            mock_session_maker.return_value.__aexit__ = AsyncMock()
+
+            result = await get_upcoming_fixtures()
+            assert len(result) == 1
+            assert result[0]["id"] == "evt-1"
+
+
+class TestGetCurrentOddsMissingEvent:
+    @pytest.mark.asyncio
+    async def test_missing_event(self) -> None:
+        from odds_mcp.server import get_current_odds
+
+        mock_reader = AsyncMock()
+        mock_reader.get_event_by_id = AsyncMock(return_value=None)
+
+        with (
+            patch("odds_mcp.server.async_session_maker") as mock_session_maker,
+            patch("odds_mcp.server.OddsReader", return_value=mock_reader),
+        ):
+            mock_session_maker.return_value.__aenter__ = AsyncMock()
+            mock_session_maker.return_value.__aexit__ = AsyncMock()
+
+            result = await get_current_odds("nonexistent")
+            assert "error" in result
+            assert "nonexistent" in result["error"]
+
+
+class TestGetModelPredictionMissingEvent:
+    @pytest.mark.asyncio
+    async def test_missing_event(self) -> None:
+        from odds_mcp.server import get_model_prediction
+
+        mock_reader = AsyncMock()
+        mock_reader.get_event_by_id = AsyncMock(return_value=None)
+
+        with (
+            patch("odds_mcp.server.async_session_maker") as mock_session_maker,
+            patch("odds_mcp.server.OddsReader", return_value=mock_reader),
+        ):
+            mock_session_maker.return_value.__aenter__ = AsyncMock()
+            mock_session_maker.return_value.__aexit__ = AsyncMock()
+
+            result = await get_model_prediction("nonexistent")
+            assert "error" in result
+
+
+class TestPaperBetValidation:
+    @pytest.mark.asyncio
+    async def test_rejects_non_scheduled_event(self) -> None:
+        from odds_mcp.server import paper_bet
+
+        mock_event = MagicMock(spec=Event)
+        mock_event.id = "evt-1"
+        mock_event.status = EventStatus.FINAL
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_event
+
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("odds_mcp.server.async_session_maker") as mock_session_maker:
+            mock_session_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_maker.return_value.__aexit__ = AsyncMock()
+
+            result = await paper_bet(
+                event_id="evt-1",
+                market="h2h",
+                selection="home",
+                odds=-110,
+                stake=10.0,
+            )
+            assert "error" in result
+            assert "final" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_missing_event(self) -> None:
+        from odds_mcp.server import paper_bet
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("odds_mcp.server.async_session_maker") as mock_session_maker:
+            mock_session_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_maker.return_value.__aexit__ = AsyncMock()
+
+            result = await paper_bet(
+                event_id="nonexistent",
+                market="h2h",
+                selection="home",
+                odds=-110,
+                stake=10.0,
+            )
+            assert "error" in result
+            assert "nonexistent" in result["error"]

--- a/packages/odds-mcp/tests/test_server.py
+++ b/packages/odds-mcp/tests/test_server.py
@@ -256,10 +256,10 @@ class TestGetCurrentOddsMissingEvent:
             assert "nonexistent" in result["error"]
 
 
-class TestGetModelPredictionMissingEvent:
+class TestGetPredictionsMissingEvent:
     @pytest.mark.asyncio
     async def test_missing_event(self) -> None:
-        from odds_mcp.server import get_model_prediction
+        from odds_mcp.server import get_predictions
 
         mock_reader = AsyncMock()
         mock_reader.get_event_by_id = AsyncMock(return_value=None)
@@ -271,7 +271,7 @@ class TestGetModelPredictionMissingEvent:
             mock_session_maker.return_value.__aenter__ = AsyncMock()
             mock_session_maker.return_value.__aexit__ = AsyncMock()
 
-            result = await get_model_prediction("nonexistent")
+            result = await get_predictions("nonexistent")
             assert "error" in result
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ members = [
     "packages/odds-lambda",
     "packages/odds-analytics",
     "packages/odds-cli",
+    "packages/odds-mcp",
 ]
 
 [project]
@@ -20,6 +21,7 @@ dependencies = [
     "odds-lambda",
     "odds-analytics[training]",
     "odds-cli",
+    "odds-mcp",
 ]
 
 [tool.uv.sources]
@@ -27,6 +29,7 @@ odds-core = { workspace = true }
 odds-lambda = { workspace = true }
 odds-analytics = { workspace = true }
 odds-cli = { workspace = true }
+odds-mcp = { workspace = true }
 oddsharvester = { git = "https://github.com/Acusick1/OddsHarvester.git", branch = "fix/fractional-odds-and-unknown-bookmaker" }
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,19 @@ members = [
     "odds-cli",
     "odds-core",
     "odds-lambda",
+    "odds-mcp",
+]
+
+[[package]]
+name = "aiofile"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
 ]
 
 [[package]]
@@ -298,12 +311,33 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.6.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
 ]
 
 [[package]]
@@ -328,6 +362,7 @@ dependencies = [
     { name = "odds-cli" },
     { name = "odds-core" },
     { name = "odds-lambda" },
+    { name = "odds-mcp" },
 ]
 
 [package.dev-dependencies]
@@ -359,6 +394,7 @@ requires-dist = [
     { name = "odds-cli", editable = "packages/odds-cli" },
     { name = "odds-core", editable = "packages/odds-core" },
     { name = "odds-lambda", editable = "packages/odds-lambda" },
+    { name = "odds-mcp", editable = "packages/odds-mcp" },
 ]
 
 [package.metadata.requires-dev]
@@ -445,6 +481,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fb/44/ca1675be2a83aeee1886ab745b28cda92093066590233cc501890eb8417a/cachetools-6.2.2.tar.gz", hash = "sha256:8e6d266b25e539df852251cfd6f990b4bc3a141db73b939058d809ebd2590fc6", size = 31571, upload-time = "2025-11-13T17:42:51.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/46/eb6eca305c77a4489affe1c5d8f4cae82f285d9addd8de4ec084a7184221/cachetools-6.2.2-py3-none-any.whl", hash = "sha256:6c09c98183bf58560c97b2abfcedcbaf6a896a490f534b031b661d3723b45ace", size = 11503, upload-time = "2025-11-13T17:42:50.232Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
 ]
 
 [[package]]
@@ -836,6 +893,21 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "4.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/2c/fced34890f6e5a93a4b7afb2c71e8eee2a0719fb26193a0abf159ecb714d/cyclopts-4.10.2.tar.gz", hash = "sha256:d7b950457ef2563596d56331f80cbbbf86a2772535fb8b315c4f03bc7e6127f1", size = 166664, upload-time = "2026-04-08T23:57:45.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/bd/05055d8360cef0757d79367157f3b15c0a0715e81e08f86a04018ec045f0/cyclopts-4.10.2-py3-none-any.whl", hash = "sha256:a1f2d6f8f7afac9456b48f75a40b36658778ddc9c6d406b520d017ae32c990fe", size = 204314, upload-time = "2026-04-08T23:57:46.969Z" },
+]
+
+[[package]]
 name = "databricks-sdk"
 version = "0.73.0"
 source = { registry = "https://pypi.org/simple" }
@@ -907,6 +979,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "docker"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -918,6 +999,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
 ]
 
 [[package]]
@@ -960,6 +1084,38 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/b5/23b216d9d985a956623b6bd12d4086b60f0059b27799f23016af04a74ea1/fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de", size = 374130, upload-time = "2025-08-14T18:49:36.666Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463", size = 24024, upload-time = "2025-08-14T18:49:34.776Z" },
+]
+
+[[package]]
+name = "fastmcp"
+version = "3.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pyperclip" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/42/7eed0a38e3b7a386805fecacf8a5a9353a2b3040395ef9e30e585d8549ac/fastmcp-3.2.3.tar.gz", hash = "sha256:4f02ae8b00227285a0cf6544dea1db29b022c8cdd8d3dfdec7118540210ae60a", size = 26328743, upload-time = "2026-04-09T22:05:03.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/48/84b6dcba793178a44b9d99b4def6cd62f870dcfc5bb7b9153ac390135812/fastmcp-3.2.3-py3-none-any.whl", hash = "sha256:cc50af6eed1f62ed8b6ebf4987286d8d1d006f08d5bec739d5c7fb76160e0911", size = 707260, upload-time = "2026-04-09T22:05:01.225Z" },
 ]
 
 [[package]]
@@ -1324,6 +1480,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "huey"
 version = "2.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1466,6 +1631,39 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+]
+
+[[package]]
 name = "jedi"
 version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1475,6 +1673,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
@@ -1550,6 +1757,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1575,6 +1791,20 @@ format-nongpl = [
     { name = "rfc3987-syntax" },
     { name = "uri-template" },
     { name = "webcolors" },
+]
+
+[[package]]
+name = "jsonschema-path"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/8a/7e6102f2b8bdc6705a9eb5294f8f6f9ccd3a8420e8e8e19671d1dd773251/jsonschema_path-0.4.5.tar.gz", hash = "sha256:c6cd7d577ae290c7defd4f4029e86fdb248ca1bd41a07557795b3c95e5144918", size = 15113, upload-time = "2026-03-03T09:56:46.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/d5/4e96c44f6c1ea3d812cf5391d81a4f5abaa540abf8d04ecd7f66e0ed11df/jsonschema_path-0.4.5-py3-none-any.whl", hash = "sha256:7d77a2c3f3ec569a40efe5c5f942c44c1af2a6f96fe0866794c9ef5b8f87fd65", size = 19368, upload-time = "2026-03-03T09:56:45.39Z" },
 ]
 
 [[package]]
@@ -1785,6 +2015,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/26/2d/ef58fed122b268c69c0aa099da20bc67657cdfb2e222688d5731bd5b971d/jupyterlab_widgets-3.0.16.tar.gz", hash = "sha256:423da05071d55cf27a9e602216d35a3a65a3e41cdf9c5d3b643b814ce38c19e0", size = 897423, upload-time = "2025-11-01T21:11:29.724Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl", hash = "sha256:45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8", size = 914926, upload-time = "2025-11-01T21:11:28.008Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -2102,6 +2349,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2195,6 +2467,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/11/4e/a1b2f977a50ed3860e2848548a9173b9018806628d46d5bdafa8b45bc0c7/mlflow_tracing-3.6.0.tar.gz", hash = "sha256:ccff80b3aad6caa18233c98ba69922a91a6f914e0a13d12e1977af7523523d4c", size = 1061879, upload-time = "2025-11-07T18:36:24.818Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/ec/ba3f513152cf5404e36263604d484728d47e61678c39228c36eb769199af/mlflow_tracing-3.6.0-py3-none-any.whl", hash = "sha256:a68ff03ba5129c67dc98e6871e0d5ef512dd3ee66d01e1c1a0c946c08a6d4755", size = 1281617, upload-time = "2025-11-07T18:36:23.299Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
 ]
 
 [[package]]
@@ -2813,6 +3094,25 @@ requires-dist = [
 ]
 
 [[package]]
+name = "odds-mcp"
+version = "0.1.0"
+source = { editable = "packages/odds-mcp" }
+dependencies = [
+    { name = "fastmcp" },
+    { name = "odds-analytics" },
+    { name = "odds-core" },
+    { name = "odds-lambda" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastmcp", specifier = ">=2.0.0" },
+    { name = "odds-analytics", editable = "packages/odds-analytics" },
+    { name = "odds-core", editable = "packages/odds-core" },
+    { name = "odds-lambda", editable = "packages/odds-lambda" },
+]
+
+[[package]]
 name = "oddsharvester"
 version = "0.1.0"
 source = { git = "https://github.com/Acusick1/OddsHarvester.git?branch=fix%2Ffractional-odds-and-unknown-bookmaker#79c17d74693ba8d6a8c99c6233f32ab9d7ae42de" }
@@ -2823,6 +3123,18 @@ dependencies = [
     { name = "lxml" },
     { name = "playwright" },
     { name = "pytz" },
+]
+
+[[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
 ]
 
 [[package]]
@@ -2984,6 +3296,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d4/de/53e0bcf53d13e005bd8c92e7855142494f41171b34c2536b86187474184d/parso-0.8.5.tar.gz", hash = "sha256:034d7354a9a018bdce352f48b2a8a450f05e9d6ee85db84764e9b6bd96dafe5a", size = 401205, upload-time = "2025-08-23T15:15:28.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/32/f8e3c85d1d5250232a5d3477a2a28cc291968ff175caeadaf3cc19ce0e4a/parso-0.8.5-py2.py3-none-any.whl", hash = "sha256:646204b5ee239c396d040b90f9e272e9a8017c630092bf59980beb62fd033887", size = 106668, upload-time = "2025-08-23T15:15:25.663Z" },
+]
+
+[[package]]
+name = "pathable"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/55/b748445cb4ea6b125626f15379be7c96d1035d4fa3e8fee362fa92298abf/pathable-0.5.0.tar.gz", hash = "sha256:d81938348a1cacb525e7c75166270644782c0fb9c8cecc16be033e71427e0ef1", size = 16655, upload-time = "2026-02-20T08:47:00.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/96/5a770e5c461462575474468e5af931cff9de036e7c2b4fea23c1c58d2cbe/pathable-0.5.0-py3-none-any.whl", hash = "sha256:646e3d09491a6351a0c82632a09c02cdf70a252e73196b36d8a15ba0a114f0a6", size = 16867, upload-time = "2026-02-20T08:46:59.536Z" },
 ]
 
 [[package]]
@@ -3362,6 +3683,31 @@ wheels = [
 ]
 
 [[package]]
+name = "py-key-value-aio"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
+]
+
+[package.optional-dependencies]
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
+]
+
+[[package]]
 name = "py-pglite"
 version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3467,6 +3813,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/ad/a17bc283d7d81837c061c49e3eaa27a45991759a1b7eae1031921c6bd924/pydantic-2.12.4.tar.gz", hash = "sha256:0f8cb9555000a4b5b617f66bfd2566264c4984b27589d3b845685983e8ea85ac", size = 821038, upload-time = "2025-11-05T10:50:08.59Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/2f/e68750da9b04856e2a7ec56fc6f034a5a79775e9b9a81882252789873798/pydantic-2.12.4-py3-none-any.whl", hash = "sha256:92d3d202a745d46f9be6df459ac5a064fdaa3c1c4cd8adcfa332ccf3c05f871e", size = 463400, upload-time = "2025-11-05T10:50:06.732Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
 ]
 
 [[package]]
@@ -3576,6 +3927,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.2.5"
 source = { registry = "https://pypi.org/simple" }
@@ -3591,6 +3956,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/bb/18dc3062d37db6c491392007dfd1a7f524bb95886eb956569ac38a23a784/PyPDF2-3.0.1.tar.gz", hash = "sha256:a74408f69ba6271f71b9352ef4ed03dc53a31aa404d29b5d31f53bfecfee1440", size = 227419, upload-time = "2022-12-31T10:36:13.13Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/5e/c86a5643653825d3c913719e788e41386bee415c2b87b4f955432f2de6b2/pypdf2-3.0.1-py3-none-any.whl", hash = "sha256:d16e4205cfee272fbdc0568b68d82be796540b1537508cef59388f839c191928", size = 232572, upload-time = "2022-12-31T10:36:10.327Z" },
+]
+
+[[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
 ]
 
 [[package]]
@@ -3679,6 +4053,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.24"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/45/e23b5dc14ddb9918ae4a625379506b17b6f8fc56ca1d82db62462f59aea6/python_multipart-0.0.24.tar.gz", hash = "sha256:9574c97e1c026e00bc30340ef7c7d76739512ab4dfd428fec8c330fa6a5cc3c8", size = 37695, upload-time = "2026-04-05T20:49:13.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/73/89930efabd4da63cea44a3f438aeb753d600123570e6d6264e763617a9ce/python_multipart-0.0.24-py3-none-any.whl", hash = "sha256:9b110a98db707df01a53c194f0af075e736a770dc5058089650d70b4a182f950", size = 24420, upload-time = "2026-04-05T20:49:12.555Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3701,6 +4084,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
     { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -3878,6 +4270,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+]
+
+[[package]]
+name = "rich-rst"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
 ]
 
 [[package]]
@@ -4121,6 +4526,19 @@ wheels = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
 name = "send2trash"
 version = "1.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4232,6 +4650,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/40/edede8dd6977b0d3da179a342c198ed100dd2aba4be081861ee5911e4da4/sqlparse-0.5.3.tar.gz", hash = "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272", size = 84999, upload-time = "2024-12-10T12:05:30.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/5c/bfd6bd0bf979426d405cc6e71eceb8701b148b16c21d2dc3c261efc61c7b/sqlparse-0.5.3-py3-none-any.whl", hash = "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca", size = 44415, upload-time = "2024-12-10T12:05:27.824Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
 ]
 
 [[package]]
@@ -4535,6 +4966,15 @@ wheels = [
 ]
 
 [[package]]
+name = "uncalled-for"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/68/35c1d87e608940badbcfeb630347aa0509897284684f61fab6423d02b253/uncalled_for-0.3.1.tar.gz", hash = "sha256:5e412ac6708f04b56bef5867b5dcf6690ebce4eb7316058d9c50787492bb4bca", size = 49693, upload-time = "2026-04-07T13:05:06.462Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/e1/7ec67882ad8fc9f86384bef6421fa252c9cbe5744f8df6ce77afc9eca1f5/uncalled_for-0.3.1-py3-none-any.whl", hash = "sha256:074cdc92da8356278f93d0ded6f2a66dd883dbecaf9bc89437646ee2289cc200", size = 11361, upload-time = "2026-04-07T13:05:05.341Z" },
+]
+
+[[package]]
 name = "uri-template"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4589,6 +5029,76 @@ wheels = [
 ]
 
 [[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
 name = "wcwidth"
 version = "0.2.14"
 source = { registry = "https://pypi.org/simple" }
@@ -4622,6 +5132,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- New `packages/odds-mcp/` workspace package with FastMCP server exposing 9 MCP tools as the canonical agent interface
- **Fixture/odds tools**: `get_upcoming_fixtures`, `get_current_odds`, `get_odds_history` — thin wrappers over `OddsReader`
- **Scraping**: `refresh_scrape` — triggers OddsPortal scrape on-demand via `ingest_league()`
- **ML tools**: `get_model_prediction` (queries Prediction table), `get_event_features` (runs TabularFeatureExtractor with configurable sharp/retail bookmakers)
- **Paper trading**: `paper_bet`, `get_portfolio`, `settle_bets` — wraps paper trading module from #270
- `.mcp.json` for Claude Code stdio transport discovery
- 18 unit tests covering serialization helpers and error paths

## Design decisions

- `get_odds_history` uses `extract_odds_from_snapshot()` for structured output instead of raw JSON blobs (context-window friendly)
- `get_event_features` accepts `sharp_bookmakers`/`retail_bookmakers` params, defaulting to hybrid sharp reference `[pinnacle, betfair_exchange]`
- `refresh_scrape` uses `LEAGUE_SPECS` from `fetch_oddsportal` to avoid duplicating league-to-sport mapping
- `paper_bet` validates event is SCHEDULED before placing
- All error returns include `error_type` for debuggability

## Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)