### PR TITLE
Move check-health to fixed cron, skip overnight

### DIFF
--- a/deployment/aws/terraform/eventbridge.tf
+++ b/deployment/aws/terraform/eventbridge.tf
@@ -54,10 +54,10 @@ resource "aws_cloudwatch_event_target" "fixed_scheduler_target" {
   target_id = "1"
   arn       = aws_lambda_function.odds_scheduler.arn
 
-  input = jsonencode({
-    job   = each.value.job
-    sport = each.value.sport_key
-  })
+  input = jsonencode(merge(
+    { job = each.value.job },
+    each.value.sport_key != null ? { sport = each.value.sport_key } : {}
+  ))
 }
 
 resource "aws_lambda_permission" "allow_fixed_scheduler" {
@@ -94,7 +94,7 @@ locals {
   per_sport_scraper_jobs = ["fetch-oddsportal", "fetch-oddsportal-results"]
 
   # Jobs that run once globally (no sport param)
-  global_jobs = ["update-status", "check-health"]
+  global_jobs = ["update-status"]
 
   polymarket_jobs = var.enable_polymarket ? ["fetch-polymarket"] : []
 
@@ -138,6 +138,7 @@ locals {
   fixed_schedule_expressions = {
     "daily-digest"      = "cron(0 8 * * ? *)"
     "score-predictions" = "cron(30 * * * ? *)"
+    "check-health"      = "cron(0 6-21 * * ? *)"  # Hourly, skip overnight (22:00-06:00 UTC)
   }
 
   # Per-sport fixed-schedule jobs (daily-digest, score-predictions)
@@ -151,7 +152,19 @@ locals {
     ]
   ])
 
-  fixed_scheduler_rules_map = { for r in local.sport_fixed_scheduler_rules : r.key => r }
+  # Global fixed-schedule jobs (no sport param)
+  global_fixed_scheduler_rules = [
+    for job in ["check-health"] : {
+      key       = job
+      job       = job
+      sport_key = null
+    }
+  ]
+
+  fixed_scheduler_rules_map = merge(
+    { for r in local.sport_fixed_scheduler_rules : r.key => r },
+    { for r in local.global_fixed_scheduler_rules : r.key => r },
+  )
 }
 
 resource "aws_cloudwatch_event_rule" "dynamic" {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -139,7 +139,7 @@ Centralized mapping of job names to async entry points. Modules are lazy-importe
 | `fetch-odds` | `odds_lambda.jobs.fetch_odds` | Self-scheduling (tier-based) |
 | `fetch-scores` | `odds_lambda.jobs.fetch_scores` | Self-scheduling |
 | `update-status` | `odds_lambda.jobs.update_status` | Self-scheduling |
-| `check-health` | `odds_lambda.jobs.check_health` | Self-scheduling |
+| `check-health` | `odds_lambda.jobs.check_health` | Fixed: hourly, 06:00–21:00 UTC |
 | `fetch-polymarket` | `odds_lambda.jobs.fetch_polymarket` | Self-scheduling (deprioritized) |
 | `backfill-polymarket` | `odds_lambda.jobs.backfill_polymarket` | Fixed: every 3 days (deprioritized) |
 | `fetch-oddsportal` | `odds_lambda.jobs.fetch_oddsportal` | Fixed: hourly |

--- a/packages/odds-lambda/odds_lambda/jobs/check_health.py
+++ b/packages/odds-lambda/odds_lambda/jobs/check_health.py
@@ -1,37 +1,25 @@
 """
 Health check job - standalone executable or Lambda handler.
 
-This job:
-1. Checks system health metrics (stale data, failures, quota, quality)
-2. Sends alerts when thresholds are breached
-3. Self-schedules next execution (60-minute intervals)
+Checks system health metrics (stale data, failures, quota, quality)
+and sends alerts when thresholds are breached.
 """
 
 import asyncio
 
 import structlog
-from odds_core.config import get_settings
 
 from odds_lambda.health_monitor import check_system_health
-from odds_lambda.scheduling.backends import get_scheduler_backend
 from odds_lambda.scheduling.jobs import JobContext
 
 logger = structlog.get_logger()
 
 
 async def main(ctx: JobContext) -> None:
-    """Main job execution flow.
-
-    Flow:
-    1. Run health checks
-    2. Log results
-    3. Schedule next execution (60 minutes)
-    """
+    """Run health checks and log results."""
     from odds_core.alerts import job_alert_context
 
-    app_settings = get_settings()
-
-    logger.info("health_check_job_started", backend=app_settings.scheduler.backend)
+    logger.info("health_check_job_started")
 
     async with job_alert_context("check-health"):
         health_status = await check_system_health()
@@ -53,31 +41,6 @@ async def main(ctx: JobContext) -> None:
                 issues=health_status.issues_detected,
                 alerts_sent=health_status.alerts_sent,
             )
-
-    # Self-schedule next execution (60 minutes from now)
-    try:
-        from datetime import UTC, datetime, timedelta
-
-        next_execution = datetime.now(UTC) + timedelta(minutes=60)
-
-        backend = get_scheduler_backend(dry_run=app_settings.scheduler.dry_run)
-        await backend.schedule_next_execution(job_name="check-health", next_time=next_execution)
-
-        logger.info(
-            "health_check_next_scheduled",
-            next_time=next_execution.isoformat(),
-            backend=backend.get_backend_name(),
-        )
-
-    except Exception as e:
-        logger.error("health_check_scheduling_failed", error=str(e), exc_info=True)
-
-        # Send error alert
-        from odds_core.alerts import send_error
-
-        await send_error(f"Health check scheduling failed: {type(e).__name__}: {str(e)}")
-
-        # Don't fail the job if scheduling fails - the health check itself succeeded
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Move `check-health` from self-scheduling to a fixed EventBridge cron (`0 6-21 * * ? *`) — hourly during active hours only
- Eliminates false heartbeat alerts during the 22:00–06:00 UTC overnight window when EPL scraping is paused
- Fix `fixed_scheduler_target` to conditionally include `sport` param (was passing null for global jobs)

## Test plan
- [x] Existing health monitor tests pass (24/24)
- [ ] Verify Terraform plan shows the new fixed rule and removal from dynamic rules
- [ ] Confirm no heartbeat alerts fire overnight after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)