### PR TITLE
Defensive self-scheduling to survive DB/Lambda failures

### DIFF
--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
@@ -2,14 +2,20 @@
 
 Scrapes pre-match odds for configured leagues, converts to pipeline format,
 and stores via OddsWriter. Self-schedules next execution based on scrape
-outcome and game proximity.
+outcome.
+
+Self-scheduling strategy: defensively schedule at retry cadence before any
+work (no DB needed), then reschedule at normal cadence on success. If
+anything fails — DB, browser, Lambda timeout — the retry schedule is already
+set and the chain survives.
 
 This job:
-1. Scrapes upcoming matches from OddsPortal (via OddsHarvester)
-2. Converts fractional odds to pipeline raw_data format
-3. Matches or creates Event records
-4. Stores snapshots via OddsWriter.store_odds_snapshot()
-5. Self-schedules next execution via scheduler backend
+1. Pre-schedules next run at retry cadence (no DB, survives any failure)
+2. Scrapes upcoming matches from OddsPortal (via OddsHarvester)
+3. Converts fractional odds to pipeline raw_data format
+4. Matches or creates Event records
+5. Stores snapshots via OddsWriter.store_odds_snapshot()
+6. On success, reschedules at normal cadence (1h) with overnight skip
 """
 
 from __future__ import annotations
@@ -44,7 +50,6 @@ RETRY_DELAY_MINUTES_MAX = 15
 MAX_FAST_RETRIES = 2
 OVERNIGHT_RESUME_HOUR_UTC = 6
 OVERNIGHT_START_HOUR_UTC = 22
-GAME_LOOKAHEAD_HOURS = 8
 
 
 @dataclass
@@ -259,25 +264,6 @@ async def ingest_league(
     return stats
 
 
-async def _get_next_game_time(sport_key: str = LEAGUE_SPECS[0].sport_key) -> datetime | None:
-    """Find the commence_time of the nearest upcoming scheduled game."""
-    from odds_lambda.storage.readers import OddsReader
-
-    async with async_session_maker() as session:
-        reader = OddsReader(session)
-        now = datetime.now(UTC)
-        events = await reader.get_events_by_date_range(
-            start_date=now,
-            end_date=now + timedelta(days=14),
-            sport_key=sport_key,
-            status=EventStatus.SCHEDULED,
-        )
-
-    if not events:
-        return None
-    return min(e.commence_time for e in events)
-
-
 def _calculate_next_execution(
     *,
     success: bool,
@@ -304,19 +290,17 @@ def _calculate_next_execution(
     return now + timedelta(hours=NORMAL_INTERVAL_HOURS), 0
 
 
-def _apply_overnight_skip(next_time: datetime, next_game_time: datetime | None) -> datetime:
-    """Push next_time to morning if overnight and no imminent games."""
-    hours_to_game = float("inf")
-    if next_game_time is not None:
-        hours_to_game = (next_game_time - next_time).total_seconds() / 3600
+def _apply_overnight_skip(next_time: datetime) -> datetime:
+    """Push next_time to morning if overnight.
 
+    EPL games never kick off during the overnight window (22:00-06:00 UTC),
+    so no game-proximity check is needed.
+    """
     is_overnight = (
         next_time.hour >= OVERNIGHT_START_HOUR_UTC or next_time.hour < OVERNIGHT_RESUME_HOUR_UTC
     )
-    no_imminent_games = hours_to_game > GAME_LOOKAHEAD_HOURS
 
-    if is_overnight and no_imminent_games:
-        # Skip to 06:00 UTC the next morning (or same morning if before 06:00)
+    if is_overnight:
         resume = next_time.replace(
             hour=OVERNIGHT_RESUME_HOUR_UTC, minute=0, second=0, microsecond=0
         )
@@ -366,6 +350,10 @@ async def main(
 ) -> None:
     """Main job execution — scrapes configured league(s), then self-schedules.
 
+    Scheduling strategy: defensively pre-schedule at retry cadence (no DB
+    needed) so the chain survives any failure including Lambda timeouts. On
+    success, reschedule at normal cadence with overnight skip.
+
     Args:
         sport: Sport key (e.g. "soccer_epl"). When provided, only the matching
             LeagueSpec is scraped. Falls back to all LEAGUE_SPECS.
@@ -387,20 +375,21 @@ async def main(
         specs = LEAGUE_SPECS
 
     compound_job_name = make_compound_job_name("fetch-oddsportal", sport)
-    sport_key_for_lookup = sport or LEAGUE_SPECS[0].sport_key
 
-    # Pre-schedule at normal cadence BEFORE scraping so the chain survives
-    # Lambda timeouts. Updated to retry interval after scrape if needed.
-    now = datetime.now(UTC)
-    default_next_time = _apply_overnight_skip(
-        now + timedelta(hours=NORMAL_INTERVAL_HOURS),
-        await _get_next_game_time(sport_key=sport_key_for_lookup),
+    # Defensive pre-schedule at retry cadence BEFORE any DB or browser work.
+    # No DB query needed — just now + retry delay. If anything fails (DB down,
+    # browser crash, Lambda timeout), this schedule is already set.
+    defensive_next_time, defensive_retry_count = _calculate_next_execution(
+        success=False,
+        retry_count=retry_count,
+        now=datetime.now(UTC),
     )
+    defensive_next_time = _apply_overnight_skip(defensive_next_time)
     try:
         await _self_schedule(
             job_name=compound_job_name,
-            next_time=default_next_time,
-            next_retry_count=0,
+            next_time=defensive_next_time,
+            next_retry_count=defensive_retry_count,
             dry_run=settings.scheduler.dry_run,
             sport=sport,
         )
@@ -456,28 +445,21 @@ async def main(
                 message=f"⚠️ OddsPortal scrape empty ({detail}), retry #{retry_count}",
             )
 
-    # If scrape failed, update schedule to retry sooner
-    scrape_success = total_scraped > 0
-    if not scrape_success:
-        retry_next_time, next_retry_count = _calculate_next_execution(
-            success=False,
-            retry_count=retry_count,
-            now=datetime.now(UTC),
-        )
-        retry_next_time = _apply_overnight_skip(
-            retry_next_time,
-            await _get_next_game_time(sport_key=sport_key_for_lookup),
+    # On success, push schedule out to normal cadence
+    if total_scraped > 0:
+        success_next_time = _apply_overnight_skip(
+            datetime.now(UTC) + timedelta(hours=NORMAL_INTERVAL_HOURS),
         )
         try:
             await _self_schedule(
                 job_name=compound_job_name,
-                next_time=retry_next_time,
-                next_retry_count=next_retry_count,
+                next_time=success_next_time,
+                next_retry_count=0,
                 dry_run=settings.scheduler.dry_run,
                 sport=sport,
             )
         except Exception as e:
-            logger.error("fetch_oddsportal_retry_scheduling_failed", error=str(e), exc_info=True)
+            logger.error("fetch_oddsportal_success_scheduling_failed", error=str(e), exc_info=True)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_fetch_oddsportal_scheduling.py
+++ b/tests/unit/test_fetch_oddsportal_scheduling.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from odds_lambda.jobs.fetch_oddsportal import (
-    GAME_LOOKAHEAD_HOURS,
     MAX_FAST_RETRIES,
     NORMAL_INTERVAL_HOURS,
     OVERNIGHT_RESUME_HOUR_UTC,
@@ -69,44 +68,41 @@ class TestCalculateNextExecution:
 class TestApplyOvernightSkip:
     """Tests for _apply_overnight_skip logic."""
 
-    def test_overnight_no_games_skips_to_morning(self) -> None:
+    def test_overnight_skips_to_morning(self) -> None:
         next_time = datetime(2026, 4, 7, 23, 0, tzinfo=UTC)
-        result = _apply_overnight_skip(next_time, next_game_time=None)
+        result = _apply_overnight_skip(next_time)
         assert result.hour == OVERNIGHT_RESUME_HOUR_UTC
         assert result.minute == 0
         assert result > next_time
 
-    def test_overnight_with_imminent_game_no_skip(self) -> None:
-        next_time = datetime(2026, 4, 7, 23, 0, tzinfo=UTC)
-        game_time = next_time + timedelta(hours=2)
-        result = _apply_overnight_skip(next_time, next_game_time=game_time)
-        assert result == next_time
-
     def test_afternoon_no_skip(self) -> None:
         next_time = datetime(2026, 4, 7, 14, 0, tzinfo=UTC)
-        result = _apply_overnight_skip(next_time, next_game_time=None)
+        result = _apply_overnight_skip(next_time)
         assert result == next_time
 
-    def test_early_morning_no_games_skips_to_morning(self) -> None:
+    def test_early_morning_skips_to_morning(self) -> None:
         next_time = datetime(2026, 4, 7, 3, 0, tzinfo=UTC)
-        result = _apply_overnight_skip(next_time, next_game_time=None)
+        result = _apply_overnight_skip(next_time)
         assert result.hour == OVERNIGHT_RESUME_HOUR_UTC
         assert result.day == next_time.day
 
-    def test_overnight_distant_game_skips(self) -> None:
-        next_time = datetime(2026, 4, 7, 23, 0, tzinfo=UTC)
-        game_time = next_time + timedelta(hours=GAME_LOOKAHEAD_HOURS + 1)
-        result = _apply_overnight_skip(next_time, next_game_time=game_time)
-        assert result.hour == OVERNIGHT_RESUME_HOUR_UTC
-        assert result > next_time
+    def test_exactly_at_resume_hour_no_skip(self) -> None:
+        next_time = datetime(2026, 4, 7, OVERNIGHT_RESUME_HOUR_UTC, 0, tzinfo=UTC)
+        result = _apply_overnight_skip(next_time)
+        assert result == next_time
 
 
-class TestPreScheduling:
-    """Verify scheduling happens before scraping to survive Lambda timeouts."""
+class TestDefensivePreScheduling:
+    """Verify defensive scheduling: pre-schedule at retry cadence, reschedule on success."""
+
+    @staticmethod
+    @asynccontextmanager
+    async def _noop_alert_context(name: str) -> AsyncIterator[None]:
+        yield
 
     @pytest.mark.asyncio
-    async def test_schedule_fires_before_ingest(self) -> None:
-        """Pre-schedule must happen before ingest_league so a timeout can't break the chain."""
+    async def test_preschedule_at_retry_cadence_before_scrape(self) -> None:
+        """Pre-schedule must use retry cadence and fire before ingest_league."""
         call_order: list[str] = []
 
         async def fake_ingest(spec):
@@ -118,10 +114,6 @@ class TestPreScheduling:
         async def fake_schedule(**kwargs):
             call_order.append("schedule")
 
-        @asynccontextmanager
-        async def noop_alert_context(name: str) -> AsyncIterator[None]:
-            yield
-
         mock_backend = AsyncMock()
         mock_backend.get_backend_name.return_value = "test"
         mock_backend.schedule_next_execution = AsyncMock(side_effect=fake_schedule)
@@ -129,16 +121,11 @@ class TestPreScheduling:
         with (
             patch("odds_lambda.jobs.fetch_oddsportal.ingest_league", side_effect=fake_ingest),
             patch(
-                "odds_lambda.jobs.fetch_oddsportal._get_next_game_time",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
-            patch(
                 "odds_lambda.jobs.fetch_oddsportal.get_scheduler_backend",
                 return_value=mock_backend,
             ),
             patch("odds_core.config.get_settings") as mock_settings,
-            patch("odds_core.alerts.job_alert_context", side_effect=noop_alert_context),
+            patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
         ):
             mock_settings.return_value.scheduler.dry_run = False
             await main(retry_count=0)
@@ -149,13 +136,68 @@ class TestPreScheduling:
         assert "ingest" in call_order
 
     @pytest.mark.asyncio
+    async def test_success_reschedules_at_normal_cadence(self) -> None:
+        """On success, a second schedule call pushes to normal cadence."""
+        mock_backend = AsyncMock()
+        mock_backend.get_backend_name.return_value = "test"
+
+        with (
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal.ingest_league", new_callable=AsyncMock
+            ) as mock_ingest,
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal.get_scheduler_backend",
+                return_value=mock_backend,
+            ),
+            patch("odds_core.config.get_settings") as mock_settings,
+            patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
+        ):
+            from odds_lambda.jobs.fetch_oddsportal import IngestionStats
+
+            mock_settings.return_value.scheduler.dry_run = False
+            mock_ingest.return_value = IngestionStats(
+                league="test", matches_scraped=5, snapshots_stored=3
+            )
+
+            await main(retry_count=0)
+
+        # Pre-schedule (retry cadence) + success reschedule (normal cadence)
+        assert mock_backend.schedule_next_execution.call_count == 2
+        # Last call should have no retry payload (success resets)
+        last_call = mock_backend.schedule_next_execution.call_args
+        assert last_call.kwargs.get("payload") is None
+
+    @pytest.mark.asyncio
+    async def test_failure_keeps_defensive_schedule(self) -> None:
+        """On failure, no second schedule call — the defensive one stands."""
+        mock_backend = AsyncMock()
+        mock_backend.get_backend_name.return_value = "test"
+
+        with (
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal.ingest_league", new_callable=AsyncMock
+            ) as mock_ingest,
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal.get_scheduler_backend",
+                return_value=mock_backend,
+            ),
+            patch("odds_core.config.get_settings") as mock_settings,
+            patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
+            patch("odds_core.alerts.send_job_warning", new_callable=AsyncMock),
+        ):
+            from odds_lambda.jobs.fetch_oddsportal import IngestionStats
+
+            mock_settings.return_value.scheduler.dry_run = False
+            mock_ingest.return_value = IngestionStats(league="test", matches_scraped=0)
+
+            await main(retry_count=0)
+
+        # Only the defensive pre-schedule fires
+        assert mock_backend.schedule_next_execution.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_chain_survives_ingest_exception(self) -> None:
-        """If ingest_league raises, the pre-scheduled rule is still the last schedule call."""
-
-        @asynccontextmanager
-        async def noop_alert_context(name: str) -> AsyncIterator[None]:
-            yield
-
+        """If ingest_league raises, the defensive schedule is already set."""
         mock_backend = AsyncMock()
         mock_backend.get_backend_name.return_value = "test"
 
@@ -166,23 +208,18 @@ class TestPreScheduling:
                 side_effect=Exception("simulated timeout"),
             ),
             patch(
-                "odds_lambda.jobs.fetch_oddsportal._get_next_game_time",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
-            patch(
                 "odds_lambda.jobs.fetch_oddsportal.get_scheduler_backend",
                 return_value=mock_backend,
             ),
             patch("odds_core.config.get_settings") as mock_settings,
-            patch("odds_core.alerts.job_alert_context", side_effect=noop_alert_context),
+            patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
             patch("odds_core.alerts.send_job_warning", new_callable=AsyncMock),
         ):
             mock_settings.return_value.scheduler.dry_run = False
             await main(retry_count=0)
 
-        # Pre-schedule fired, then retry re-schedule fired (scrape failed)
-        assert mock_backend.schedule_next_execution.call_count == 2
+        # Only the defensive pre-schedule fires (no success reschedule)
+        assert mock_backend.schedule_next_execution.call_count == 1
 
 
 class TestRetryCountIntegration:
@@ -204,11 +241,6 @@ class TestRetryCountIntegration:
                 new_callable=AsyncMock,
             ) as mock_ingest,
             patch(
-                "odds_lambda.jobs.fetch_oddsportal._get_next_game_time",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
-            patch(
                 "odds_lambda.jobs.fetch_oddsportal.get_scheduler_backend",
                 return_value=mock_backend,
             ),
@@ -223,7 +255,7 @@ class TestRetryCountIntegration:
 
             await main(retry_count=0)
 
-            # Last call is the retry re-schedule (overwrites pre-schedule)
+            # Defensive pre-schedule has retry_count=1
             call_kwargs = mock_backend.schedule_next_execution.call_args
             assert call_kwargs.kwargs["payload"] == {"retry_count": 1}
 
@@ -237,11 +269,6 @@ class TestRetryCountIntegration:
                 "odds_lambda.jobs.fetch_oddsportal.ingest_league",
                 new_callable=AsyncMock,
             ) as mock_ingest,
-            patch(
-                "odds_lambda.jobs.fetch_oddsportal._get_next_game_time",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
             patch(
                 "odds_lambda.jobs.fetch_oddsportal.get_scheduler_backend",
                 return_value=mock_backend,
@@ -258,8 +285,7 @@ class TestRetryCountIntegration:
 
             await main(retry_count=2)
 
-            # Only the pre-schedule fires on success (no retry re-schedule)
-            assert mock_backend.schedule_next_execution.call_count == 1
-            call_kwargs = mock_backend.schedule_next_execution.call_args
-            # retry_count=0 means no payload (None)
-            assert call_kwargs.kwargs.get("payload") is None
+            # Last call is the success reschedule with no retry payload
+            assert mock_backend.schedule_next_execution.call_count == 2
+            last_call = mock_backend.schedule_next_execution.call_args
+            assert last_call.kwargs.get("payload") is None


### PR DESCRIPTION
## Summary
- Pre-schedule at **retry cadence** (10-15 min) before any DB or browser work, no DB query needed
- On success, reschedule at **normal cadence** (1h) with overnight skip
- On any failure (DB timeout, browser crash, Lambda timeout), the retry schedule is already set — chain never breaks
- Remove `_get_next_game_time` DB query from the scheduling path — EPL has no games during overnight window (22:00-06:00 UTC), so the game-proximity check was unnecessary

## Context
The scraper chain broke when Neon DB was unreachable at 06:00 UTC. asyncpg's default 60s connection timeout killed the Lambda before `_self_schedule` could fire, because the pre-schedule path called `_get_next_game_time()` (a DB query) first. No next run was scheduled, breaking the chain for 14+ hours until manual restart.

## Test plan
- [x] 16 scheduling tests pass (rewritten to match new strategy)
- [x] Full test suite passes (288 passed, 1 pre-existing failure)
- [x] Verified no remaining references to removed `_get_next_game_time` or `GAME_LOOKAHEAD_HOURS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)