### PR TITLE
Standardise job signatures with typed JobContext

### DIFF
--- a/packages/odds-cli/odds_cli/commands/polymarket.py
+++ b/packages/odds-cli/odds_cli/commands/polymarket.py
@@ -86,6 +86,7 @@ async def _backfill_async(
 
     # Import job module
     from odds_lambda.jobs import backfill_polymarket
+    from odds_lambda.scheduling.jobs import JobContext
 
     # Execute with progress indicator
     with Progress(
@@ -97,9 +98,11 @@ async def _backfill_async(
 
         try:
             await backfill_polymarket.main(
-                include_spreads=include_spreads,
-                include_totals=include_totals,
-                dry_run=dry_run,
+                JobContext(
+                    include_spreads=include_spreads,
+                    include_totals=include_totals,
+                    dry_run=dry_run,
+                )
             )
             progress.update(task, completed=True)
 

--- a/packages/odds-cli/odds_cli/commands/scheduler.py
+++ b/packages/odds-cli/odds_cli/commands/scheduler.py
@@ -119,12 +119,19 @@ def run_once(
 
     try:
         # Use centralized job registry
-        from odds_lambda.scheduling.jobs import JobContext, get_job_function, list_available_jobs
+        from odds_lambda.scheduling.jobs import (
+            JobContext,
+            get_job_function,
+            list_available_jobs,
+            resolve_job_name,
+        )
 
-        job_func = get_job_function(job)
+        base_name, sport = resolve_job_name(job)
+        job_func = get_job_function(base_name)
+        ctx = JobContext(sport=sport) if sport else JobContext()
 
         # Run job
-        asyncio.run(job_func(JobContext()))
+        asyncio.run(job_func(ctx))
 
         console.print(f"\n[bold green]✓ {job} completed[/bold green]")
 

--- a/packages/odds-cli/odds_cli/commands/scheduler.py
+++ b/packages/odds-cli/odds_cli/commands/scheduler.py
@@ -60,8 +60,9 @@ def start_local():
 
         try:
             from odds_lambda.jobs import fetch_odds
+            from odds_lambda.scheduling.jobs import JobContext
 
-            await fetch_odds.main()
+            await fetch_odds.main(JobContext())
             console.print("[green]✓ Bootstrap complete[/green]\n")
         except Exception as e:
             console.print(f"[bold red]✗ Bootstrap failed:[/bold red] {e}\n")
@@ -118,12 +119,12 @@ def run_once(
 
     try:
         # Use centralized job registry
-        from odds_lambda.scheduling.jobs import get_job_function, list_available_jobs
+        from odds_lambda.scheduling.jobs import JobContext, get_job_function, list_available_jobs
 
         job_func = get_job_function(job)
 
         # Run job
-        asyncio.run(job_func())
+        asyncio.run(job_func(JobContext()))
 
         console.print(f"\n[bold green]✓ {job} completed[/bold green]")
 

--- a/packages/odds-lambda/odds_lambda/jobs/backfill_polymarket.py
+++ b/packages/odds-lambda/odds_lambda/jobs/backfill_polymarket.py
@@ -30,6 +30,7 @@ from odds_core.polymarket_models import (
 )
 
 from odds_lambda.polymarket_fetcher import PolymarketClient
+from odds_lambda.scheduling.jobs import JobContext
 from odds_lambda.storage.polymarket_reader import PolymarketReader
 from odds_lambda.storage.polymarket_writer import PolymarketWriter
 
@@ -39,18 +40,8 @@ logger = structlog.get_logger()
 CLOB_DELAY_MS = 100
 
 
-async def main(
-    include_spreads: bool = False,
-    include_totals: bool = False,
-    dry_run: bool = False,
-):
-    """
-    Main backfill execution flow.
-
-    Args:
-        include_spreads: Whether to backfill spread market histories
-        include_totals: Whether to backfill total market histories
-        dry_run: Simulate execution without storing data
+async def main(ctx: JobContext) -> None:
+    """Main backfill execution flow.
 
     Flow:
         1. Fetch all closed NBA events from Gamma API (with pagination)
@@ -59,6 +50,10 @@ async def main(
         4. Bulk store in database
         5. Log results
     """
+    include_spreads = ctx.include_spreads
+    include_totals = ctx.include_totals
+    dry_run = ctx.dry_run
+
     app_settings = get_settings()
 
     if not app_settings.polymarket.enabled:
@@ -350,4 +345,4 @@ async def _backfill_market_history(
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    asyncio.run(main(JobContext()))

--- a/packages/odds-lambda/odds_lambda/jobs/check_health.py
+++ b/packages/odds-lambda/odds_lambda/jobs/check_health.py
@@ -14,13 +14,13 @@ from odds_core.config import get_settings
 
 from odds_lambda.health_monitor import check_system_health
 from odds_lambda.scheduling.backends import get_scheduler_backend
+from odds_lambda.scheduling.jobs import JobContext
 
 logger = structlog.get_logger()
 
 
-async def main():
-    """
-    Main job execution flow.
+async def main(ctx: JobContext) -> None:
+    """Main job execution flow.
 
     Flow:
     1. Run health checks
@@ -81,4 +81,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    asyncio.run(main(JobContext()))

--- a/packages/odds-lambda/odds_lambda/jobs/daily_digest.py
+++ b/packages/odds-lambda/odds_lambda/jobs/daily_digest.py
@@ -335,24 +335,16 @@ async def send_digest(
     return stats
 
 
-async def main(
-    sport: str | None = None,
-    lookback_hours: float = 24,
-    lookahead_hours: float = 48,
-    **_kwargs: object,
-) -> None:
-    """Main job entry point.
-
-    Args:
-        sport: Sport key (e.g. "soccer_epl"). Defaults to DEFAULT_SPORT_KEY.
-        lookback_hours: How far back to look for completed events.
-        lookahead_hours: How far ahead to look for upcoming events.
-    """
+async def main(ctx: JobContext) -> None:
+    """Main job entry point."""
     from odds_core.alerts import job_alert_context
 
     from odds_lambda.scheduling.jobs import make_compound_job_name
 
+    sport = ctx.sport
     sport_key = sport or DEFAULT_SPORT_KEY
+    lookback_hours = ctx.lookback_hours
+    lookahead_hours = ctx.lookahead_hours
 
     async with job_alert_context(make_compound_job_name("daily-digest", sport)):
         logger.info(
@@ -371,4 +363,6 @@ async def main(
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    from odds_lambda.scheduling.jobs import JobContext
+
+    asyncio.run(main(JobContext()))

--- a/packages/odds-lambda/odds_lambda/jobs/daily_digest.py
+++ b/packages/odds-lambda/odds_lambda/jobs/daily_digest.py
@@ -19,6 +19,8 @@ from odds_core.prediction_models import Prediction
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from odds_lambda.scheduling.jobs import JobContext
+
 logger = structlog.get_logger()
 
 DEFAULT_SPORT_KEY = "soccer_epl"
@@ -363,6 +365,4 @@ async def main(ctx: JobContext) -> None:
 
 
 if __name__ == "__main__":
-    from odds_lambda.scheduling.jobs import JobContext
-
     asyncio.run(main(JobContext()))

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_odds.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_odds.py
@@ -18,7 +18,7 @@ from odds_lambda.event_sync import EventSyncService
 from odds_lambda.ingestion import OddsIngestionService
 from odds_lambda.scheduling.backends import get_scheduler_backend
 from odds_lambda.scheduling.intelligence import SchedulingIntelligence
-from odds_lambda.scheduling.jobs import make_compound_job_name
+from odds_lambda.scheduling.jobs import JobContext, make_compound_job_name
 
 logger = structlog.get_logger()
 
@@ -33,13 +33,8 @@ def build_event_sync_service(client: TheOddsAPIClient) -> EventSyncService:
     return EventSyncService(client=client)
 
 
-async def main(sport: str | None = None, **_kwargs: object) -> None:
-    """
-    Main job execution flow.
-
-    Args:
-        sport: Sport key to fetch (e.g. "soccer_epl"). Falls back to
-            ``data_collection.sports`` config when not provided.
+async def main(ctx: JobContext) -> None:
+    """Main job execution flow.
 
     Flow:
     1. Sync upcoming events from free /events endpoint (discovery)
@@ -49,6 +44,7 @@ async def main(sport: str | None = None, **_kwargs: object) -> None:
     5. Schedule next run via backend
     """
     app_settings = get_settings()
+    sport = ctx.sport
     sports = [sport] if sport else app_settings.data_collection.sports
 
     logger.info(
@@ -218,4 +214,4 @@ async def main(sport: str | None = None, **_kwargs: object) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    asyncio.run(main(JobContext()))

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
@@ -343,7 +343,7 @@ async def _self_schedule(
 
 
 async def main(ctx: JobContext) -> None:
-    """Main job execution -- scrapes configured league(s), then self-schedules.
+    """Main job execution — scrapes configured league(s), then self-schedules.
 
     Scheduling strategy: defensively pre-schedule at retry cadence (no DB
     needed) so the chain survives any failure including Lambda timeouts. On

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
@@ -38,7 +38,7 @@ from odds_lambda.oddsportal_adapter import (
 )
 from odds_lambda.oddsportal_common import hours_to_tier, run_scraper_with_retry, team_abbrev
 from odds_lambda.scheduling.backends import get_scheduler_backend
-from odds_lambda.scheduling.jobs import make_compound_job_name
+from odds_lambda.scheduling.jobs import JobContext, make_compound_job_name
 from odds_lambda.storage.writers import OddsWriter
 
 logger = structlog.get_logger()
@@ -342,27 +342,19 @@ async def _self_schedule(
     )
 
 
-async def main(
-    *,
-    sport: str | None = None,
-    retry_count: int = 0,
-    **_kwargs: object,
-) -> None:
-    """Main job execution — scrapes configured league(s), then self-schedules.
+async def main(ctx: JobContext) -> None:
+    """Main job execution -- scrapes configured league(s), then self-schedules.
 
     Scheduling strategy: defensively pre-schedule at retry cadence (no DB
     needed) so the chain survives any failure including Lambda timeouts. On
     success, reschedule at normal cadence with overnight skip.
-
-    Args:
-        sport: Sport key (e.g. "soccer_epl"). When provided, only the matching
-            LeagueSpec is scraped. Falls back to all LEAGUE_SPECS.
-        retry_count: Current retry attempt (passed via self-scheduling payload).
     """
     from odds_core.alerts import job_alert_context, send_job_warning
     from odds_core.config import get_settings
 
     settings = get_settings()
+    sport = ctx.sport
+    retry_count = ctx.retry_count
 
     # Resolve which leagues to scrape
     if sport:
@@ -463,4 +455,4 @@ async def main(
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    asyncio.run(main(JobContext()))

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py
@@ -234,7 +234,7 @@ async def process_results(
 
 
 async def main(ctx: JobContext) -> None:
-    """Main job entry point -- runs results collection, then self-schedules for tomorrow."""
+    """Main job entry point — runs results collection, then self-schedules for tomorrow."""
     from odds_core.alerts import job_alert_context
     from odds_core.config import get_settings
 

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py
@@ -26,7 +26,7 @@ from odds_lambda.oddsportal_common import (
     parse_match_date,
     run_scraper_with_retry,
 )
-from odds_lambda.scheduling.jobs import make_compound_job_name
+from odds_lambda.scheduling.jobs import JobContext, make_compound_job_name
 from odds_lambda.storage.writers import OddsWriter
 
 logger = structlog.get_logger()
@@ -233,16 +233,13 @@ async def process_results(
     return stats
 
 
-async def main(sport: str | None = None, **_kwargs: object) -> None:
-    """Main job entry point — runs results collection, then self-schedules for tomorrow.
-
-    Args:
-        sport: Sport key (e.g. "soccer_epl"). Currently only soccer_epl is supported.
-    """
+async def main(ctx: JobContext) -> None:
+    """Main job entry point -- runs results collection, then self-schedules for tomorrow."""
     from odds_core.alerts import job_alert_context
     from odds_core.config import get_settings
 
     settings = get_settings()
+    sport = ctx.sport
 
     async with job_alert_context(make_compound_job_name("fetch-oddsportal-results", sport)):
         logger.info("fetch_oddsportal_results_started", sport=sport)
@@ -277,4 +274,4 @@ async def main(sport: str | None = None, **_kwargs: object) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    asyncio.run(main(JobContext()))

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_polymarket.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_polymarket.py
@@ -21,6 +21,7 @@ from odds_core.polymarket_models import PolymarketFetchLog
 from odds_lambda.polymarket_fetcher import PolymarketClient
 from odds_lambda.polymarket_ingestion import PolymarketIngestionResult, PolymarketIngestionService
 from odds_lambda.scheduling.backends import get_scheduler_backend
+from odds_lambda.scheduling.jobs import JobContext
 from odds_lambda.storage.polymarket_reader import PolymarketReader
 from odds_lambda.storage.polymarket_writer import PolymarketWriter
 from odds_lambda.tier_utils import calculate_tier
@@ -93,7 +94,7 @@ async def _log_fetch(
         await log_session.commit()
 
 
-async def main() -> None:
+async def main(ctx: JobContext) -> None:
     """Main job execution flow."""
     app_settings = get_settings()
 
@@ -197,4 +198,4 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    asyncio.run(main(JobContext()))

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_scores.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_scores.py
@@ -19,19 +19,14 @@ from odds_core.models import EventStatus
 from odds_lambda.data_fetcher import TheOddsAPIClient
 from odds_lambda.scheduling.backends import get_scheduler_backend
 from odds_lambda.scheduling.intelligence import SchedulingIntelligence
-from odds_lambda.scheduling.jobs import make_compound_job_name
+from odds_lambda.scheduling.jobs import JobContext, make_compound_job_name
 from odds_lambda.storage.writers import OddsWriter
 
 logger = structlog.get_logger()
 
 
-async def main(sport: str | None = None, **_kwargs: object) -> None:
-    """
-    Main job execution flow.
-
-    Args:
-        sport: Sport key to fetch scores for (e.g. "soccer_epl"). Falls back
-            to ``data_collection.sports`` config when not provided.
+async def main(ctx: JobContext) -> None:
+    """Main job execution flow.
 
     Flow:
     1. Check if we should execute (smart gating)
@@ -40,6 +35,7 @@ async def main(sport: str | None = None, **_kwargs: object) -> None:
     4. Schedule next run via backend
     """
     app_settings = get_settings()
+    sport = ctx.sport
     sports = [sport] if sport else app_settings.data_collection.sports
 
     logger.info(
@@ -166,4 +162,4 @@ async def _fetch_and_update_scores(sports: list[str]) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    asyncio.run(main(JobContext()))

--- a/packages/odds-lambda/odds_lambda/jobs/score_predictions.py
+++ b/packages/odds-lambda/odds_lambda/jobs/score_predictions.py
@@ -29,6 +29,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from odds_lambda.model_loader import get_cached_version, load_model
+from odds_lambda.scheduling.jobs import JobContext, make_compound_job_name
 
 logger = structlog.get_logger()
 
@@ -245,16 +246,11 @@ async def score_events(
     return stats
 
 
-async def main(sport: str | None = None, **_kwargs: object) -> None:
-    """Main job entry point.
-
-    Args:
-        sport: Sport key from event payload. Passed to ``score_events`` for
-            validation against the model's bundled sport_key.
-    """
+async def main(ctx: JobContext) -> None:
+    """Main job entry point."""
     from odds_core.alerts import job_alert_context
 
-    from odds_lambda.scheduling.jobs import make_compound_job_name
+    sport = ctx.sport
 
     async with job_alert_context(make_compound_job_name("score-predictions", sport)):
         logger.info("score_predictions_started", sport=sport)
@@ -262,4 +258,4 @@ async def main(sport: str | None = None, **_kwargs: object) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    asyncio.run(main(JobContext()))

--- a/packages/odds-lambda/odds_lambda/jobs/update_status.py
+++ b/packages/odds-lambda/odds_lambda/jobs/update_status.py
@@ -18,15 +18,15 @@ from odds_core.models import EventStatus
 
 from odds_lambda.scheduling.backends import get_scheduler_backend
 from odds_lambda.scheduling.intelligence import SchedulingIntelligence
+from odds_lambda.scheduling.jobs import JobContext
 from odds_lambda.storage.readers import OddsReader
 from odds_lambda.storage.writers import OddsWriter
 
 logger = structlog.get_logger()
 
 
-async def main():
-    """
-    Main job execution flow.
+async def main(ctx: JobContext) -> None:
+    """Main job execution flow.
 
     Flow:
     1. Check if we should execute (smart gating)
@@ -128,4 +128,4 @@ async def _update_event_statuses():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    asyncio.run(main(JobContext()))

--- a/packages/odds-lambda/odds_lambda/lambda_handler.py
+++ b/packages/odds-lambda/odds_lambda/lambda_handler.py
@@ -25,7 +25,7 @@ import structlog
 from odds_core.config import get_settings
 from odds_core.logging_setup import configure_logging
 
-from odds_lambda.scheduling.jobs import resolve_job_name
+from odds_lambda.scheduling.jobs import JobContext, resolve_job_name
 
 # Configure structured logging for Lambda (JSON output for CloudWatch)
 configure_logging(get_settings(), json_output=True)
@@ -33,39 +33,12 @@ configure_logging(get_settings(), json_output=True)
 logger = structlog.get_logger()
 
 
-async def _run_job_async(job_name: str, **kwargs: object) -> None:
-    """Run the job module's main function asynchronously.
-
-    Extra kwargs from the event payload are passed to the job function.
-    Jobs that accept parameters should declare **kwargs to receive them;
-    jobs that don't will ignore extra fields (we inspect the signature).
-    """
-    import inspect
-
+async def _run_job_async(job_name: str, ctx: JobContext) -> None:
+    """Run the job module's main function with the given context."""
     from odds_lambda.scheduling.jobs import get_job_function
 
     job_fn = get_job_function(job_name)
-    sig = inspect.signature(job_fn)
-
-    # Determine which kwargs the function can accept
-    accepted_params = set(sig.parameters.keys())
-    has_var_keyword = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values())
-
-    if kwargs:
-        if has_var_keyword:
-            await job_fn(**kwargs)
-        else:
-            # Pass only kwargs that match named parameters
-            filtered = {k: v for k, v in kwargs.items() if k in accepted_params}
-            dropped = {k: v for k, v in kwargs.items() if k not in accepted_params}
-            if dropped:
-                logger.debug("job_kwargs_filtered", job=job_name, dropped_keys=list(dropped))
-            if filtered:
-                await job_fn(**filtered)
-            else:
-                await job_fn()
-    else:
-        await job_fn()
+    await job_fn(ctx)
 
 
 def lambda_handler(event: dict, context: object) -> dict:
@@ -110,13 +83,14 @@ def lambda_handler(event: dict, context: object) -> dict:
             memory_limit=context.memory_limit_in_mb,
         )
 
-        # Build job params: everything except "job", plus sport if resolved
+        # Build JobContext from payload
         job_params: dict[str, object] = {k: v for k, v in event.items() if k != "job"}
         if sport and "sport" not in job_params:
             job_params["sport"] = sport
+        ctx = JobContext.from_payload(job_params)
 
         # Run async job
-        asyncio.run(_run_job_async(base_job_name, **job_params))
+        asyncio.run(_run_job_async(base_job_name, ctx))
 
         logger.info(
             "lambda_completed",

--- a/packages/odds-lambda/odds_lambda/scheduling/backends/local.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/backends/local.py
@@ -220,9 +220,18 @@ class LocalSchedulerBackend(SchedulerBackend):
 
         try:
             # Get job function from centralized registry
-            from odds_lambda.scheduling.jobs import get_job_function
+            from odds_lambda.scheduling.jobs import JobContext, get_job_function, resolve_job_name
 
             job_func = get_job_function(job_name)
+
+            # Build JobContext from compound name + payload
+            _, resolved_sport = resolve_job_name(job_name)
+            ctx_payload: dict[str, object] = {}
+            if resolved_sport:
+                ctx_payload["sport"] = resolved_sport
+            if payload:
+                ctx_payload.update(payload)
+            ctx = JobContext.from_payload(ctx_payload)
 
             # Remove existing job if present (replace with new schedule)
             if self.scheduler.get_job(job_name):
@@ -237,6 +246,7 @@ class LocalSchedulerBackend(SchedulerBackend):
                 id=job_name,
                 name=f"Odds {job_name}",
                 replace_existing=True,
+                args=[ctx],
             )
 
             logger.info(

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -1,8 +1,56 @@
 """Centralized job registry for scheduler backends."""
 
+from __future__ import annotations
+
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
 from importlib import import_module
-from typing import Any
+
+
+@dataclass
+class JobContext:
+    """Typed context passed to every job ``main()`` function.
+
+    Scheduler backends construct this from the event payload. Jobs that
+    require specific fields (e.g. ``sport``) assert them at the top of
+    ``main()``. Adding new fields here is backward-compatible — all
+    fields have defaults.
+    """
+
+    sport: str | None = None
+    retry_count: int = 0
+
+    # backfill-polymarket manual invocation params
+    include_spreads: bool = False
+    include_totals: bool = False
+    dry_run: bool = False
+
+    # daily-digest configuration
+    lookback_hours: float = 24
+    lookahead_hours: float = 48
+
+    # Catch-all for forward-compatibility with new payload fields
+    extra: dict[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, object]) -> JobContext:
+        """Construct a ``JobContext`` from a raw event/scheduler payload.
+
+        Known keys are mapped to dataclass fields; unknown keys are
+        collected into ``extra``.
+        """
+        known_fields = {f.name for f in cls.__dataclass_fields__.values()} - {"extra"}
+        known: dict[str, object] = {}
+        extra: dict[str, object] = {}
+        for k, v in payload.items():
+            if k in known_fields:
+                known[k] = v
+            else:
+                extra[k] = v
+        ctx = cls(**known)  # type: ignore[arg-type]
+        ctx.extra = extra
+        return ctx
+
 
 # Maps job name to (module_path, function_name).
 # Modules are imported lazily when the job is first requested, so a Lambda
@@ -41,7 +89,7 @@ _PER_SPORT_JOBS: frozenset[str] = frozenset(
 )
 
 # Cache of already-imported job functions.
-_loaded_jobs: dict[str, Callable[..., Awaitable[Any]]] = {}
+_loaded_jobs: dict[str, Callable[[JobContext], Awaitable[None]]] = {}
 
 
 def sport_key_to_suffix(sport_key: str) -> str | None:
@@ -95,7 +143,7 @@ def resolve_job_name(compound_name: str) -> tuple[str, str | None]:
     return compound_name, None
 
 
-def get_job_function(job_name: str) -> Callable[..., Awaitable[Any]]:
+def get_job_function(job_name: str) -> Callable[[JobContext], Awaitable[None]]:
     """Get job function by name, importing its module on first access.
 
     Uses the base job name (without sport suffix) for module lookup.

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from importlib import import_module
 
 
@@ -39,7 +39,7 @@ class JobContext:
         Known keys are mapped to dataclass fields; unknown keys are
         collected into ``extra``.
         """
-        known_fields = {f.name for f in cls.__dataclass_fields__.values()} - {"extra"}
+        known_fields = {f.name for f in fields(cls)} - {"extra"}
         known: dict[str, object] = {}
         extra: dict[str, object] = {}
         for k, v in payload.items():

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, fields
 from importlib import import_module
+
+import structlog
+
+logger = structlog.get_logger()
 
 
 @dataclass
@@ -29,27 +33,21 @@ class JobContext:
     lookback_hours: float = 24
     lookahead_hours: float = 48
 
-    # Catch-all for forward-compatibility with new payload fields
-    extra: dict[str, object] = field(default_factory=dict)
-
     @classmethod
     def from_payload(cls, payload: dict[str, object]) -> JobContext:
         """Construct a ``JobContext`` from a raw event/scheduler payload.
 
         Known keys are mapped to dataclass fields; unknown keys are
-        collected into ``extra``.
+        logged and ignored.
         """
-        known_fields = {f.name for f in fields(cls)} - {"extra"}
+        known_fields = {f.name for f in fields(cls)}
         known: dict[str, object] = {}
-        extra: dict[str, object] = {}
         for k, v in payload.items():
             if k in known_fields:
                 known[k] = v
             else:
-                extra[k] = v
-        ctx = cls(**known)  # type: ignore[arg-type]
-        ctx.extra = extra
-        return ctx
+                logger.debug("job_context_unknown_key", key=k, value=v)
+        return cls(**known)  # type: ignore[arg-type]
 
 
 # Maps job name to (module_path, function_name).

--- a/tests/integration/test_local_backend.py
+++ b/tests/integration/test_local_backend.py
@@ -10,6 +10,7 @@ from odds_lambda.scheduling.exceptions import (
     JobNotFoundError,
     SchedulingFailedError,
 )
+from odds_lambda.scheduling.jobs import JobContext
 
 
 class TestLocalSchedulerBackend:
@@ -241,7 +242,7 @@ class TestLocalSchedulerBackend:
         # Create a flag to track execution
         executed = asyncio.Event()
 
-        async def test_job(ctx):
+        async def test_job(ctx: JobContext) -> None:
             executed.set()
 
         with patch("odds_lambda.scheduling.jobs.get_job_function", return_value=test_job):
@@ -264,10 +265,10 @@ class TestLocalSchedulerBackend:
         job1_executed = asyncio.Event()
         job2_executed = asyncio.Event()
 
-        async def job1(ctx):
+        async def job1(ctx: JobContext) -> None:
             job1_executed.set()
 
-        async def job2(ctx):
+        async def job2(ctx: JobContext) -> None:
             job2_executed.set()
 
         def get_job_func(job_name):

--- a/tests/integration/test_local_backend.py
+++ b/tests/integration/test_local_backend.py
@@ -241,7 +241,7 @@ class TestLocalSchedulerBackend:
         # Create a flag to track execution
         executed = asyncio.Event()
 
-        async def test_job():
+        async def test_job(ctx):
             executed.set()
 
         with patch("odds_lambda.scheduling.jobs.get_job_function", return_value=test_job):
@@ -264,10 +264,10 @@ class TestLocalSchedulerBackend:
         job1_executed = asyncio.Event()
         job2_executed = asyncio.Event()
 
-        async def job1():
+        async def job1(ctx):
             job1_executed.set()
 
-        async def job2():
+        async def job2(ctx):
             job2_executed.set()
 
         def get_job_func(job_name):

--- a/tests/integration/test_scheduler_e2e.py
+++ b/tests/integration/test_scheduler_e2e.py
@@ -158,7 +158,7 @@ async def test_scheduler_end_to_end(
             session_factory=mock_session_factory,
         )
 
-    async def wrapped_fetch_odds():
+    async def wrapped_fetch_odds(ctx=None):
         """Wrapped job with mocked dependencies."""
         mock_event_sync = AsyncMock()
         mock_event_sync.sync_sports = AsyncMock(return_value=[])
@@ -173,7 +173,9 @@ async def test_scheduler_end_to_end(
             execution_happened["fetch_odds"] = True
 
             # Execute the real job
-            await original_main()
+            from odds_lambda.scheduling.jobs import JobContext
+
+            await original_main(JobContext())
 
     # Start the scheduler backend
     async with LocalSchedulerBackend(dry_run=False) as backend:
@@ -320,7 +322,9 @@ async def test_job_self_scheduling_chain(test_session, mock_session_factory):
             mock_backend_getter.return_value = mock_backend
 
             # Execute job
-            await fetch_odds.main()
+            from odds_lambda.scheduling.jobs import JobContext
+
+            await fetch_odds.main(JobContext())
 
         # Verify self-scheduling
         assert len(scheduled_calls) == 1, f"Expected 1 schedule call for {tier_name}"

--- a/tests/integration/test_scheduler_e2e.py
+++ b/tests/integration/test_scheduler_e2e.py
@@ -174,8 +174,6 @@ async def test_scheduler_end_to_end(
             execution_happened["fetch_odds"] = True
 
             # Execute the real job
-            from odds_lambda.scheduling.jobs import JobContext
-
             await original_main(JobContext())
 
     # Start the scheduler backend
@@ -323,8 +321,6 @@ async def test_job_self_scheduling_chain(test_session, mock_session_factory):
             mock_backend_getter.return_value = mock_backend
 
             # Execute job
-            from odds_lambda.scheduling.jobs import JobContext
-
             await fetch_odds.main(JobContext())
 
         # Verify self-scheduling

--- a/tests/integration/test_scheduler_e2e.py
+++ b/tests/integration/test_scheduler_e2e.py
@@ -21,6 +21,7 @@ from odds_core.api_models import OddsResponse, api_dict_to_event
 from odds_core.models import Event, EventStatus, OddsSnapshot
 from odds_lambda.fetch_tier import FetchTier
 from odds_lambda.ingestion import OddsIngestionService
+from odds_lambda.scheduling.jobs import JobContext
 from odds_lambda.storage.readers import OddsReader
 from odds_lambda.storage.writers import OddsWriter
 from sqlalchemy import select
@@ -158,7 +159,7 @@ async def test_scheduler_end_to_end(
             session_factory=mock_session_factory,
         )
 
-    async def wrapped_fetch_odds(ctx=None):
+    async def wrapped_fetch_odds(ctx: JobContext) -> None:
         """Wrapped job with mocked dependencies."""
         mock_event_sync = AsyncMock()
         mock_event_sync.sync_sports = AsyncMock(return_value=[])

--- a/tests/unit/test_backfill_polymarket.py
+++ b/tests/unit/test_backfill_polymarket.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from odds_core.polymarket_models import PolymarketMarket, PolymarketMarketType
 from odds_lambda.jobs import backfill_polymarket
+from odds_lambda.scheduling.jobs import JobContext
 
 
 class TestBackfillMarketHistory:
@@ -253,7 +254,7 @@ class TestMainIntegration:
             "odds_lambda.jobs.backfill_polymarket.get_settings",
             return_value=mock_polymarket_settings,
         ):
-            await backfill_polymarket.main(dry_run=True)
+            await backfill_polymarket.main(JobContext(dry_run=True))
 
         # No assertions needed - just verifies no exceptions raised and early return
 
@@ -337,9 +338,7 @@ class TestMainIntegration:
                 patch("odds_lambda.jobs.backfill_polymarket.asyncio.sleep"),
             ):
                 await backfill_polymarket.main(
-                    include_spreads=False,  # Spreads NOT included
-                    include_totals=False,
-                    dry_run=False,
+                    JobContext(include_spreads=False, include_totals=False, dry_run=False)
                 )
 
             # Only 1 call for moneyline market, not 2
@@ -405,9 +404,7 @@ class TestMainIntegration:
                 patch("odds_lambda.jobs.backfill_polymarket.asyncio.sleep"),
             ):
                 await backfill_polymarket.main(
-                    include_spreads=True,  # Spreads INCLUDED
-                    include_totals=False,
-                    dry_run=False,
+                    JobContext(include_spreads=True, include_totals=False, dry_run=False)
                 )
 
             # 2 calls: one for moneyline, one for spread
@@ -479,7 +476,7 @@ class TestMainIntegration:
                 ),
             ):
                 # Should not raise exception
-                await backfill_polymarket.main(dry_run=True)
+                await backfill_polymarket.main(JobContext(dry_run=True))
 
             # Both events attempted
             assert mock_writer.upsert_event.call_count == 2
@@ -535,7 +532,7 @@ class TestMainIntegration:
                 ),
                 patch("odds_lambda.jobs.backfill_polymarket.asyncio.sleep"),
             ):
-                await backfill_polymarket.main(dry_run=True)
+                await backfill_polymarket.main(JobContext(dry_run=True))
 
             # Verify commit NOT called in dry run
             mock_async_session.commit.assert_not_called()
@@ -592,7 +589,7 @@ class TestMainIntegration:
                 ),
                 patch("odds_lambda.jobs.backfill_polymarket.asyncio.sleep"),
             ):
-                await backfill_polymarket.main(dry_run=False)
+                await backfill_polymarket.main(JobContext(dry_run=False))
 
             # Verify commit WAS called
             mock_async_session.commit.assert_called()

--- a/tests/unit/test_fetch_oddsportal_scheduling.py
+++ b/tests/unit/test_fetch_oddsportal_scheduling.py
@@ -18,6 +18,7 @@ from odds_lambda.jobs.fetch_oddsportal import (
     _calculate_next_execution,
     main,
 )
+from odds_lambda.scheduling.jobs import JobContext
 
 
 class TestCalculateNextExecution:
@@ -128,7 +129,7 @@ class TestDefensivePreScheduling:
             patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
         ):
             mock_settings.return_value.scheduler.dry_run = False
-            await main(retry_count=0)
+            await main(JobContext(retry_count=0))
 
         assert call_order[0] == "schedule", (
             "schedule_next_execution must be called before ingest_league"
@@ -159,7 +160,7 @@ class TestDefensivePreScheduling:
                 league="test", matches_scraped=5, snapshots_stored=3
             )
 
-            await main(retry_count=0)
+            await main(JobContext(retry_count=0))
 
         # Pre-schedule (retry cadence) + success reschedule (normal cadence)
         assert mock_backend.schedule_next_execution.call_count == 2
@@ -190,7 +191,7 @@ class TestDefensivePreScheduling:
             mock_settings.return_value.scheduler.dry_run = False
             mock_ingest.return_value = IngestionStats(league="test", matches_scraped=0)
 
-            await main(retry_count=0)
+            await main(JobContext(retry_count=0))
 
         # Only the defensive pre-schedule fires
         assert mock_backend.schedule_next_execution.call_count == 1
@@ -216,7 +217,7 @@ class TestDefensivePreScheduling:
             patch("odds_core.alerts.send_job_warning", new_callable=AsyncMock),
         ):
             mock_settings.return_value.scheduler.dry_run = False
-            await main(retry_count=0)
+            await main(JobContext(retry_count=0))
 
         # Only the defensive pre-schedule fires (no success reschedule)
         assert mock_backend.schedule_next_execution.call_count == 1
@@ -253,7 +254,7 @@ class TestRetryCountIntegration:
             mock_settings.return_value.scheduler.dry_run = False
             mock_ingest.return_value = IngestionStats(league="test", matches_scraped=0)
 
-            await main(retry_count=0)
+            await main(JobContext(retry_count=0))
 
             # Defensive pre-schedule has retry_count=1
             call_kwargs = mock_backend.schedule_next_execution.call_args
@@ -283,7 +284,7 @@ class TestRetryCountIntegration:
                 league="test", matches_scraped=5, snapshots_stored=3
             )
 
-            await main(retry_count=2)
+            await main(JobContext(retry_count=2))
 
             # Last call is the success reschedule with no retry payload
             assert mock_backend.schedule_next_execution.call_count == 2

--- a/tests/unit/test_fetch_polymarket.py
+++ b/tests/unit/test_fetch_polymarket.py
@@ -8,6 +8,7 @@ from freezegun import freeze_time
 from odds_lambda.fetch_tier import FetchTier
 from odds_lambda.jobs import fetch_polymarket
 from odds_lambda.polymarket_ingestion import PolymarketIngestionResult
+from odds_lambda.scheduling.jobs import JobContext
 
 FROZEN_NOW = datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC)
 
@@ -120,7 +121,7 @@ class TestFetchPolymarketMain:
     @pytest.mark.asyncio
     async def test_early_return_when_polymarket_disabled(self, job: JobMocks) -> None:
         job.settings.polymarket.enabled = False
-        await fetch_polymarket.main()
+        await fetch_polymarket.main(JobContext())
         job.client.get_nba_events.assert_not_called()
 
     @pytest.mark.asyncio
@@ -129,7 +130,7 @@ class TestFetchPolymarketMain:
         job.client.get_nba_events.return_value = []
         job.reader.get_active_events.return_value = [db_event]
 
-        await fetch_polymarket.main()
+        await fetch_polymarket.main(JobContext())
 
         job.backend.schedule_next_execution.assert_called_once()
         next_time = job.backend.schedule_next_execution.call_args.kwargs["next_time"]
@@ -140,7 +141,7 @@ class TestFetchPolymarketMain:
         job.client.get_nba_events.return_value = []
         job.reader.get_active_events.return_value = []
 
-        await fetch_polymarket.main()
+        await fetch_polymarket.main(JobContext())
 
         job.backend.schedule_next_execution.assert_called_once()
         next_time = job.backend.schedule_next_execution.call_args.kwargs["next_time"]
@@ -159,7 +160,7 @@ class TestFetchPolymarketMain:
         job.service.discover_and_upsert_events.return_value = discovery_result
         job.service.collect_snapshots.return_value = snapshot_result
 
-        await fetch_polymarket.main()
+        await fetch_polymarket.main(JobContext())
 
         job.service.discover_and_upsert_events.assert_called_once_with([{"id": "ev-1"}])
         job.service.collect_snapshots.assert_called_once()
@@ -174,7 +175,7 @@ class TestFetchPolymarketMain:
         job.service.discover_and_upsert_events.return_value = discovery_result
         job.service.collect_snapshots.return_value = snapshot_result
 
-        await fetch_polymarket.main()
+        await fetch_polymarket.main(JobContext())
 
         job.backend.schedule_next_execution.assert_called_once()
         next_time = job.backend.schedule_next_execution.call_args.kwargs["next_time"]
@@ -193,7 +194,7 @@ class TestFetchPolymarketMain:
         job.service.discover_and_upsert_events.return_value = discovery_result
         job.service.collect_snapshots.return_value = snapshot_result
 
-        await fetch_polymarket.main()
+        await fetch_polymarket.main(JobContext())
 
         job.log_writer.log_fetch.assert_called_once()
         log_arg = job.log_writer.log_fetch.call_args.args[0]
@@ -208,7 +209,7 @@ class TestFetchPolymarketMain:
         job.client.get_nba_events.side_effect = Exception("API down")
 
         with pytest.raises(Exception, match="API down"):
-            await fetch_polymarket.main()
+            await fetch_polymarket.main(JobContext())
 
         job.log_writer.log_fetch.assert_called_once()
         log_arg = job.log_writer.log_fetch.call_args.args[0]
@@ -229,7 +230,7 @@ class TestFetchPolymarketMain:
         job.service.discover_and_upsert_events.return_value = discovery_result
         job.service.collect_snapshots.return_value = snapshot_result
 
-        await fetch_polymarket.main()
+        await fetch_polymarket.main(JobContext())
 
         job.backend.schedule_next_execution.assert_called_once()
         next_time = job.backend.schedule_next_execution.call_args.kwargs["next_time"]
@@ -247,4 +248,4 @@ class TestFetchPolymarketMain:
         job.service.collect_snapshots.return_value = snapshot_result
         job.backend.schedule_next_execution.side_effect = Exception("Scheduler unreachable")
 
-        await fetch_polymarket.main()  # must not raise
+        await fetch_polymarket.main(JobContext())  # must not raise


### PR DESCRIPTION
## Summary
- Define `JobContext` dataclass in `odds_lambda/scheduling/jobs.py` with `sport`, `retry_count`, and job-specific fields (`include_spreads`, `include_totals`, `dry_run`, `lookback_hours`, `lookahead_hours`, `extra`)
- Update all 10 job `main()` functions to accept `ctx: JobContext` as their only parameter
- Simplify `lambda_handler._run_job_async` — construct `JobContext.from_payload()` and pass directly, removing `inspect.signature` introspection
- Simplify local backend's `schedule_next_execution` — pass `JobContext` to APScheduler instead of filtering kwargs via `inspect.signature`
- Update CLI callers and test files to use `JobContext`

## Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)