### PR TITLE
Fix migration enum: PostgreSQL stores uppercase labels

### DIFF
--- a/migrations/versions/d8858af1ee85_merge_duplicate_oddsportal_events.py
+++ b/migrations/versions/d8858af1ee85_merge_duplicate_oddsportal_events.py
@@ -122,9 +122,9 @@ def upgrade() -> None:
         sa.text(
             """
             UPDATE events
-            SET status = 'final'::eventstatus, updated_at = NOW()
+            SET status = 'FINAL'::eventstatus, updated_at = NOW()
             WHERE sport_key = 'soccer_epl'
-              AND status IN ('scheduled'::eventstatus, 'live'::eventstatus)
+              AND status IN ('SCHEDULED'::eventstatus, 'LIVE'::eventstatus)
               AND commence_time < NOW()
             """
         )
@@ -137,9 +137,9 @@ def upgrade() -> None:
         sa.text(
             """
             UPDATE events
-            SET status = 'final'::eventstatus, updated_at = NOW()
+            SET status = 'FINAL'::eventstatus, updated_at = NOW()
             WHERE sport_key LIKE 'basketball_nba%'
-              AND status IN ('scheduled'::eventstatus, 'live'::eventstatus)
+              AND status IN ('SCHEDULED'::eventstatus, 'LIVE'::eventstatus)
               AND commence_time < NOW()
             """
         )


### PR DESCRIPTION
## Summary

- Use uppercase enum labels (`SCHEDULED`, `LIVE`, `FINAL`) in migration raw SQL — SQLAlchemy stores the Python enum `.name` not `.value` as PostgreSQL enum labels
- Previous fix (#284) added `::eventstatus` casts which was necessary but insufficient — the values themselves were wrong case
- Verified locally: merged 1 duplicate, settled 33 stale EPL + 99 stale NBA events

## Follow-up to #283, #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)