### PR TITLE
Centralized team name normalization

### DIFF
--- a/migrations/versions/e7f2a1b3c4d5_normalize_team_names.py
+++ b/migrations/versions/e7f2a1b3c4d5_normalize_team_names.py
@@ -6,6 +6,7 @@ Create Date: 2026-04-10 12:00:00.000000
 
 """
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -44,7 +45,8 @@ def upgrade() -> None:
     for alias, canonical in _ALIAS_MAP.items():
         for col in ("home_team", "away_team"):
             op.execute(
-                f"UPDATE events SET {col} = '{canonical}' WHERE {col} = '{alias}'"  # noqa: S608
+                sa.text(f"UPDATE events SET {col} = :val WHERE {col} = :old"),
+                {"val": canonical, "old": alias},
             )
 
 
@@ -75,5 +77,6 @@ def downgrade() -> None:
     for canonical, alias in _REVERSE.items():
         for col in ("home_team", "away_team"):
             op.execute(
-                f"UPDATE events SET {col} = '{alias}' WHERE {col} = '{canonical}'"  # noqa: S608
+                sa.text(f"UPDATE events SET {col} = :val WHERE {col} = :old"),
+                {"val": alias, "old": canonical},
             )

--- a/migrations/versions/e7f2a1b3c4d5_normalize_team_names.py
+++ b/migrations/versions/e7f2a1b3c4d5_normalize_team_names.py
@@ -45,8 +45,9 @@ def upgrade() -> None:
     for alias, canonical in _ALIAS_MAP.items():
         for col in ("home_team", "away_team"):
             op.execute(
-                sa.text(f"UPDATE events SET {col} = :val WHERE {col} = :old"),
-                {"val": canonical, "old": alias},
+                sa.text(f"UPDATE events SET {col} = :val WHERE {col} = :old").bindparams(
+                    val=canonical, old=alias
+                )
             )
 
 
@@ -77,6 +78,7 @@ def downgrade() -> None:
     for canonical, alias in _REVERSE.items():
         for col in ("home_team", "away_team"):
             op.execute(
-                sa.text(f"UPDATE events SET {col} = :val WHERE {col} = :old"),
-                {"val": alias, "old": canonical},
+                sa.text(f"UPDATE events SET {col} = :val WHERE {col} = :old").bindparams(
+                    val=alias, old=canonical
+                )
             )

--- a/migrations/versions/e7f2a1b3c4d5_normalize_team_names.py
+++ b/migrations/versions/e7f2a1b3c4d5_normalize_team_names.py
@@ -1,0 +1,79 @@
+"""normalize team names in events table
+
+Revision ID: e7f2a1b3c4d5
+Revises: 021f43706c10
+Create Date: 2026-04-10 12:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e7f2a1b3c4d5"
+down_revision = "021f43706c10"
+branch_labels = None
+depends_on = None
+
+# Alias -> canonical (same mappings as odds_core.team._TEAM_ALIASES).
+# Only includes names that could exist in the events table.
+_ALIAS_MAP: dict[str, str] = {
+    "AFC Bournemouth": "Bournemouth",
+    "Brighton & Hove Albion": "Brighton",
+    "Brighton and Hove Albion": "Brighton",
+    "Cardiff City": "Cardiff",
+    "Huddersfield Town": "Huddersfield",
+    "Hull City": "Hull",
+    "Ipswich Town": "Ipswich",
+    "Leicester City": "Leicester",
+    "Leeds United": "Leeds",
+    "Manchester United": "Manchester Utd",
+    "Newcastle United": "Newcastle",
+    "Norwich City": "Norwich",
+    "Nottingham Forest": "Nottingham",
+    "Sheffield United": "Sheffield Utd",
+    "Stoke City": "Stoke",
+    "Swansea City": "Swansea",
+    "Tottenham Hotspur": "Tottenham",
+    "West Bromwich Albion": "West Brom",
+    "West Ham United": "West Ham",
+    "Wolverhampton Wanderers": "Wolves",
+}
+
+
+def upgrade() -> None:
+    for alias, canonical in _ALIAS_MAP.items():
+        for col in ("home_team", "away_team"):
+            op.execute(
+                f"UPDATE events SET {col} = '{canonical}' WHERE {col} = '{alias}'"  # noqa: S608
+            )
+
+
+def downgrade() -> None:
+    # Reverse mapping is lossy (multiple aliases map to one canonical).
+    # Use the longest/most-specific alias as the reverse form.
+    _REVERSE: dict[str, str] = {
+        "Bournemouth": "AFC Bournemouth",
+        "Brighton": "Brighton and Hove Albion",
+        "Cardiff": "Cardiff City",
+        "Huddersfield": "Huddersfield Town",
+        "Hull": "Hull City",
+        "Ipswich": "Ipswich Town",
+        "Leicester": "Leicester City",
+        "Leeds": "Leeds United",
+        "Manchester Utd": "Manchester United",
+        "Newcastle": "Newcastle United",
+        "Norwich": "Norwich City",
+        "Nottingham": "Nottingham Forest",
+        "Sheffield Utd": "Sheffield United",
+        "Stoke": "Stoke City",
+        "Swansea": "Swansea City",
+        "Tottenham": "Tottenham Hotspur",
+        "West Brom": "West Bromwich Albion",
+        "West Ham": "West Ham United",
+        "Wolves": "Wolverhampton Wanderers",
+    }
+    for canonical, alias in _REVERSE.items():
+        for col in ("home_team", "away_team"):
+            op.execute(
+                f"UPDATE events SET {col} = '{alias}' WHERE {col} = '{canonical}'"  # noqa: S608
+            )

--- a/packages/odds-core/odds_core/__init__.py
+++ b/packages/odds-core/odds_core/__init__.py
@@ -33,6 +33,7 @@ from odds_core.polymarket_models import (
     PolymarketPriceSnapshot,
 )
 from odds_core.prediction_models import Prediction
+from odds_core.team import normalize_team_name
 
 __all__ = [
     # Models
@@ -60,6 +61,8 @@ __all__ = [
     # Config
     "Settings",
     "get_settings",
+    # Team normalization
+    "normalize_team_name",
     # API Models
     "OddsResponse",
     "ScoresResponse",

--- a/packages/odds-core/odds_core/models.py
+++ b/packages/odds-core/odds_core/models.py
@@ -2,9 +2,9 @@
 
 from datetime import UTC, datetime
 from enum import Enum
+from typing import Any
 
 from sqlalchemy import JSON, Column, DateTime, Index
-from sqlalchemy.orm import validates
 from sqlmodel import Field, SQLModel
 
 from odds_core.team import normalize_team_name
@@ -48,13 +48,9 @@ class Event(SQLModel, table=True):
     away_team: str = Field(index=True, description="Away team name")
     status: EventStatus = Field(default=EventStatus.SCHEDULED, description="Event status")
 
-    @validates("home_team")
-    def _normalize_home_team(self, key: str, value: str) -> str:
-        return normalize_team_name(value)
-
-    @validates("away_team")
-    def _normalize_away_team(self, key: str, value: str) -> str:
-        return normalize_team_name(value)
+    def model_post_init(self, __context: Any) -> None:
+        self.home_team = normalize_team_name(self.home_team)
+        self.away_team = normalize_team_name(self.away_team)
 
     # Results (populated after game completion)
     home_score: int | None = Field(default=None, description="Final home team score")

--- a/packages/odds-core/odds_core/models.py
+++ b/packages/odds-core/odds_core/models.py
@@ -2,9 +2,12 @@
 
 from datetime import UTC, datetime
 from enum import Enum
+from typing import Any
 
 from sqlalchemy import JSON, Column, DateTime, Index
 from sqlmodel import Field, SQLModel
+
+from odds_core.team import normalize_team_name
 
 
 def utc_now() -> datetime:
@@ -44,6 +47,13 @@ class Event(SQLModel, table=True):
     home_team: str = Field(index=True, description="Home team name")
     away_team: str = Field(index=True, description="Away team name")
     status: EventStatus = Field(default=EventStatus.SCHEDULED, description="Event status")
+
+    def __init__(self, **data: Any) -> None:
+        if "home_team" in data:
+            data["home_team"] = normalize_team_name(data["home_team"])
+        if "away_team" in data:
+            data["away_team"] = normalize_team_name(data["away_team"])
+        super().__init__(**data)
 
     # Results (populated after game completion)
     home_score: int | None = Field(default=None, description="Final home team score")

--- a/packages/odds-core/odds_core/models.py
+++ b/packages/odds-core/odds_core/models.py
@@ -2,8 +2,8 @@
 
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Any
 
+from pydantic import field_validator
 from sqlalchemy import JSON, Column, DateTime, Index
 from sqlmodel import Field, SQLModel
 
@@ -48,12 +48,10 @@ class Event(SQLModel, table=True):
     away_team: str = Field(index=True, description="Away team name")
     status: EventStatus = Field(default=EventStatus.SCHEDULED, description="Event status")
 
-    def __init__(self, **data: Any) -> None:
-        if "home_team" in data:
-            data["home_team"] = normalize_team_name(data["home_team"])
-        if "away_team" in data:
-            data["away_team"] = normalize_team_name(data["away_team"])
-        super().__init__(**data)
+    @field_validator("home_team", "away_team", mode="before")
+    @classmethod
+    def _normalize_team(cls, v: str) -> str:
+        return normalize_team_name(v)
 
     # Results (populated after game completion)
     home_score: int | None = Field(default=None, description="Final home team score")

--- a/packages/odds-core/odds_core/models.py
+++ b/packages/odds-core/odds_core/models.py
@@ -3,8 +3,8 @@
 from datetime import UTC, datetime
 from enum import Enum
 
-from pydantic import field_validator
 from sqlalchemy import JSON, Column, DateTime, Index
+from sqlalchemy.orm import validates
 from sqlmodel import Field, SQLModel
 
 from odds_core.team import normalize_team_name
@@ -48,10 +48,13 @@ class Event(SQLModel, table=True):
     away_team: str = Field(index=True, description="Away team name")
     status: EventStatus = Field(default=EventStatus.SCHEDULED, description="Event status")
 
-    @field_validator("home_team", "away_team", mode="before")
-    @classmethod
-    def _normalize_team(cls, v: str) -> str:
-        return normalize_team_name(v)
+    @validates("home_team")
+    def _normalize_home_team(self, key: str, value: str) -> str:
+        return normalize_team_name(value)
+
+    @validates("away_team")
+    def _normalize_away_team(self, key: str, value: str) -> str:
+        return normalize_team_name(value)
 
     # Results (populated after game completion)
     home_score: int | None = Field(default=None, description="Final home team score")

--- a/packages/odds-core/odds_core/team.py
+++ b/packages/odds-core/odds_core/team.py
@@ -1,8 +1,8 @@
 """Centralized team name normalization.
 
-Maps source-specific team names to pipeline canonical names (Odds API forms
-stored in the events table). Whitespace/case cleanup applied before alias
-lookup. Passthrough for names that are already canonical.
+Maps source-specific team names to pipeline canonical names (short forms
+stored in the events table). Whitespace cleanup applied before alias lookup.
+Passthrough for names that are already canonical.
 """
 
 from __future__ import annotations

--- a/packages/odds-core/odds_core/team.py
+++ b/packages/odds-core/odds_core/team.py
@@ -14,44 +14,44 @@ from __future__ import annotations
 #   Middlesbrough, Newcastle, Norwich, Nottingham, Sheffield Utd, Southampton,
 #   Stoke, Sunderland, Swansea, Tottenham, Watford, West Brom, West Ham, Wolves
 
-# Alias -> canonical. Title-cased before lookup so each variant needs one entry.
+# Alias -> canonical. Keys are lowercased for case-insensitive lookup.
 _TEAM_ALIASES: dict[str, str] = {
     # OddsPortal / football-data.co.uk / ESPN / FBref variants
-    "Afc Bournemouth": "Bournemouth",
-    "Brighton & Hove Albion": "Brighton",
-    "Brighton And Hove Albion": "Brighton",
-    "Cardiff City": "Cardiff",
-    "Huddersfield Town": "Huddersfield",
-    "Hull City": "Hull",
-    "Ipswich Town": "Ipswich",
-    "Leicester City": "Leicester",
-    "Leeds United": "Leeds",
-    "Man City": "Manchester City",
-    "Man United": "Manchester Utd",
-    "Man Utd": "Manchester Utd",
-    "Manchester United": "Manchester Utd",
-    "Newcastle United": "Newcastle",
-    "Newcastle Utd": "Newcastle",
-    "Norwich City": "Norwich",
-    "Nott'M Forest": "Nottingham",
-    "Nott'Ham Forest": "Nottingham",
-    "Nottingham Forest": "Nottingham",
-    "Sheffield United": "Sheffield Utd",
-    "Stoke City": "Stoke",
-    "Swansea City": "Swansea",
-    "Tottenham Hotspur": "Tottenham",
-    "Spurs": "Tottenham",
-    "West Bromwich Albion": "West Brom",
-    "West Ham United": "West Ham",
-    "Wolverhampton Wanderers": "Wolves",
+    "afc bournemouth": "Bournemouth",
+    "brighton & hove albion": "Brighton",
+    "brighton and hove albion": "Brighton",
+    "cardiff city": "Cardiff",
+    "huddersfield town": "Huddersfield",
+    "hull city": "Hull",
+    "ipswich town": "Ipswich",
+    "leicester city": "Leicester",
+    "leeds united": "Leeds",
+    "man city": "Manchester City",
+    "man united": "Manchester Utd",
+    "man utd": "Manchester Utd",
+    "manchester united": "Manchester Utd",
+    "newcastle united": "Newcastle",
+    "newcastle utd": "Newcastle",
+    "norwich city": "Norwich",
+    "nott'm forest": "Nottingham",
+    "nott'ham forest": "Nottingham",
+    "nottingham forest": "Nottingham",
+    "sheffield united": "Sheffield Utd",
+    "stoke city": "Stoke",
+    "swansea city": "Swansea",
+    "tottenham hotspur": "Tottenham",
+    "spurs": "Tottenham",
+    "west bromwich albion": "West Brom",
+    "west ham united": "West Ham",
+    "wolverhampton wanderers": "Wolves",
 }
 
 
 def normalize_team_name(name: str) -> str:
     """Normalize a team name to pipeline canonical form.
 
-    Applies whitespace/case cleanup then explicit alias lookup.
-    Returns the canonical name, or the cleaned name if no alias matches.
+    Collapses whitespace then does case-insensitive alias lookup.
+    Returns the canonical name, or the cleaned name unchanged if no alias matches.
 
     >>> normalize_team_name("Wolves")
     'Wolves'
@@ -62,8 +62,8 @@ def normalize_team_name(name: str) -> str:
     >>> normalize_team_name("Arsenal")
     'Arsenal'
     """
-    # Collapse whitespace and strip
     cleaned = " ".join(name.split())
-    # Title-case for consistent lookup
-    titled = cleaned.title()
-    return _TEAM_ALIASES.get(titled, titled)
+    canonical = _TEAM_ALIASES.get(cleaned.lower())
+    if canonical is not None:
+        return canonical
+    return cleaned

--- a/packages/odds-core/odds_core/team.py
+++ b/packages/odds-core/odds_core/team.py
@@ -1,0 +1,69 @@
+"""Centralized team name normalization.
+
+Maps source-specific team names to pipeline canonical names (Odds API forms
+stored in the events table). Whitespace/case cleanup applied before alias
+lookup. Passthrough for names that are already canonical.
+"""
+
+from __future__ import annotations
+
+# Pipeline canonical EPL names (from The Odds API / events table):
+#   Arsenal, Aston Villa, Bournemouth, Brentford, Brighton, Burnley, Cardiff,
+#   Chelsea, Crystal Palace, Everton, Fulham, Huddersfield, Hull, Ipswich,
+#   Leeds, Leicester, Liverpool, Luton, Manchester City, Manchester Utd,
+#   Middlesbrough, Newcastle, Norwich, Nottingham, Sheffield Utd, Southampton,
+#   Stoke, Sunderland, Swansea, Tottenham, Watford, West Brom, West Ham, Wolves
+
+# Alias -> canonical. Title-cased before lookup so each variant needs one entry.
+_TEAM_ALIASES: dict[str, str] = {
+    # OddsPortal / football-data.co.uk / ESPN / FBref variants
+    "Afc Bournemouth": "Bournemouth",
+    "Brighton & Hove Albion": "Brighton",
+    "Brighton And Hove Albion": "Brighton",
+    "Cardiff City": "Cardiff",
+    "Huddersfield Town": "Huddersfield",
+    "Hull City": "Hull",
+    "Ipswich Town": "Ipswich",
+    "Leicester City": "Leicester",
+    "Leeds United": "Leeds",
+    "Man City": "Manchester City",
+    "Man United": "Manchester Utd",
+    "Man Utd": "Manchester Utd",
+    "Manchester United": "Manchester Utd",
+    "Newcastle United": "Newcastle",
+    "Newcastle Utd": "Newcastle",
+    "Norwich City": "Norwich",
+    "Nott'M Forest": "Nottingham",
+    "Nott'Ham Forest": "Nottingham",
+    "Nottingham Forest": "Nottingham",
+    "Sheffield United": "Sheffield Utd",
+    "Stoke City": "Stoke",
+    "Swansea City": "Swansea",
+    "Tottenham Hotspur": "Tottenham",
+    "Spurs": "Tottenham",
+    "West Bromwich Albion": "West Brom",
+    "West Ham United": "West Ham",
+    "Wolverhampton Wanderers": "Wolves",
+}
+
+
+def normalize_team_name(name: str) -> str:
+    """Normalize a team name to pipeline canonical form.
+
+    Applies whitespace/case cleanup then explicit alias lookup.
+    Returns the canonical name, or the cleaned name if no alias matches.
+
+    >>> normalize_team_name("Wolves")
+    'Wolves'
+    >>> normalize_team_name("  manchester   united ")
+    'Manchester Utd'
+    >>> normalize_team_name("Wolverhampton Wanderers")
+    'Wolves'
+    >>> normalize_team_name("Arsenal")
+    'Arsenal'
+    """
+    # Collapse whitespace and strip
+    cleaned = " ".join(name.split())
+    # Title-case for consistent lookup
+    titled = cleaned.title()
+    return _TEAM_ALIASES.get(titled, titled)

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
@@ -28,15 +28,12 @@ from typing import Any
 
 import structlog
 from odds_core.database import async_session_maker
-from odds_core.models import Event, EventStatus
-from sqlalchemy import and_, select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from odds_lambda.oddsportal_adapter import (
     MatchOdds,
     convert_upcoming_matches,
 )
-from odds_lambda.oddsportal_common import hours_to_tier, run_scraper_with_retry, team_abbrev
+from odds_lambda.oddsportal_common import hours_to_tier, run_scraper_with_retry
 from odds_lambda.scheduling.backends import get_scheduler_backend
 from odds_lambda.scheduling.jobs import make_compound_job_name
 from odds_lambda.storage.writers import OddsWriter
@@ -90,14 +87,6 @@ class IngestionStats:
     errors: list[str] = field(default_factory=list)
 
 
-def _build_event_id(home_team: str, away_team: str, match_date: datetime) -> str:
-    """Generate deterministic event ID for OddsPortal-sourced events."""
-    home_abbrev = team_abbrev(home_team)
-    away_abbrev = team_abbrev(away_team)
-    date_str = match_date.strftime("%Y-%m-%d")
-    return f"op_live_{home_abbrev}_{away_abbrev}_{date_str}"
-
-
 async def run_harvester_upcoming(spec: LeagueSpec) -> list[dict[str, Any]]:
     """Scrape upcoming matches for a league via ``run_scraper_with_retry``."""
     from oddsharvester.utils.command_enum import CommandEnum
@@ -110,64 +99,6 @@ async def run_harvester_upcoming(spec: LeagueSpec) -> list[dict[str, Any]]:
         headless=True,
     )
     return result.success
-
-
-async def find_or_create_event(
-    session: AsyncSession,
-    match: MatchOdds,
-    spec: LeagueSpec,
-) -> tuple[str, bool]:
-    """Find existing event or create a new one.
-
-    Returns:
-        (event_id, was_created)
-    """
-    window_start = match.match_date - timedelta(hours=24)
-    window_end = match.match_date + timedelta(hours=24)
-
-    query = select(Event.id).where(
-        and_(
-            Event.commence_time >= window_start,
-            Event.commence_time <= window_end,
-            Event.home_team == match.home_team,
-            Event.away_team == match.away_team,
-        )
-    )
-    result = await session.execute(query)
-    candidates = list(result.scalars().all())
-
-    if len(candidates) == 1:
-        return candidates[0], False
-
-    if len(candidates) > 1:
-        logger.warning(
-            "ambiguous_event_match",
-            home=match.home_team,
-            away=match.away_team,
-            date=match.match_date.isoformat(),
-            count=len(candidates),
-        )
-        return candidates[0], False
-
-    # Create new event
-    event_id = _build_event_id(match.home_team, match.away_team, match.match_date)
-
-    # Check idempotency
-    existing = await session.get(Event, event_id)
-    if existing:
-        return event_id, False
-
-    event = Event(
-        id=event_id,
-        sport_key=spec.sport_key,
-        sport_title=spec.sport_title,
-        commence_time=match.match_date,
-        home_team=match.home_team,
-        away_team=match.away_team,
-        status=EventStatus.SCHEDULED,
-    )
-    session.add(event)
-    return event_id, True
 
 
 async def ingest_league(
@@ -225,7 +156,13 @@ async def ingest_league(
 
         for market, match in all_converted:
             try:
-                event_id, created = await find_or_create_event(session, match, spec)
+                event_id, created = await writer.find_or_create_event(
+                    home_team=match.home_team,
+                    away_team=match.away_team,
+                    match_date=match.match_date,
+                    sport_key=spec.sport_key,
+                    sport_title=spec.sport_title,
+                )
 
                 if created:
                     stats.events_created += 1

--- a/packages/odds-lambda/odds_lambda/storage/writers.py
+++ b/packages/odds-lambda/odds_lambda/storage/writers.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import structlog
 from odds_core.models import DataQualityLog, Event, EventStatus, FetchLog, Odds, OddsSnapshot
 from odds_core.time import ensure_utc, parse_api_datetime
-from sqlalchemy import select
+from sqlalchemy import and_, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from odds_lambda.oddsportal_common import team_abbrev
 from odds_lambda.storage.validators import OddsValidator
 from odds_lambda.tier_utils import calculate_hours_until_commence, calculate_tier_from_timestamps
 
@@ -71,6 +72,74 @@ class OddsWriter:
             self.session.add(event)
             logger.info("event_created", event_id=event.id)
             return event
+
+    @staticmethod
+    def _build_event_id(home_team: str, away_team: str, match_date: datetime) -> str:
+        """Generate deterministic event ID for OddsPortal-sourced events."""
+        home_abbrev = team_abbrev(home_team)
+        away_abbrev = team_abbrev(away_team)
+        date_str = match_date.strftime("%Y-%m-%d")
+        return f"op_live_{home_abbrev}_{away_abbrev}_{date_str}"
+
+    async def find_or_create_event(
+        self,
+        home_team: str,
+        away_team: str,
+        match_date: datetime,
+        sport_key: str,
+        sport_title: str,
+    ) -> tuple[str, bool]:
+        """Find existing event by team+date or create a new one.
+
+        Returns:
+            (event_id, was_created)
+        """
+        window_start = match_date - timedelta(hours=24)
+        window_end = match_date + timedelta(hours=24)
+
+        query = select(Event.id).where(
+            and_(
+                Event.commence_time >= window_start,
+                Event.commence_time <= window_end,
+                Event.home_team == home_team,
+                Event.away_team == away_team,
+            )
+        )
+        result = await self.session.execute(query)
+        candidates = list(result.scalars().all())
+
+        if len(candidates) == 1:
+            return candidates[0], False
+
+        if len(candidates) > 1:
+            logger.warning(
+                "ambiguous_event_match",
+                home=home_team,
+                away=away_team,
+                date=match_date.isoformat(),
+                count=len(candidates),
+            )
+            return candidates[0], False
+
+        # Create new event
+        event_id = self._build_event_id(home_team, away_team, match_date)
+
+        # Check idempotency
+        existing = await self.session.get(Event, event_id)
+        if existing:
+            return event_id, False
+
+        event = Event(
+            id=event_id,
+            sport_key=sport_key,
+            sport_title=sport_title,
+            commence_time=match_date,
+            home_team=home_team,
+            away_team=away_team,
+            status=EventStatus.SCHEDULED,
+        )
+        self.session.add(event)
+        return event_id, True
 
     async def store_odds_snapshot(
         self,

--- a/packages/odds-lambda/odds_lambda/storage/writers.py
+++ b/packages/odds-lambda/odds_lambda/storage/writers.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime, timedelta
 
 import structlog
 from odds_core.models import DataQualityLog, Event, EventStatus, FetchLog, Odds, OddsSnapshot
+from odds_core.team import normalize_team_name
 from odds_core.time import ensure_utc, parse_api_datetime
 from sqlalchemy import and_, select
 from sqlalchemy.dialects.postgresql import insert
@@ -94,6 +95,9 @@ class OddsWriter:
         Returns:
             (event_id, was_created)
         """
+        home_team = normalize_team_name(home_team)
+        away_team = normalize_team_name(away_team)
+
         window_start = match_date - timedelta(hours=24)
         window_end = match_date + timedelta(hours=24)
 

--- a/scripts/ingest_fpl_availability.py
+++ b/scripts/ingest_fpl_availability.py
@@ -69,7 +69,7 @@ REQUEST_DELAY = 0.3
 
 
 def _normalize_team(fpl_name: str) -> str:
-    return normalize_team(fpl_name, source="fpl")
+    return normalize_team(fpl_name)
 
 
 def _snapshot_time_from_path(year: int, month: int, day: int, filename: str) -> datetime:

--- a/scripts/team_names.py
+++ b/scripts/team_names.py
@@ -1,7 +1,6 @@
 """Centralized EPL team name normalization.
 
-Delegates to odds_core.team.normalize_team_name(). Source-specific overrides
-(e.g. FPL abbreviations) are handled here as a thin wrapper.
+Delegates to odds_core.team.normalize_team_name().
 """
 
 from __future__ import annotations
@@ -9,16 +8,6 @@ from __future__ import annotations
 from odds_core.team import normalize_team_name
 
 
-def normalize_team(name: str, source: str | None = None) -> str:
-    """Normalize a team name to the pipeline canonical form.
-
-    Args:
-        name: Raw team name from the data source.
-        source: Optional source identifier (e.g. "fpl", "espn", "fbref", "fduk")
-                for source-specific overrides. Reserved for future use.
-    """
+def normalize_team(name: str) -> str:
+    """Normalize a team name to the pipeline canonical form."""
     return normalize_team_name(name)
-
-
-# Re-export for backward compatibility
-__all__ = ["normalize_team"]

--- a/scripts/team_names.py
+++ b/scripts/team_names.py
@@ -8,13 +8,6 @@ from __future__ import annotations
 
 from odds_core.team import normalize_team_name
 
-# Source-specific aliases (only entries not covered by _TEAM_ALIASES).
-_SOURCE_ALIASES: dict[str, dict[str, str]] = {
-    "fpl": {
-        "Man Utd": "Manchester Utd",
-    },
-}
-
 
 def normalize_team(name: str, source: str | None = None) -> str:
     """Normalize a team name to the pipeline canonical form.
@@ -22,12 +15,8 @@ def normalize_team(name: str, source: str | None = None) -> str:
     Args:
         name: Raw team name from the data source.
         source: Optional source identifier (e.g. "fpl", "espn", "fbref", "fduk")
-                for source-specific overrides.
+                for source-specific overrides. Reserved for future use.
     """
-    if source and source in _SOURCE_ALIASES:
-        canonical = _SOURCE_ALIASES[source].get(name)
-        if canonical:
-            return canonical
     return normalize_team_name(name)
 
 

--- a/scripts/team_names.py
+++ b/scripts/team_names.py
@@ -1,51 +1,14 @@
 """Centralized EPL team name normalization.
 
-Maps source-specific team names to pipeline canonical names (as stored in the
-events table, sourced from The Odds API). Each data source has its own alias
-dict; normalize_team() accepts an optional source parameter for source-specific
-lookups, then falls back to the shared aliases.
+Delegates to odds_core.team.normalize_team_name(). Source-specific overrides
+(e.g. FPL abbreviations) are handled here as a thin wrapper.
 """
 
 from __future__ import annotations
 
-# Pipeline canonical names (34 teams across all EPL seasons in the events table):
-#   Arsenal, Aston Villa, Bournemouth, Brentford, Brighton, Burnley, Cardiff,
-#   Chelsea, Crystal Palace, Everton, Fulham, Huddersfield, Hull, Ipswich,
-#   Leeds, Leicester, Liverpool, Luton, Manchester City, Manchester Utd,
-#   Middlesbrough, Newcastle, Norwich, Nottingham, Sheffield Utd, Southampton,
-#   Stoke, Sunderland, Swansea, Tottenham, Watford, West Brom, West Ham, Wolves
+from odds_core.team import normalize_team_name
 
-# Shared aliases that appear across multiple sources.
-_COMMON_ALIASES: dict[str, str] = {
-    "AFC Bournemouth": "Bournemouth",
-    "Brighton & Hove Albion": "Brighton",
-    "Brighton and Hove Albion": "Brighton",
-    "Cardiff City": "Cardiff",
-    "Huddersfield Town": "Huddersfield",
-    "Hull City": "Hull",
-    "Ipswich Town": "Ipswich",
-    "Leicester City": "Leicester",
-    "Leeds United": "Leeds",
-    "Man City": "Manchester City",
-    "Man United": "Manchester Utd",
-    "Manchester United": "Manchester Utd",
-    "Newcastle United": "Newcastle",
-    "Newcastle Utd": "Newcastle",
-    "Norwich City": "Norwich",
-    "Nott'm Forest": "Nottingham",
-    "Nott'ham Forest": "Nottingham",
-    "Nottingham Forest": "Nottingham",
-    "Sheffield United": "Sheffield Utd",
-    "Stoke City": "Stoke",
-    "Swansea City": "Swansea",
-    "Tottenham Hotspur": "Tottenham",
-    "Spurs": "Tottenham",
-    "West Bromwich Albion": "West Brom",
-    "West Ham United": "West Ham",
-    "Wolverhampton Wanderers": "Wolves",
-}
-
-# Source-specific aliases (only entries not covered by _COMMON_ALIASES).
+# Source-specific aliases (only entries not covered by _TEAM_ALIASES).
 _SOURCE_ALIASES: dict[str, dict[str, str]] = {
     "fpl": {
         "Man Utd": "Manchester Utd",
@@ -65,4 +28,8 @@ def normalize_team(name: str, source: str | None = None) -> str:
         canonical = _SOURCE_ALIASES[source].get(name)
         if canonical:
             return canonical
-    return _COMMON_ALIASES.get(name, name)
+    return normalize_team_name(name)
+
+
+# Re-export for backward compatibility
+__all__ = ["normalize_team"]

--- a/tests/unit/test_team_normalization.py
+++ b/tests/unit/test_team_normalization.py
@@ -1,0 +1,200 @@
+"""Tests for team name normalization and Event field validator."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from odds_core.models import Event, EventStatus
+from odds_core.team import normalize_team_name
+
+
+class TestNormalizeTeamName:
+    """Unit tests for normalize_team_name()."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            # OddsPortal aliases
+            ("Wolverhampton Wanderers", "Wolves"),
+            ("Tottenham Hotspur", "Tottenham"),
+            ("Manchester United", "Manchester Utd"),
+            ("Newcastle United", "Newcastle"),
+            ("Nottingham Forest", "Nottingham"),
+            ("Sheffield United", "Sheffield Utd"),
+            ("West Ham United", "West Ham"),
+            ("Brighton and Hove Albion", "Brighton"),
+            ("Leeds United", "Leeds"),
+            # Passthrough for canonical names
+            ("Arsenal", "Arsenal"),
+            ("Wolves", "Wolves"),
+            ("Tottenham", "Tottenham"),
+            ("Manchester Utd", "Manchester Utd"),
+            ("Brighton", "Brighton"),
+            ("Chelsea", "Chelsea"),
+            ("Liverpool", "Liverpool"),
+            # Whitespace cleanup
+            ("  manchester   united ", "Manchester Utd"),
+            ("\tArsenal\n", "Arsenal"),
+            ("  Wolverhampton   Wanderers  ", "Wolves"),
+            # Case insensitivity (title-cased before lookup)
+            ("wolverhampton wanderers", "Wolves"),
+            ("TOTTENHAM HOTSPUR", "Tottenham"),
+            ("manchester united", "Manchester Utd"),
+            # Other source variants
+            ("Brighton & Hove Albion", "Brighton"),
+            ("AFC Bournemouth", "Bournemouth"),
+            ("Leicester City", "Leicester"),
+            ("Cardiff City", "Cardiff"),
+            ("Nott'm Forest", "Nottingham"),
+            ("West Bromwich Albion", "West Brom"),
+            ("Spurs", "Tottenham"),
+        ],
+    )
+    def test_normalize(self, raw: str, expected: str) -> None:
+        assert normalize_team_name(raw) == expected
+
+    def test_unknown_team_passthrough(self) -> None:
+        assert normalize_team_name("Some Random FC") == "Some Random Fc"
+
+
+class TestEventFieldValidator:
+    """Test that Event model normalizes team names on construction."""
+
+    def test_normalizes_home_team(self) -> None:
+        event = Event(
+            id="test1",
+            sport_key="soccer_epl",
+            sport_title="EPL",
+            commence_time=datetime(2026, 1, 1, tzinfo=UTC),
+            home_team="Wolverhampton Wanderers",
+            away_team="Arsenal",
+        )
+        assert event.home_team == "Wolves"
+
+    def test_normalizes_away_team(self) -> None:
+        event = Event(
+            id="test2",
+            sport_key="soccer_epl",
+            sport_title="EPL",
+            commence_time=datetime(2026, 1, 1, tzinfo=UTC),
+            home_team="Arsenal",
+            away_team="Tottenham Hotspur",
+        )
+        assert event.away_team == "Tottenham"
+
+    def test_normalizes_both_teams(self) -> None:
+        event = Event(
+            id="test3",
+            sport_key="soccer_epl",
+            sport_title="EPL",
+            commence_time=datetime(2026, 1, 1, tzinfo=UTC),
+            home_team="Manchester United",
+            away_team="Newcastle United",
+        )
+        assert event.home_team == "Manchester Utd"
+        assert event.away_team == "Newcastle"
+
+    def test_canonical_names_unchanged(self) -> None:
+        event = Event(
+            id="test4",
+            sport_key="soccer_epl",
+            sport_title="EPL",
+            commence_time=datetime(2026, 1, 1, tzinfo=UTC),
+            home_team="Arsenal",
+            away_team="Chelsea",
+        )
+        assert event.home_team == "Arsenal"
+        assert event.away_team == "Chelsea"
+
+    def test_whitespace_cleaned(self) -> None:
+        event = Event(
+            id="test5",
+            sport_key="soccer_epl",
+            sport_title="EPL",
+            commence_time=datetime(2026, 1, 1, tzinfo=UTC),
+            home_team="  Manchester   City ",
+            away_team="Liverpool",
+        )
+        assert event.home_team == "Manchester City"
+
+
+class TestFindOrCreateEventOnWriter:
+    """Test that find_or_create_event lives on OddsWriter."""
+
+    @pytest.mark.asyncio
+    async def test_creates_event_when_none_exists(self, test_session) -> None:
+        from odds_lambda.storage.writers import OddsWriter
+
+        writer = OddsWriter(test_session)
+
+        event_id, created = await writer.find_or_create_event(
+            home_team="Arsenal",
+            away_team="Chelsea",
+            match_date=datetime(2026, 4, 15, 15, 0, tzinfo=UTC),
+            sport_key="soccer_epl",
+            sport_title="EPL",
+        )
+
+        assert created is True
+        assert event_id.startswith("op_live_")
+        assert "ARS" in event_id
+        assert "CHE" in event_id
+
+    @pytest.mark.asyncio
+    async def test_finds_existing_event(self, test_session) -> None:
+        from odds_lambda.storage.writers import OddsWriter
+
+        # Pre-create an event
+        event = Event(
+            id="existing_123",
+            sport_key="soccer_epl",
+            sport_title="EPL",
+            commence_time=datetime(2026, 4, 15, 15, 0, tzinfo=UTC),
+            home_team="Arsenal",
+            away_team="Chelsea",
+            status=EventStatus.SCHEDULED,
+        )
+        test_session.add(event)
+        await test_session.flush()
+
+        writer = OddsWriter(test_session)
+
+        event_id, created = await writer.find_or_create_event(
+            home_team="Arsenal",
+            away_team="Chelsea",
+            match_date=datetime(2026, 4, 15, 16, 0, tzinfo=UTC),
+            sport_key="soccer_epl",
+            sport_title="EPL",
+        )
+
+        assert created is False
+        assert event_id == "existing_123"
+
+    @pytest.mark.asyncio
+    async def test_idempotent_create(self, test_session) -> None:
+        from odds_lambda.storage.writers import OddsWriter
+
+        writer = OddsWriter(test_session)
+        match_date = datetime(2026, 4, 15, 15, 0, tzinfo=UTC)
+
+        event_id_1, created_1 = await writer.find_or_create_event(
+            home_team="Arsenal",
+            away_team="Chelsea",
+            match_date=match_date,
+            sport_key="soccer_epl",
+            sport_title="EPL",
+        )
+        await test_session.flush()
+
+        event_id_2, created_2 = await writer.find_or_create_event(
+            home_team="Arsenal",
+            away_team="Chelsea",
+            match_date=match_date,
+            sport_key="soccer_epl",
+            sport_title="EPL",
+        )
+
+        assert event_id_1 == event_id_2
+        assert created_1 is True
+        assert created_2 is False

--- a/tests/unit/test_team_normalization.py
+++ b/tests/unit/test_team_normalization.py
@@ -119,6 +119,40 @@ class TestEventFieldValidator:
         assert event.home_team == "Manchester City"
 
 
+class TestFindOrCreateEventNormalization:
+    """Test that find_or_create_event normalizes inputs before querying."""
+
+    @pytest.mark.asyncio
+    async def test_finds_existing_event_with_alias_input(self, test_session) -> None:
+        """Query with 'Wolverhampton Wanderers' matches DB row with 'Wolves'."""
+        from odds_lambda.storage.writers import OddsWriter
+
+        event = Event(
+            id="existing_wolves",
+            sport_key="soccer_epl",
+            sport_title="EPL",
+            commence_time=datetime(2026, 4, 15, 15, 0, tzinfo=UTC),
+            home_team="Wolves",
+            away_team="Arsenal",
+            status=EventStatus.SCHEDULED,
+        )
+        test_session.add(event)
+        await test_session.flush()
+
+        writer = OddsWriter(test_session)
+
+        event_id, created = await writer.find_or_create_event(
+            home_team="Wolverhampton Wanderers",
+            away_team="Arsenal",
+            match_date=datetime(2026, 4, 15, 16, 0, tzinfo=UTC),
+            sport_key="soccer_epl",
+            sport_title="EPL",
+        )
+
+        assert created is False
+        assert event_id == "existing_wolves"
+
+
 class TestFindOrCreateEventOnWriter:
     """Test that find_or_create_event lives on OddsWriter."""
 

--- a/tests/unit/test_team_normalization.py
+++ b/tests/unit/test_team_normalization.py
@@ -37,7 +37,7 @@ class TestNormalizeTeamName:
             ("  manchester   united ", "Manchester Utd"),
             ("\tArsenal\n", "Arsenal"),
             ("  Wolverhampton   Wanderers  ", "Wolves"),
-            # Case insensitivity (title-cased before lookup)
+            # Case insensitivity
             ("wolverhampton wanderers", "Wolves"),
             ("TOTTENHAM HOTSPUR", "Tottenham"),
             ("manchester united", "Manchester Utd"),
@@ -55,7 +55,7 @@ class TestNormalizeTeamName:
         assert normalize_team_name(raw) == expected
 
     def test_unknown_team_passthrough(self) -> None:
-        assert normalize_team_name("Some Random FC") == "Some Random Fc"
+        assert normalize_team_name("Some Random FC") == "Some Random FC"
 
 
 class TestEventFieldValidator:


### PR DESCRIPTION
## Summary
- Add `odds_core.team.normalize_team_name()` — single source of truth for mapping source-specific team names (OddsPortal, FDUK, ESPN, FBref) to canonical short forms stored in the events table
- Normalize `Event.home_team` and `Event.away_team` on construction via `model_post_init`
- Move `find_or_create_event()` and `_build_event_id()` from `fetch_oddsportal.py` to `OddsWriter` — event identity resolution is a storage concern. Inputs are normalized before querying and ID generation
- Data migration normalizes existing team names in the events table (parameterized SQL, reversible)
- Delegate `scripts/team_names.py` to the core normalization function, removing duplicate alias dicts

## Test plan
- [x] Unit tests for `normalize_team_name()` (aliases, passthrough, whitespace, case)
- [x] Unit tests for `Event` model normalization via `model_post_init`
- [x] Unit tests for `OddsWriter.find_or_create_event()` (create, find existing, idempotency)
- [x] Test for normalization-during-query path (query with alias when DB has canonical name)
- [x] CI green (1651 passed)

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)