### PR TITLE
Fix local scheduler to resolve compound job names

### DIFF
--- a/packages/odds-lambda/odds_lambda/scheduling/backends/local.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/backends/local.py
@@ -219,10 +219,17 @@ class LocalSchedulerBackend(SchedulerBackend):
         self._ensure_started()
 
         try:
-            # Get job function from centralized registry
-            from odds_lambda.scheduling.jobs import get_job_function
+            # Resolve compound job names (e.g. "fetch-oddsportal-epl" -> "fetch-oddsportal")
+            # mirroring how the Lambda handler resolves them at invocation time.
+            from odds_lambda.scheduling.jobs import get_job_function, resolve_job_name
 
-            job_func = get_job_function(job_name)
+            base_name, resolved_sport = resolve_job_name(job_name)
+            job_func = get_job_function(base_name)
+
+            # Merge resolved sport into payload so the job receives it as a kwarg
+            job_kwargs: dict[str, object] = dict(payload) if payload else {}
+            if resolved_sport and "sport" not in job_kwargs:
+                job_kwargs["sport"] = resolved_sport
 
             # Remove existing job if present (replace with new schedule)
             if self.scheduler.get_job(job_name):
@@ -237,6 +244,7 @@ class LocalSchedulerBackend(SchedulerBackend):
                 id=job_name,
                 name=f"Odds {job_name}",
                 replace_existing=True,
+                kwargs=job_kwargs if job_kwargs else None,
             )
 
             logger.info(

--- a/packages/odds-lambda/odds_lambda/scheduling/backends/local.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/backends/local.py
@@ -219,6 +219,8 @@ class LocalSchedulerBackend(SchedulerBackend):
         self._ensure_started()
 
         try:
+            import inspect
+
             # Resolve compound job names (e.g. "fetch-oddsportal-epl" -> "fetch-oddsportal")
             # mirroring how the Lambda handler resolves them at invocation time.
             from odds_lambda.scheduling.jobs import get_job_function, resolve_job_name
@@ -230,6 +232,16 @@ class LocalSchedulerBackend(SchedulerBackend):
             job_kwargs: dict[str, object] = dict(payload) if payload else {}
             if resolved_sport and "sport" not in job_kwargs:
                 job_kwargs["sport"] = resolved_sport
+
+            # Filter kwargs to only those the job function accepts,
+            # mirroring the Lambda handler's inspect.signature filtering.
+            sig = inspect.signature(job_func)
+            accepted = set(sig.parameters.keys())
+            has_var_keyword = any(
+                p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+            )
+            if job_kwargs and not has_var_keyword:
+                job_kwargs = {k: v for k, v in job_kwargs.items() if k in accepted}
 
             # Remove existing job if present (replace with new schedule)
             if self.scheduler.get_job(job_name):


### PR DESCRIPTION
## Summary
- Resolve compound job names (e.g. `fetch-oddsportal-epl`) via `resolve_job_name` before looking up the job function, mirroring the Lambda handler's resolution logic
- Pass resolved sport as a kwarg so jobs receive the same parameters as in production

## Context
Running the scraper job locally with `SCHEDULER_BACKEND=local` crashed because `get_job_function("fetch-oddsportal-epl")` failed — only base names like `fetch-oddsportal` are in the registry. The AWS backend doesn't hit this because EventBridge stores the name as a string and resolution happens at Lambda invocation time.

Needed now because OddsPortal is blocking the AWS Lambda IP, so local execution may be required as a fallback.

## Test plan
- [x] 19 local scheduler tests pass
- [x] Full test suite passes (288 passed, 1 pre-existing failure)
- [x] Manually verified: compound name resolves correctly, job gets `sport` kwarg

🤖 Generated with [Claude Code](https://claude.com/claude-code)