### PR TITLE
Fix scheduler Lambda crash: move team_abbrev out of oddsharvester-dependent module

### DIFF
--- a/packages/odds-core/odds_core/__init__.py
+++ b/packages/odds-core/odds_core/__init__.py
@@ -33,7 +33,7 @@ from odds_core.polymarket_models import (
     PolymarketPriceSnapshot,
 )
 from odds_core.prediction_models import Prediction
-from odds_core.team import normalize_team_name
+from odds_core.team import normalize_team_name, team_abbrev
 
 __all__ = [
     # Models
@@ -63,6 +63,7 @@ __all__ = [
     "get_settings",
     # Team normalization
     "normalize_team_name",
+    "team_abbrev",
     # API Models
     "OddsResponse",
     "ScoresResponse",

--- a/packages/odds-core/odds_core/team.py
+++ b/packages/odds-core/odds_core/team.py
@@ -67,3 +67,16 @@ def normalize_team_name(name: str) -> str:
     if canonical is not None:
         return canonical
     return cleaned
+
+
+def team_abbrev(name: str) -> str:
+    """Derive a short abbreviation from a team name.
+
+    Single-word names get 3 chars (e.g. "Arsenal" -> "ARS").
+    Multi-word names use first 3 chars of first + last word
+    (e.g. "Manchester United" -> "MANUNI").
+    """
+    words = name.split()
+    if len(words) == 1:
+        return words[0][:3].upper()
+    return (words[0][:3] + words[-1][:3]).upper()

--- a/packages/odds-lambda/odds_lambda/oddsportal_common.py
+++ b/packages/odds-lambda/odds_lambda/oddsportal_common.py
@@ -96,19 +96,6 @@ def hours_to_tier(hours_before: float) -> str:
     return "opening"
 
 
-def team_abbrev(name: str) -> str:
-    """Derive a short abbreviation from a team name.
-
-    Single-word names get 3 chars (e.g. "Arsenal" -> "ARS").
-    Multi-word names use first 3 chars of first + last word
-    (e.g. "Manchester United" -> "MANUNI").
-    """
-    words = name.split()
-    if len(words) == 1:
-        return words[0][:3].upper()
-    return (words[0][:3] + words[-1][:3]).upper()
-
-
 def parse_odds_timestamp(ts_str: str) -> datetime:
     """Parse OddsPortal odds_history timestamp (naive, wrong year)."""
     return datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%S")

--- a/packages/odds-lambda/odds_lambda/storage/writers.py
+++ b/packages/odds-lambda/odds_lambda/storage/writers.py
@@ -6,13 +6,12 @@ from datetime import UTC, datetime, timedelta
 
 import structlog
 from odds_core.models import DataQualityLog, Event, EventStatus, FetchLog, Odds, OddsSnapshot
-from odds_core.team import normalize_team_name
+from odds_core.team import normalize_team_name, team_abbrev
 from odds_core.time import ensure_utc, parse_api_datetime
 from sqlalchemy import and_, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from odds_lambda.oddsportal_common import team_abbrev
 from odds_lambda.storage.validators import OddsValidator
 from odds_lambda.tier_utils import calculate_hours_until_commence, calculate_tier_from_timestamps
 

--- a/scripts/ingest_football_data_uk.py
+++ b/scripts/ingest_football_data_uk.py
@@ -34,12 +34,12 @@ from urllib.request import urlopen
 
 from odds_core.database import async_session_maker
 from odds_core.models import Event, EventStatus, OddsSnapshot
+from odds_core.team import team_abbrev
 from odds_lambda.oddsportal_common import (
     IngestionStats,
     decimal_to_american,
     find_existing_event,
     hours_to_tier,
-    team_abbrev,
 )
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/scripts/ingest_oddsportal.py
+++ b/scripts/ingest_oddsportal.py
@@ -38,13 +38,13 @@ from zoneinfo import ZoneInfo
 
 from odds_core.database import async_session_maker
 from odds_core.models import Event, EventStatus, OddsSnapshot
+from odds_core.team import team_abbrev
 from odds_lambda.oddsportal_common import (
     IngestionStats,
     build_raw_data,
     find_existing_event,
     hours_to_tier,
     parse_match_date,
-    team_abbrev,
 )
 from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/tests/unit/test_oddsportal_ingest.py
+++ b/tests/unit/test_oddsportal_ingest.py
@@ -7,7 +7,8 @@ from datetime import UTC, datetime
 import pytest
 
 # Import directly from script (it's on sys.path via the repo root)
-from odds_lambda.oddsportal_common import build_raw_data, team_abbrev
+from odds_core.team import team_abbrev
+from odds_lambda.oddsportal_common import build_raw_data
 
 from scripts.ingest_oddsportal import build_event_id
 


### PR DESCRIPTION
## Summary

- **Root cause**: #281 added `from odds_lambda.oddsportal_common import team_abbrev` to `storage/writers.py`. `oddsportal_common` has a top-level `from oddsharvester.core.scrape_result import ScrapeResult`, which crashes the scheduler Lambda since it doesn't bundle oddsharvester (only the scraper Lambda does).
- **Import chain**: `lambda_handler` → `odds_lambda.__init__` → `ingestion` → `storage.writers` → `oddsportal_common` → 💥 `oddsharvester`
- **Fix**: Move `team_abbrev` to `odds_core.team` (where team normalization already lives) and update all importers.

## Test plan

- [x] All 168 unit tests pass (only pre-existing `test_settings_defaults` failure)
- [x] Ruff lint + format clean
- [ ] CI/CD pipeline deploys successfully (scheduler Lambda can import `lambda_handler`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)