### PR TITLE
Add limit and since_hours params to get_predictions MCP tool

### DIFF
--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -25,7 +25,7 @@ from odds_lambda.paper_trading import (
     settle_trades,
 )
 from odds_lambda.storage.readers import OddsReader
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 logger = structlog.get_logger()
 
@@ -289,18 +289,24 @@ async def refresh_scrape(
 
 
 @mcp.tool()
-async def get_predictions(event_id: str) -> dict[str, Any]:
+async def get_predictions(
+    event_id: str,
+    limit: int = 5,
+    since_hours: float | None = None,
+) -> dict[str, Any]:
     """Get pre-scored CLV predictions for an event.
 
     Reads predictions stored by the scoring pipeline (not on-demand inference).
-    Returns all predictions (one per snapshot scored) for the given event,
-    ordered by creation time. If no predictions exist, returns an empty list.
+    Returns the most recent predictions for the given event. Use `limit` to
+    control how many are returned, or `since_hours` to filter by recency.
 
     Args:
         event_id: Event identifier.
+        limit: Maximum number of predictions to return (most recent first). Default 5.
+        since_hours: If set, only return predictions from the last N hours.
 
     Returns:
-        Dict with event info and list of prediction records.
+        Dict with event info, total prediction count, and the filtered list.
     """
     async with async_session_maker() as session:
         reader = OddsReader(session)
@@ -308,16 +314,26 @@ async def get_predictions(event_id: str) -> dict[str, Any]:
         if event is None:
             return {"error": f"Event '{event_id}' not found"}
 
-        pred_result = await session.execute(
-            select(Prediction)
-            .where(Prediction.event_id == event_id)
-            .order_by(Prediction.created_at)
+        query = select(Prediction).where(Prediction.event_id == event_id)
+
+        if since_hours is not None:
+            cutoff = datetime.now(UTC) - timedelta(hours=since_hours)
+            query = query.where(Prediction.created_at >= cutoff)
+
+        # Total count before limit (so caller knows if there are more)
+        count_result = await session.execute(
+            select(func.count(Prediction.id)).where(Prediction.event_id == event_id)
         )
+        total_count = count_result.scalar() or 0
+
+        query = query.order_by(Prediction.created_at.desc()).limit(max(1, limit))
+        pred_result = await session.execute(query)
         predictions = list(pred_result.scalars().all())
 
     return {
         "event": _event_to_dict(event),
-        "prediction_count": len(predictions),
+        "total_predictions": total_count,
+        "returned": len(predictions),
         "predictions": [
             {
                 "id": p.id,

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -294,19 +294,19 @@ async def get_predictions(
     limit: int = 5,
     since_hours: float | None = None,
 ) -> dict[str, Any]:
-    """Get pre-scored CLV predictions for an event.
+    """Get pre-scored CLV predictions for an event (most recent first).
 
     Reads predictions stored by the scoring pipeline (not on-demand inference).
-    Returns the most recent predictions for the given event. Use `limit` to
-    control how many are returned, or `since_hours` to filter by recency.
+    Returns up to `limit` predictions, newest first. Use `since_hours` to
+    restrict to recent predictions only.
 
     Args:
         event_id: Event identifier.
-        limit: Maximum number of predictions to return (most recent first). Default 5.
-        since_hours: If set, only return predictions from the last N hours.
+        limit: Max predictions to return, newest first. Clamped to 1 minimum. Default 5.
+        since_hours: If set, only return predictions created in the last N hours.
 
     Returns:
-        Dict with event info, total prediction count, and the filtered list.
+        Dict with event info, total matching count, and the limited list.
     """
     async with async_session_maker() as session:
         reader = OddsReader(session)
@@ -320,11 +320,10 @@ async def get_predictions(
             cutoff = datetime.now(UTC) - timedelta(hours=since_hours)
             query = query.where(Prediction.created_at >= cutoff)
 
-        # Total count before limit (so caller knows if there are more)
-        count_result = await session.execute(
-            select(func.count(Prediction.id)).where(Prediction.event_id == event_id)
-        )
-        total_count = count_result.scalar() or 0
+        # Count matching rows (respects since_hours filter)
+        count_query = query.with_only_columns(func.count(Prediction.id))
+        count_result = await session.execute(count_query)
+        total_matching = count_result.scalar() or 0
 
         query = query.order_by(Prediction.created_at.desc()).limit(max(1, limit))
         pred_result = await session.execute(query)
@@ -332,7 +331,7 @@ async def get_predictions(
 
     return {
         "event": _event_to_dict(event),
-        "total_predictions": total_count,
+        "total_matching": total_matching,
         "returned": len(predictions),
         "predictions": [
             {
@@ -578,3 +577,7 @@ async def settle_bets() -> dict[str, Any]:
         "total_pnl": total_pnl,
         "settled_trades": serialized,
     }
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/packages/odds-mcp/tests/test_server.py
+++ b/packages/odds-mcp/tests/test_server.py
@@ -256,7 +256,33 @@ class TestGetCurrentOddsMissingEvent:
             assert "nonexistent" in result["error"]
 
 
-class TestGetPredictionsMissingEvent:
+class TestGetPredictions:
+    def _make_event(self) -> MagicMock:
+        event = MagicMock(spec=Event)
+        event.id = "evt-1"
+        event.sport_key = "soccer_epl"
+        event.sport_title = "EPL"
+        event.home_team = "Arsenal"
+        event.away_team = "Chelsea"
+        event.commence_time = datetime(2026, 4, 12, 15, 0, tzinfo=UTC)
+        event.status = EventStatus.SCHEDULED
+        event.home_score = None
+        event.away_score = None
+        event.completed_at = None
+        return event
+
+    def _make_prediction(self, id: int, hours_ago: float, clv: float) -> MagicMock:
+        from odds_core.prediction_models import Prediction
+
+        pred = MagicMock(spec=Prediction)
+        pred.id = id
+        pred.snapshot_id = id * 100
+        pred.model_name = "epl-clv-home"
+        pred.model_version = "v1"
+        pred.predicted_clv = clv
+        pred.created_at = datetime(2026, 4, 12, 15, 0, tzinfo=UTC)
+        return pred
+
     @pytest.mark.asyncio
     async def test_missing_event(self) -> None:
         from odds_mcp.server import get_predictions
@@ -273,6 +299,93 @@ class TestGetPredictionsMissingEvent:
 
             result = await get_predictions("nonexistent")
             assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_default_limit(self) -> None:
+        from odds_mcp.server import get_predictions
+
+        preds = [self._make_prediction(i, i, 0.01 * i) for i in range(1, 11)]
+
+        mock_reader = AsyncMock()
+        mock_reader.get_event_by_id = AsyncMock(return_value=self._make_event())
+
+        # Mock session.execute to return count then predictions
+        mock_count_result = MagicMock()
+        mock_count_result.scalar.return_value = 10
+
+        mock_pred_result = MagicMock()
+        mock_pred_result.scalars.return_value.all.return_value = preds[:5]
+
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(side_effect=[mock_count_result, mock_pred_result])
+
+        with (
+            patch("odds_mcp.server.async_session_maker") as mock_session_maker,
+            patch("odds_mcp.server.OddsReader", return_value=mock_reader),
+        ):
+            mock_session_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_maker.return_value.__aexit__ = AsyncMock()
+
+            result = await get_predictions("evt-1")
+            assert result["total_matching"] == 10
+            assert result["returned"] == 5
+            assert len(result["predictions"]) == 5
+
+    @pytest.mark.asyncio
+    async def test_custom_limit(self) -> None:
+        from odds_mcp.server import get_predictions
+
+        preds = [self._make_prediction(i, i, 0.01 * i) for i in range(1, 4)]
+
+        mock_reader = AsyncMock()
+        mock_reader.get_event_by_id = AsyncMock(return_value=self._make_event())
+
+        mock_count_result = MagicMock()
+        mock_count_result.scalar.return_value = 10
+
+        mock_pred_result = MagicMock()
+        mock_pred_result.scalars.return_value.all.return_value = preds
+
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(side_effect=[mock_count_result, mock_pred_result])
+
+        with (
+            patch("odds_mcp.server.async_session_maker") as mock_session_maker,
+            patch("odds_mcp.server.OddsReader", return_value=mock_reader),
+        ):
+            mock_session_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_maker.return_value.__aexit__ = AsyncMock()
+
+            result = await get_predictions("evt-1", limit=3)
+            assert result["returned"] == 3
+
+    @pytest.mark.asyncio
+    async def test_no_predictions(self) -> None:
+        from odds_mcp.server import get_predictions
+
+        mock_reader = AsyncMock()
+        mock_reader.get_event_by_id = AsyncMock(return_value=self._make_event())
+
+        mock_count_result = MagicMock()
+        mock_count_result.scalar.return_value = 0
+
+        mock_pred_result = MagicMock()
+        mock_pred_result.scalars.return_value.all.return_value = []
+
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(side_effect=[mock_count_result, mock_pred_result])
+
+        with (
+            patch("odds_mcp.server.async_session_maker") as mock_session_maker,
+            patch("odds_mcp.server.OddsReader", return_value=mock_reader),
+        ):
+            mock_session_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_maker.return_value.__aexit__ = AsyncMock()
+
+            result = await get_predictions("evt-1")
+            assert result["total_matching"] == 0
+            assert result["returned"] == 0
+            assert result["predictions"] == []
 
 
 class TestPaperBetValidation:


### PR DESCRIPTION
## Summary
- `get_predictions` previously returned all predictions for an event (196 for a single EPL match over 4 weeks), wasting agent context
- Now defaults to returning the 5 most recent predictions, with `limit` and `since_hours` params for control
- Reports `total_predictions` count so callers know if more exist

## Test plan
- [x] Existing odds-mcp tests pass (18/18)
- [x] Smoke tested against local DB: 196 total → 3 returned with `limit=3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)