### PR TITLE
Fix asyncpg enum cast in stale-event migration

### DIFF
--- a/migrations/versions/d8858af1ee85_merge_duplicate_oddsportal_events.py
+++ b/migrations/versions/d8858af1ee85_merge_duplicate_oddsportal_events.py
@@ -122,9 +122,9 @@ def upgrade() -> None:
         sa.text(
             """
             UPDATE events
-            SET status = 'final', updated_at = NOW()
+            SET status = 'final'::eventstatus, updated_at = NOW()
             WHERE sport_key = 'soccer_epl'
-              AND status IN ('scheduled', 'live')
+              AND status IN ('scheduled'::eventstatus, 'live'::eventstatus)
               AND commence_time < NOW()
             """
         )
@@ -137,9 +137,9 @@ def upgrade() -> None:
         sa.text(
             """
             UPDATE events
-            SET status = 'final', updated_at = NOW()
+            SET status = 'final'::eventstatus, updated_at = NOW()
             WHERE sport_key LIKE 'basketball_nba%'
-              AND status IN ('scheduled', 'live')
+              AND status IN ('scheduled'::eventstatus, 'live'::eventstatus)
               AND commence_time < NOW()
             """
         )


### PR DESCRIPTION
## Summary

- Add `::eventstatus` casts to raw SQL in migration `d8858af1ee85` — asyncpg doesn't auto-cast string literals to PostgreSQL enum types, which caused the dev deploy to fail with `invalid input value for enum eventstatus: "scheduled"`

## Follow-up to #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)