### PR TITLE
Add match briefs model and phase 2 MCP tools

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -8,6 +8,7 @@ from odds_core.config import get_settings
 from odds_core.epl_data_models import EspnFixture, EspnLineup, FplAvailability  # noqa: F401
 from odds_core.game_log_models import NbaTeamGameLog  # noqa: F401
 from odds_core.injury_models import InjuryReport, InjuryStatus  # noqa: F401
+from odds_core.match_brief_models import MatchBrief  # noqa: F401
 
 # Import all models to ensure they're registered with SQLModel.metadata
 from odds_core.models import (  # noqa: F401

--- a/migrations/versions/f1a2b3c4d5e6_add_match_briefs_table.py
+++ b/migrations/versions/f1a2b3c4d5e6_add_match_briefs_table.py
@@ -1,0 +1,52 @@
+"""add match_briefs table
+
+Revision ID: f1a2b3c4d5e6
+Revises: d8858af1ee85
+Create Date: 2026-04-12 12:20:52.679712
+
+"""
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f1a2b3c4d5e6"
+down_revision = "d8858af1ee85"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "match_briefs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("event_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column(
+            "checkpoint",
+            sa.Enum("CONTEXT", "DECISION", name="briefcheckpoint"),
+            nullable=False,
+        ),
+        sa.Column("brief_text", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("sharp_price_at_brief", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["event_id"],
+            ["events.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_match_briefs_event_id"), "match_briefs", ["event_id"], unique=False)
+    op.create_index(
+        "ix_match_briefs_event_checkpoint",
+        "match_briefs",
+        ["event_id", "checkpoint"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_match_briefs_event_checkpoint", table_name="match_briefs")
+    op.drop_index(op.f("ix_match_briefs_event_id"), table_name="match_briefs")
+    op.drop_table("match_briefs")
+    op.execute("DROP TYPE IF EXISTS briefcheckpoint")

--- a/migrations/versions/fc55da171cdb_add_match_briefs_table.py
+++ b/migrations/versions/fc55da171cdb_add_match_briefs_table.py
@@ -1,6 +1,6 @@
 """add match_briefs table
 
-Revision ID: f1a2b3c4d5e6
+Revision ID: fc55da171cdb
 Revises: d8858af1ee85
 Create Date: 2026-04-12 12:20:52.679712
 
@@ -11,7 +11,7 @@ import sqlmodel
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "f1a2b3c4d5e6"
+revision = "fc55da171cdb"
 down_revision = "d8858af1ee85"
 branch_labels = None
 depends_on = None
@@ -24,12 +24,12 @@ def upgrade() -> None:
         sa.Column("event_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
         sa.Column(
             "checkpoint",
-            sa.Enum("CONTEXT", "DECISION", name="briefcheckpoint"),
+            sa.Enum("context", "decision", name="briefcheckpoint"),
             nullable=False,
         ),
         sa.Column("brief_text", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
         sa.Column("sharp_price_at_brief", sa.JSON(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.ForeignKeyConstraint(
             ["event_id"],
             ["events.id"],

--- a/packages/odds-core/odds_core/match_brief_models.py
+++ b/packages/odds-core/odds_core/match_brief_models.py
@@ -1,0 +1,43 @@
+"""Match brief model for cross-session agent memory."""
+
+from datetime import datetime
+from enum import Enum
+
+from sqlalchemy import JSON, Column, DateTime, Index
+from sqlmodel import Field, SQLModel
+
+from odds_core.models import utc_now
+
+
+class BriefCheckpoint(str, Enum):
+    """Checkpoint at which a brief is written."""
+
+    CONTEXT = "context"
+    DECISION = "decision"
+
+
+class MatchBrief(SQLModel, table=True):
+    """Agent-authored match analysis brief, written at a workflow checkpoint."""
+
+    __tablename__ = "match_briefs"
+
+    id: int | None = Field(default=None, primary_key=True)
+    event_id: str = Field(foreign_key="events.id", index=True)
+
+    checkpoint: BriefCheckpoint = Field(
+        description="Workflow checkpoint: context (day before) or decision (KO-90min)"
+    )
+    brief_text: str = Field(description="Freeform agent brief content")
+
+    sharp_price_at_brief: dict | None = Field(
+        sa_column=Column(JSON),
+        default=None,
+        description="Sharp bookmaker odds snapshot at time of brief creation",
+    )
+
+    created_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True)),
+        default_factory=utc_now,
+    )
+
+    __table_args__ = (Index("ix_match_briefs_event_checkpoint", "event_id", "checkpoint"),)

--- a/packages/odds-core/odds_core/match_brief_models.py
+++ b/packages/odds-core/odds_core/match_brief_models.py
@@ -2,11 +2,17 @@
 
 from datetime import datetime
 from enum import Enum
+from typing import Any
 
 from sqlalchemy import JSON, Column, DateTime, Index
 from sqlmodel import Field, SQLModel
 
 from odds_core.models import utc_now
+
+# Per-outcome sharp price entry: bookmaker key, American odds, implied probability.
+SharpPriceEntry = dict[str, Any]  # {"bookmaker": str, "price": int, "implied_prob": float}
+# Keyed by outcome name (e.g. "Arsenal", "Draw", "Chelsea").
+SharpPriceMap = dict[str, SharpPriceEntry]
 
 
 class BriefCheckpoint(str, Enum):
@@ -29,7 +35,7 @@ class MatchBrief(SQLModel, table=True):
     )
     brief_text: str = Field(description="Freeform agent brief content")
 
-    sharp_price_at_brief: dict | None = Field(
+    sharp_price_at_brief: SharpPriceMap | None = Field(
         sa_column=Column(JSON),
         default=None,
         description="Sharp bookmaker odds snapshot at time of brief creation",

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -13,7 +13,9 @@ from fastmcp import FastMCP
 from odds_analytics.backtesting import BacktestEvent
 from odds_analytics.feature_extraction import TabularFeatureExtractor
 from odds_analytics.sequence_loader import extract_odds_from_snapshot
+from odds_analytics.utils import calculate_implied_probability
 from odds_core.database import async_session_maker
+from odds_core.match_brief_models import BriefCheckpoint, MatchBrief
 from odds_core.models import Event, EventStatus, Odds, OddsSnapshot
 from odds_core.paper_trade_models import PaperTrade
 from odds_core.prediction_models import Prediction
@@ -576,6 +578,234 @@ async def settle_bets() -> dict[str, Any]:
         "settled_count": len(settled),
         "total_pnl": total_pnl,
         "settled_trades": serialized,
+    }
+
+
+def _snapshot_sharp_prices(
+    odds_list: list[Odds],
+    sharp_bookmakers: list[str],
+) -> dict[str, dict[str, Any]]:
+    """Extract current sharp bookmaker prices from an odds list.
+
+    Returns a dict keyed by outcome name, each containing the sharp bookmaker key,
+    American odds price, and implied probability.
+    """
+    result: dict[str, dict[str, Any]] = {}
+    for bm_key in sharp_bookmakers:
+        bm_odds = [o for o in odds_list if o.bookmaker_key == bm_key]
+        if not bm_odds:
+            continue
+        for o in bm_odds:
+            if o.outcome_name in result:
+                continue
+            result[o.outcome_name] = {
+                "bookmaker": bm_key,
+                "price": o.price,
+                "implied_prob": round(calculate_implied_probability(o.price), 6),
+            }
+        if result:
+            break
+    return result
+
+
+@mcp.tool()
+async def save_match_brief(
+    event_id: str,
+    brief_text: str,
+    checkpoint: Literal["context", "decision"],
+) -> dict[str, Any]:
+    """Save a structured analysis brief for an event at a workflow checkpoint.
+
+    Automatically snapshots current sharp bookmaker prices at save time.
+    Multiple briefs per event+checkpoint are allowed (agent may re-evaluate).
+
+    Args:
+        event_id: Event identifier.
+        brief_text: Freeform brief content (structure controlled by agent prompt).
+        checkpoint: Workflow checkpoint: "context" (day before) or "decision" (KO-90min).
+
+    Returns:
+        Dict with saved brief details including snapshotted sharp prices.
+    """
+    async with async_session_maker() as session:
+        reader = OddsReader(session)
+        event = await reader.get_event_by_id(event_id)
+        if event is None:
+            return {"error": f"Event '{event_id}' not found"}
+
+        # Snapshot sharp prices from the latest odds
+        sharp_prices: dict[str, dict[str, Any]] | None = None
+        snapshot = await reader.get_latest_snapshot(event_id)
+        if snapshot is not None:
+            odds = extract_odds_from_snapshot(snapshot, event_id, market="h2h")
+            if odds:
+                sharp_prices = _snapshot_sharp_prices(odds, _DEFAULT_SHARP_BOOKMAKERS)
+
+        brief = MatchBrief(
+            event_id=event_id,
+            checkpoint=BriefCheckpoint(checkpoint),
+            brief_text=brief_text,
+            sharp_price_at_brief=sharp_prices,
+        )
+        session.add(brief)
+        await session.commit()
+        await session.refresh(brief)
+
+    return {
+        "id": brief.id,
+        "event_id": brief.event_id,
+        "checkpoint": brief.checkpoint.value,
+        "brief_text": brief.brief_text,
+        "sharp_price_at_brief": brief.sharp_price_at_brief,
+        "created_at": brief.created_at.isoformat(),
+    }
+
+
+@mcp.tool()
+async def get_match_brief(
+    event_id: str,
+    checkpoint: Literal["context", "decision"] | None = None,
+) -> dict[str, Any]:
+    """Retrieve saved match briefs for an event.
+
+    Returns the most recent brief per checkpoint, or for a specific checkpoint.
+    Returns empty gracefully when no brief exists.
+
+    Args:
+        event_id: Event identifier.
+        checkpoint: If set, only return briefs for this checkpoint. Otherwise return latest per checkpoint.
+
+    Returns:
+        Dict with event info and list of matching briefs (newest first).
+    """
+    async with async_session_maker() as session:
+        reader = OddsReader(session)
+        event = await reader.get_event_by_id(event_id)
+        if event is None:
+            return {"error": f"Event '{event_id}' not found"}
+
+        query = select(MatchBrief).where(MatchBrief.event_id == event_id)
+        if checkpoint is not None:
+            query = query.where(MatchBrief.checkpoint == BriefCheckpoint(checkpoint))
+        query = query.order_by(MatchBrief.created_at.desc())
+
+        result = await session.execute(query)
+        briefs = list(result.scalars().all())
+
+    return {
+        "event": _event_to_dict(event),
+        "brief_count": len(briefs),
+        "briefs": [
+            {
+                "id": b.id,
+                "checkpoint": b.checkpoint.value,
+                "brief_text": b.brief_text,
+                "sharp_price_at_brief": b.sharp_price_at_brief,
+                "created_at": b.created_at.isoformat(),
+            }
+            for b in briefs
+        ],
+    }
+
+
+@mcp.tool()
+async def get_sharp_soft_spread(
+    event_id: str,
+    sharp_bookmakers: list[str] | None = None,
+    retail_bookmakers: list[str] | None = None,
+) -> dict[str, Any]:
+    """Get sharp vs soft bookmaker price divergence for an event.
+
+    Returns the sharp reference price, per-bookmaker soft prices, and implied
+    probability divergence for each outcome (home/draw/away).
+
+    Args:
+        event_id: Event identifier.
+        sharp_bookmakers: Sharp bookmaker keys (default: ["pinnacle", "betfair_exchange"]).
+        retail_bookmakers: Retail bookmaker keys (default: ["bet365", "betway", "betfred"]).
+
+    Returns:
+        Dict with per-outcome sharp price, soft prices, and divergence values.
+    """
+    sharp_bms = sharp_bookmakers or _DEFAULT_SHARP_BOOKMAKERS
+    retail_bms = retail_bookmakers or _DEFAULT_RETAIL_BOOKMAKERS
+
+    async with async_session_maker() as session:
+        reader = OddsReader(session)
+        event = await reader.get_event_by_id(event_id)
+        if event is None:
+            return {"error": f"Event '{event_id}' not found"}
+
+        snapshot = await reader.get_latest_snapshot(event_id)
+        if snapshot is None:
+            return {
+                "event": _event_to_dict(event),
+                "spread": None,
+                "message": "No odds snapshots available for this event",
+            }
+
+    odds = extract_odds_from_snapshot(snapshot, event_id, market="h2h")
+    if not odds:
+        return {
+            "event": _event_to_dict(event),
+            "spread": None,
+            "message": "No h2h odds in latest snapshot",
+        }
+
+    # Group odds by outcome
+    outcomes: dict[str, list[Odds]] = {}
+    for o in odds:
+        outcomes.setdefault(o.outcome_name, []).append(o)
+
+    spread: dict[str, dict[str, Any]] = {}
+    for outcome_name, outcome_odds in outcomes.items():
+        # Find sharp price (priority-ordered fallback)
+        sharp_price: int | None = None
+        sharp_bm: str | None = None
+        for bm_key in sharp_bms:
+            bm_match = [o for o in outcome_odds if o.bookmaker_key == bm_key]
+            if bm_match:
+                sharp_price = bm_match[0].price
+                sharp_bm = bm_key
+                break
+
+        sharp_prob = (
+            round(calculate_implied_probability(sharp_price), 6)
+            if sharp_price is not None
+            else None
+        )
+
+        # Collect retail bookmaker prices
+        soft_prices: list[dict[str, Any]] = []
+        for bm_key in retail_bms:
+            bm_match = [o for o in outcome_odds if o.bookmaker_key == bm_key]
+            if not bm_match:
+                continue
+            retail_price = bm_match[0].price
+            retail_prob = round(calculate_implied_probability(retail_price), 6)
+            divergence = round(retail_prob - sharp_prob, 6) if sharp_prob is not None else None
+            soft_prices.append(
+                {
+                    "bookmaker": bm_key,
+                    "price": retail_price,
+                    "implied_prob": retail_prob,
+                    "divergence": divergence,
+                }
+            )
+
+        spread[outcome_name] = {
+            "sharp": {
+                "bookmaker": sharp_bm,
+                "price": sharp_price,
+                "implied_prob": sharp_prob,
+            },
+            "soft": soft_prices,
+        }
+
+    return {
+        "event": _event_to_dict(event),
+        "snapshot_time": snapshot.snapshot_time.isoformat(),
+        "spread": spread,
     }
 
 

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -15,7 +15,7 @@ from odds_analytics.feature_extraction import TabularFeatureExtractor
 from odds_analytics.sequence_loader import extract_odds_from_snapshot
 from odds_analytics.utils import calculate_implied_probability
 from odds_core.database import async_session_maker
-from odds_core.match_brief_models import BriefCheckpoint, MatchBrief
+from odds_core.match_brief_models import BriefCheckpoint, MatchBrief, SharpPriceMap
 from odds_core.models import Event, EventStatus, Odds, OddsSnapshot
 from odds_core.paper_trade_models import PaperTrade
 from odds_core.prediction_models import Prediction
@@ -584,7 +584,7 @@ async def settle_bets() -> dict[str, Any]:
 def _snapshot_sharp_prices(
     odds_list: list[Odds],
     sharp_bookmakers: list[str],
-) -> dict[str, dict[str, Any]]:
+) -> SharpPriceMap:
     """Extract current sharp bookmaker prices from an odds list.
 
     Uses per-outcome priority fallback: each outcome independently falls through
@@ -640,7 +640,7 @@ async def save_match_brief(
             return {"error": f"Event '{event_id}' not found"}
 
         # Snapshot sharp prices from the latest odds
-        sharp_prices: dict[str, dict[str, Any]] | None = None
+        sharp_prices: SharpPriceMap | None = None
         snapshot = await reader.get_latest_snapshot(event_id)
         if snapshot is not None:
             odds = extract_odds_from_snapshot(snapshot, event_id, market="h2h")
@@ -762,28 +762,18 @@ async def get_sharp_soft_spread(
             "message": "No h2h odds in latest snapshot",
         }
 
-    # Group odds by outcome
+    # Reuse shared sharp price extraction
+    sharp_by_outcome = _snapshot_sharp_prices(odds, sharp_bms)
+
+    # Group odds by outcome for retail lookup
     outcomes: dict[str, list[Odds]] = {}
     for o in odds:
         outcomes.setdefault(o.outcome_name, []).append(o)
 
     spread: dict[str, dict[str, Any]] = {}
     for outcome_name, outcome_odds in outcomes.items():
-        # Find sharp price (priority-ordered fallback)
-        sharp_price: int | None = None
-        sharp_bm: str | None = None
-        for bm_key in sharp_bms:
-            bm_match = [o for o in outcome_odds if o.bookmaker_key == bm_key]
-            if bm_match:
-                sharp_price = bm_match[0].price
-                sharp_bm = bm_key
-                break
-
-        sharp_prob = (
-            round(calculate_implied_probability(sharp_price), 6)
-            if sharp_price is not None
-            else None
-        )
+        sharp_entry = sharp_by_outcome.get(outcome_name)
+        sharp_prob = sharp_entry["implied_prob"] if sharp_entry else None
 
         # Collect retail bookmaker prices
         soft_prices: list[dict[str, Any]] = []
@@ -804,11 +794,7 @@ async def get_sharp_soft_spread(
             )
 
         spread[outcome_name] = {
-            "sharp": {
-                "bookmaker": sharp_bm,
-                "price": sharp_price,
-                "implied_prob": sharp_prob,
-            },
+            "sharp": sharp_entry or {"bookmaker": None, "price": None, "implied_prob": None},
             "soft": soft_prices,
         }
 

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -587,24 +587,30 @@ def _snapshot_sharp_prices(
 ) -> dict[str, dict[str, Any]]:
     """Extract current sharp bookmaker prices from an odds list.
 
+    Uses per-outcome priority fallback: each outcome independently falls through
+    to the next sharp bookmaker if a higher-priority one lacks that outcome.
+
     Returns a dict keyed by outcome name, each containing the sharp bookmaker key,
     American odds price, and implied probability.
     """
     result: dict[str, dict[str, Any]] = {}
-    for bm_key in sharp_bookmakers:
-        bm_odds = [o for o in odds_list if o.bookmaker_key == bm_key]
-        if not bm_odds:
+    for o in odds_list:
+        if o.outcome_name in result:
             continue
-        for o in bm_odds:
-            if o.outcome_name in result:
-                continue
-            result[o.outcome_name] = {
-                "bookmaker": bm_key,
-                "price": o.price,
-                "implied_prob": round(calculate_implied_probability(o.price), 6),
-            }
-        if result:
-            break
+        # Find highest-priority sharp bookmaker that has this outcome
+        for bm_key in sharp_bookmakers:
+            bm_match = [
+                x
+                for x in odds_list
+                if x.bookmaker_key == bm_key and x.outcome_name == o.outcome_name
+            ]
+            if bm_match:
+                result[o.outcome_name] = {
+                    "bookmaker": bm_key,
+                    "price": bm_match[0].price,
+                    "implied_prob": round(calculate_implied_probability(bm_match[0].price), 6),
+                }
+                break
     return result
 
 
@@ -668,12 +674,12 @@ async def get_match_brief(
 ) -> dict[str, Any]:
     """Retrieve saved match briefs for an event.
 
-    Returns the most recent brief per checkpoint, or for a specific checkpoint.
+    Returns all briefs for the event, newest first. Optionally filtered by checkpoint.
     Returns empty gracefully when no brief exists.
 
     Args:
         event_id: Event identifier.
-        checkpoint: If set, only return briefs for this checkpoint. Otherwise return latest per checkpoint.
+        checkpoint: If set, only return briefs for this checkpoint.
 
     Returns:
         Dict with event info and list of matching briefs (newest first).
@@ -744,10 +750,14 @@ async def get_sharp_soft_spread(
                 "message": "No odds snapshots available for this event",
             }
 
-    odds = extract_odds_from_snapshot(snapshot, event_id, market="h2h")
+        # Extract odds and snapshot metadata inside session while ORM objects are live
+        odds = extract_odds_from_snapshot(snapshot, event_id, market="h2h")
+        snapshot_time_iso = snapshot.snapshot_time.isoformat()
+        event_dict = _event_to_dict(event)
+
     if not odds:
         return {
-            "event": _event_to_dict(event),
+            "event": event_dict,
             "spread": None,
             "message": "No h2h odds in latest snapshot",
         }
@@ -803,8 +813,8 @@ async def get_sharp_soft_spread(
         }
 
     return {
-        "event": _event_to_dict(event),
-        "snapshot_time": snapshot.snapshot_time.isoformat(),
+        "event": event_dict,
+        "snapshot_time": snapshot_time_iso,
         "spread": spread,
     }
 

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -1,0 +1,424 @@
+"""Integration tests for Phase 2 MCP tools (match briefs + sharp/soft spread)."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from odds_core.match_brief_models import BriefCheckpoint, MatchBrief
+from odds_core.models import Event, EventStatus, OddsSnapshot
+from sqlalchemy import select
+
+
+@pytest.fixture
+async def epl_event_with_odds(pglite_async_session):
+    """Create an EPL event with a snapshot containing sharp + retail bookmaker odds."""
+    commence_time = datetime(2026, 4, 15, 15, 0, tzinfo=UTC)
+
+    event = Event(
+        id="epl_test_001",
+        sport_key="soccer_epl",
+        sport_title="EPL",
+        commence_time=commence_time,
+        home_team="Arsenal",
+        away_team="Chelsea",
+        status=EventStatus.SCHEDULED,
+    )
+    pglite_async_session.add(event)
+
+    snapshot_time = commence_time - timedelta(hours=6)
+    raw_data = {
+        "bookmakers": [
+            {
+                "key": "pinnacle",
+                "title": "Pinnacle",
+                "last_update": snapshot_time.isoformat(),
+                "markets": [
+                    {
+                        "key": "h2h",
+                        "outcomes": [
+                            {"name": "Arsenal", "price": -120},
+                            {"name": "Draw", "price": 280},
+                            {"name": "Chelsea", "price": 310},
+                        ],
+                    }
+                ],
+            },
+            {
+                "key": "bet365",
+                "title": "Bet365",
+                "last_update": snapshot_time.isoformat(),
+                "markets": [
+                    {
+                        "key": "h2h",
+                        "outcomes": [
+                            {"name": "Arsenal", "price": -130},
+                            {"name": "Draw", "price": 260},
+                            {"name": "Chelsea", "price": 290},
+                        ],
+                    }
+                ],
+            },
+            {
+                "key": "betway",
+                "title": "Betway",
+                "last_update": snapshot_time.isoformat(),
+                "markets": [
+                    {
+                        "key": "h2h",
+                        "outcomes": [
+                            {"name": "Arsenal", "price": -125},
+                            {"name": "Draw", "price": 270},
+                            {"name": "Chelsea", "price": 300},
+                        ],
+                    }
+                ],
+            },
+        ]
+    }
+    snapshot = OddsSnapshot(
+        event_id=event.id,
+        snapshot_time=snapshot_time,
+        raw_data=raw_data,
+        bookmaker_count=3,
+        fetch_tier="pregame",
+        hours_until_commence=6.0,
+    )
+    pglite_async_session.add(snapshot)
+    await pglite_async_session.commit()
+    await pglite_async_session.refresh(event)
+    await pglite_async_session.refresh(snapshot)
+    return event, snapshot
+
+
+@pytest.fixture
+async def epl_event_no_odds(pglite_async_session):
+    """Create an EPL event with no snapshots."""
+    event = Event(
+        id="epl_test_002",
+        sport_key="soccer_epl",
+        sport_title="EPL",
+        commence_time=datetime(2026, 4, 16, 15, 0, tzinfo=UTC),
+        home_team="Liverpool",
+        away_team="Man City",
+        status=EventStatus.SCHEDULED,
+    )
+    pglite_async_session.add(event)
+    await pglite_async_session.commit()
+    await pglite_async_session.refresh(event)
+    return event
+
+
+@pytest.fixture
+async def partial_sharp_event(pglite_async_session):
+    """Event where pinnacle has only home odds, betfair_exchange has all three."""
+    commence_time = datetime(2026, 4, 17, 15, 0, tzinfo=UTC)
+    event = Event(
+        id="epl_test_003",
+        sport_key="soccer_epl",
+        sport_title="EPL",
+        commence_time=commence_time,
+        home_team="Tottenham",
+        away_team="Everton",
+        status=EventStatus.SCHEDULED,
+    )
+    pglite_async_session.add(event)
+
+    snapshot_time = commence_time - timedelta(hours=4)
+    raw_data = {
+        "bookmakers": [
+            {
+                "key": "pinnacle",
+                "title": "Pinnacle",
+                "last_update": snapshot_time.isoformat(),
+                "markets": [
+                    {
+                        "key": "h2h",
+                        "outcomes": [
+                            {"name": "Tottenham", "price": -150},
+                        ],
+                    }
+                ],
+            },
+            {
+                "key": "betfair_exchange",
+                "title": "Betfair Exchange",
+                "last_update": snapshot_time.isoformat(),
+                "markets": [
+                    {
+                        "key": "h2h",
+                        "outcomes": [
+                            {"name": "Tottenham", "price": -145},
+                            {"name": "Draw", "price": 260},
+                            {"name": "Everton", "price": 400},
+                        ],
+                    }
+                ],
+            },
+            {
+                "key": "bet365",
+                "title": "Bet365",
+                "last_update": snapshot_time.isoformat(),
+                "markets": [
+                    {
+                        "key": "h2h",
+                        "outcomes": [
+                            {"name": "Tottenham", "price": -160},
+                            {"name": "Draw", "price": 250},
+                            {"name": "Everton", "price": 380},
+                        ],
+                    }
+                ],
+            },
+        ]
+    }
+    snapshot = OddsSnapshot(
+        event_id=event.id,
+        snapshot_time=snapshot_time,
+        raw_data=raw_data,
+        bookmaker_count=3,
+        fetch_tier="pregame",
+        hours_until_commence=4.0,
+    )
+    pglite_async_session.add(snapshot)
+    await pglite_async_session.commit()
+    await pglite_async_session.refresh(event)
+    await pglite_async_session.refresh(snapshot)
+    return event, snapshot
+
+
+class TestSaveMatchBrief:
+    """Tests for the save_match_brief MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_save_and_retrieve_brief(self, pglite_async_session, epl_event_with_odds):
+        """save_match_brief persists a brief that get_match_brief can retrieve."""
+        event, _ = epl_event_with_odds
+
+        brief = MatchBrief(
+            event_id=event.id,
+            checkpoint=BriefCheckpoint.CONTEXT,
+            brief_text="Arsenal looking strong at home, Chelsea missing key players.",
+            sharp_price_at_brief={"Arsenal": {"bookmaker": "pinnacle", "price": -120}},
+        )
+        pglite_async_session.add(brief)
+        await pglite_async_session.commit()
+        await pglite_async_session.refresh(brief)
+
+        assert brief.id is not None
+        assert brief.event_id == event.id
+        assert brief.checkpoint == BriefCheckpoint.CONTEXT
+        assert brief.created_at is not None
+
+        # Retrieve
+        result = await pglite_async_session.execute(
+            select(MatchBrief).where(MatchBrief.event_id == event.id)
+        )
+        briefs = list(result.scalars().all())
+        assert len(briefs) == 1
+        assert (
+            briefs[0].brief_text == "Arsenal looking strong at home, Chelsea missing key players."
+        )
+        assert briefs[0].sharp_price_at_brief is not None
+
+    @pytest.mark.asyncio
+    async def test_multiple_briefs_per_checkpoint(self, pglite_async_session, epl_event_with_odds):
+        """Multiple briefs for the same event+checkpoint are allowed."""
+        event, _ = epl_event_with_odds
+
+        for i in range(3):
+            brief = MatchBrief(
+                event_id=event.id,
+                checkpoint=BriefCheckpoint.DECISION,
+                brief_text=f"Decision brief revision {i}",
+            )
+            pglite_async_session.add(brief)
+
+        await pglite_async_session.commit()
+
+        result = await pglite_async_session.execute(
+            select(MatchBrief)
+            .where(MatchBrief.event_id == event.id)
+            .where(MatchBrief.checkpoint == BriefCheckpoint.DECISION)
+        )
+        briefs = list(result.scalars().all())
+        assert len(briefs) == 3
+
+    @pytest.mark.asyncio
+    async def test_sharp_price_auto_capture(self, pglite_async_session, epl_event_with_odds):
+        """Sharp prices from the latest snapshot are captured in the brief."""
+        from odds_analytics.sequence_loader import extract_odds_from_snapshot
+        from odds_mcp.server import _snapshot_sharp_prices
+
+        event, snapshot = epl_event_with_odds
+        odds = extract_odds_from_snapshot(snapshot, event.id, market="h2h")
+        sharp_prices = _snapshot_sharp_prices(odds, ["pinnacle", "betfair_exchange"])
+
+        brief = MatchBrief(
+            event_id=event.id,
+            checkpoint=BriefCheckpoint.CONTEXT,
+            brief_text="Test brief with sharp prices",
+            sharp_price_at_brief=sharp_prices,
+        )
+        pglite_async_session.add(brief)
+        await pglite_async_session.commit()
+        await pglite_async_session.refresh(brief)
+
+        assert brief.sharp_price_at_brief is not None
+        # Pinnacle should be the sharp source for all outcomes
+        for outcome_data in brief.sharp_price_at_brief.values():
+            assert outcome_data["bookmaker"] == "pinnacle"
+            assert "price" in outcome_data
+            assert "implied_prob" in outcome_data
+
+
+class TestGetMatchBrief:
+    """Tests for the get_match_brief MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_filtering(self, pglite_async_session, epl_event_with_odds):
+        """Filtering by checkpoint returns only matching briefs."""
+        event, _ = epl_event_with_odds
+
+        context_brief = MatchBrief(
+            event_id=event.id,
+            checkpoint=BriefCheckpoint.CONTEXT,
+            brief_text="Context analysis",
+        )
+        decision_brief = MatchBrief(
+            event_id=event.id,
+            checkpoint=BriefCheckpoint.DECISION,
+            brief_text="Decision analysis",
+        )
+        pglite_async_session.add(context_brief)
+        pglite_async_session.add(decision_brief)
+        await pglite_async_session.commit()
+
+        # Filter by context
+        result = await pglite_async_session.execute(
+            select(MatchBrief)
+            .where(MatchBrief.event_id == event.id)
+            .where(MatchBrief.checkpoint == BriefCheckpoint.CONTEXT)
+        )
+        briefs = list(result.scalars().all())
+        assert len(briefs) == 1
+        assert briefs[0].brief_text == "Context analysis"
+
+        # Filter by decision
+        result = await pglite_async_session.execute(
+            select(MatchBrief)
+            .where(MatchBrief.event_id == event.id)
+            .where(MatchBrief.checkpoint == BriefCheckpoint.DECISION)
+        )
+        briefs = list(result.scalars().all())
+        assert len(briefs) == 1
+        assert briefs[0].brief_text == "Decision analysis"
+
+    @pytest.mark.asyncio
+    async def test_graceful_empty_results(self, pglite_async_session, epl_event_no_odds):
+        """Querying briefs for an event with none returns empty list."""
+        event = epl_event_no_odds
+
+        result = await pglite_async_session.execute(
+            select(MatchBrief).where(MatchBrief.event_id == event.id)
+        )
+        briefs = list(result.scalars().all())
+        assert len(briefs) == 0
+
+    @pytest.mark.asyncio
+    async def test_returns_all_briefs_newest_first(self, pglite_async_session, epl_event_with_odds):
+        """All briefs are returned, ordered newest first."""
+        event, _ = epl_event_with_odds
+
+        for i in range(3):
+            brief = MatchBrief(
+                event_id=event.id,
+                checkpoint=BriefCheckpoint.CONTEXT,
+                brief_text=f"Brief {i}",
+            )
+            pglite_async_session.add(brief)
+
+        await pglite_async_session.commit()
+
+        result = await pglite_async_session.execute(
+            select(MatchBrief)
+            .where(MatchBrief.event_id == event.id)
+            .order_by(MatchBrief.created_at.desc())
+        )
+        briefs = list(result.scalars().all())
+        assert len(briefs) == 3
+
+
+class TestSnapshotSharpPrices:
+    """Tests for _snapshot_sharp_prices helper."""
+
+    def test_per_outcome_fallback(self, partial_sharp_event):
+        """Each outcome independently falls through to next sharp bookmaker."""
+        from odds_analytics.sequence_loader import extract_odds_from_snapshot
+        from odds_mcp.server import _snapshot_sharp_prices
+
+        event, snapshot = partial_sharp_event
+        odds = extract_odds_from_snapshot(snapshot, event.id, market="h2h")
+        result = _snapshot_sharp_prices(odds, ["pinnacle", "betfair_exchange"])
+
+        # Pinnacle only has Tottenham, so home should come from pinnacle
+        assert result["Tottenham"]["bookmaker"] == "pinnacle"
+        # Draw and Everton should fall through to betfair_exchange
+        assert result["Draw"]["bookmaker"] == "betfair_exchange"
+        assert result["Everton"]["bookmaker"] == "betfair_exchange"
+
+    def test_all_outcomes_from_primary(self, epl_event_with_odds):
+        """When primary sharp has all outcomes, all come from it."""
+        from odds_analytics.sequence_loader import extract_odds_from_snapshot
+        from odds_mcp.server import _snapshot_sharp_prices
+
+        event, snapshot = epl_event_with_odds
+        odds = extract_odds_from_snapshot(snapshot, event.id, market="h2h")
+        result = _snapshot_sharp_prices(odds, ["pinnacle", "betfair_exchange"])
+
+        for outcome_data in result.values():
+            assert outcome_data["bookmaker"] == "pinnacle"
+
+    def test_empty_odds_list(self):
+        """Empty odds list returns empty dict."""
+        from odds_mcp.server import _snapshot_sharp_prices
+
+        result = _snapshot_sharp_prices([], ["pinnacle"])
+        assert result == {}
+
+
+class TestGetSharpSoftSpread:
+    """Tests for spread computation logic used by get_sharp_soft_spread."""
+
+    @pytest.mark.asyncio
+    async def test_spread_computation(self, pglite_async_session, epl_event_with_odds):
+        """Sharp vs soft spread is computed correctly with divergence values."""
+        from odds_analytics.sequence_loader import extract_odds_from_snapshot
+        from odds_analytics.utils import calculate_implied_probability
+
+        event, snapshot = epl_event_with_odds
+        odds = extract_odds_from_snapshot(snapshot, event.id, market="h2h")
+
+        # Group by outcome
+        outcomes: dict[str, list] = {}
+        for o in odds:
+            outcomes.setdefault(o.outcome_name, []).append(o)
+
+        # Verify Arsenal outcome has expected sharp/soft prices
+        arsenal_odds = outcomes["Arsenal"]
+        pinnacle_price = next(o.price for o in arsenal_odds if o.bookmaker_key == "pinnacle")
+        bet365_price = next(o.price for o in arsenal_odds if o.bookmaker_key == "bet365")
+
+        assert pinnacle_price == -120
+        assert bet365_price == -130
+
+        sharp_prob = calculate_implied_probability(-120)
+        soft_prob = calculate_implied_probability(-130)
+        assert soft_prob > sharp_prob  # bet365 implies higher prob (wider margin)
+
+    @pytest.mark.asyncio
+    async def test_no_snapshot_returns_gracefully(self, pglite_async_session, epl_event_no_odds):
+        """Event with no snapshots returns None spread with message."""
+        from odds_lambda.storage.readers import OddsReader
+
+        reader = OddsReader(pglite_async_session)
+        snapshot = await reader.get_latest_snapshot("epl_test_002")
+        assert snapshot is None

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -1,11 +1,25 @@
-"""Integration tests for Phase 2 MCP tools (match briefs + sharp/soft spread)."""
+"""Integration tests for Phase 2 MCP tools (match briefs + sharp/soft spread).
+
+Tests call the actual MCP tool handler functions end-to-end, with
+async_session_maker patched to use the PGlite test database.
+"""
 
 from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
 
 import pytest
 from odds_core.match_brief_models import BriefCheckpoint, MatchBrief
 from odds_core.models import Event, EventStatus, OddsSnapshot
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+
+@pytest.fixture
+def patch_session_maker(pglite_async_engine):
+    """Patch async_session_maker in the server module to use the PGlite engine."""
+    factory = async_sessionmaker(pglite_async_engine, expire_on_commit=False)
+    with patch("odds_mcp.server.async_session_maker", factory):
+        yield factory
 
 
 @pytest.fixture
@@ -189,162 +203,178 @@ class TestSaveMatchBrief:
     """Tests for the save_match_brief MCP tool."""
 
     @pytest.mark.asyncio
-    async def test_save_and_retrieve_brief(self, pglite_async_session, epl_event_with_odds):
-        """save_match_brief persists a brief that get_match_brief can retrieve."""
+    async def test_happy_path(self, patch_session_maker, epl_event_with_odds):
+        """save_match_brief persists a brief with auto-captured sharp prices."""
+        from odds_mcp.server import save_match_brief
+
         event, _ = epl_event_with_odds
 
-        brief = MatchBrief(
+        result = await save_match_brief(
             event_id=event.id,
-            checkpoint=BriefCheckpoint.CONTEXT,
             brief_text="Arsenal looking strong at home, Chelsea missing key players.",
-            sharp_price_at_brief={"Arsenal": {"bookmaker": "pinnacle", "price": -120}},
+            checkpoint="context",
         )
-        pglite_async_session.add(brief)
-        await pglite_async_session.commit()
-        await pglite_async_session.refresh(brief)
 
-        assert brief.id is not None
-        assert brief.event_id == event.id
-        assert brief.checkpoint == BriefCheckpoint.CONTEXT
-        assert brief.created_at is not None
-
-        # Retrieve
-        result = await pglite_async_session.execute(
-            select(MatchBrief).where(MatchBrief.event_id == event.id)
-        )
-        briefs = list(result.scalars().all())
-        assert len(briefs) == 1
+        assert "error" not in result
+        assert result["id"] is not None
+        assert result["event_id"] == event.id
+        assert result["checkpoint"] == "context"
         assert (
-            briefs[0].brief_text == "Arsenal looking strong at home, Chelsea missing key players."
+            result["brief_text"] == "Arsenal looking strong at home, Chelsea missing key players."
         )
-        assert briefs[0].sharp_price_at_brief is not None
+        assert result["created_at"] is not None
+        # Sharp prices auto-captured from snapshot
+        sharp = result["sharp_price_at_brief"]
+        assert sharp is not None
+        for outcome_data in sharp.values():
+            assert outcome_data["bookmaker"] == "pinnacle"
+            assert "price" in outcome_data
+            assert "implied_prob" in outcome_data
 
     @pytest.mark.asyncio
-    async def test_multiple_briefs_per_checkpoint(self, pglite_async_session, epl_event_with_odds):
+    async def test_event_not_found(self, patch_session_maker):
+        """save_match_brief returns error for nonexistent event."""
+        from odds_mcp.server import save_match_brief
+
+        result = await save_match_brief(
+            event_id="nonexistent_event",
+            brief_text="Should fail",
+            checkpoint="context",
+        )
+
+        assert result == {"error": "Event 'nonexistent_event' not found"}
+
+    @pytest.mark.asyncio
+    async def test_no_snapshot_still_saves(self, patch_session_maker, epl_event_no_odds):
+        """save_match_brief works with no snapshot (sharp prices will be null)."""
+        from odds_mcp.server import save_match_brief
+
+        event = epl_event_no_odds
+
+        result = await save_match_brief(
+            event_id=event.id,
+            brief_text="No odds available yet for this fixture.",
+            checkpoint="decision",
+        )
+
+        assert "error" not in result
+        assert result["id"] is not None
+        assert result["sharp_price_at_brief"] is None
+        assert result["checkpoint"] == "decision"
+
+    @pytest.mark.asyncio
+    async def test_multiple_briefs_per_checkpoint(
+        self, patch_session_maker, epl_event_with_odds, pglite_async_session
+    ):
         """Multiple briefs for the same event+checkpoint are allowed."""
+        from odds_mcp.server import save_match_brief
+
         event, _ = epl_event_with_odds
 
+        ids = []
         for i in range(3):
-            brief = MatchBrief(
+            result = await save_match_brief(
                 event_id=event.id,
-                checkpoint=BriefCheckpoint.DECISION,
                 brief_text=f"Decision brief revision {i}",
+                checkpoint="decision",
             )
-            pglite_async_session.add(brief)
+            assert "error" not in result
+            ids.append(result["id"])
 
-        await pglite_async_session.commit()
+        # All have distinct IDs
+        assert len(set(ids)) == 3
 
-        result = await pglite_async_session.execute(
+        # Verify via DB
+        db_result = await pglite_async_session.execute(
             select(MatchBrief)
             .where(MatchBrief.event_id == event.id)
             .where(MatchBrief.checkpoint == BriefCheckpoint.DECISION)
         )
-        briefs = list(result.scalars().all())
-        assert len(briefs) == 3
-
-    @pytest.mark.asyncio
-    async def test_sharp_price_auto_capture(self, pglite_async_session, epl_event_with_odds):
-        """Sharp prices from the latest snapshot are captured in the brief."""
-        from odds_analytics.sequence_loader import extract_odds_from_snapshot
-        from odds_mcp.server import _snapshot_sharp_prices
-
-        event, snapshot = epl_event_with_odds
-        odds = extract_odds_from_snapshot(snapshot, event.id, market="h2h")
-        sharp_prices = _snapshot_sharp_prices(odds, ["pinnacle", "betfair_exchange"])
-
-        brief = MatchBrief(
-            event_id=event.id,
-            checkpoint=BriefCheckpoint.CONTEXT,
-            brief_text="Test brief with sharp prices",
-            sharp_price_at_brief=sharp_prices,
-        )
-        pglite_async_session.add(brief)
-        await pglite_async_session.commit()
-        await pglite_async_session.refresh(brief)
-
-        assert brief.sharp_price_at_brief is not None
-        # Pinnacle should be the sharp source for all outcomes
-        for outcome_data in brief.sharp_price_at_brief.values():
-            assert outcome_data["bookmaker"] == "pinnacle"
-            assert "price" in outcome_data
-            assert "implied_prob" in outcome_data
+        assert len(list(db_result.scalars().all())) == 3
 
 
 class TestGetMatchBrief:
     """Tests for the get_match_brief MCP tool."""
 
     @pytest.mark.asyncio
-    async def test_checkpoint_filtering(self, pglite_async_session, epl_event_with_odds):
-        """Filtering by checkpoint returns only matching briefs."""
+    async def test_retrieve_after_save(self, patch_session_maker, epl_event_with_odds):
+        """get_match_brief retrieves briefs saved by save_match_brief."""
+        from odds_mcp.server import get_match_brief, save_match_brief
+
         event, _ = epl_event_with_odds
 
-        context_brief = MatchBrief(
+        await save_match_brief(
             event_id=event.id,
-            checkpoint=BriefCheckpoint.CONTEXT,
-            brief_text="Context analysis",
+            brief_text="Context analysis for Arsenal vs Chelsea.",
+            checkpoint="context",
         )
-        decision_brief = MatchBrief(
-            event_id=event.id,
-            checkpoint=BriefCheckpoint.DECISION,
-            brief_text="Decision analysis",
-        )
-        pglite_async_session.add(context_brief)
-        pglite_async_session.add(decision_brief)
-        await pglite_async_session.commit()
 
-        # Filter by context
-        result = await pglite_async_session.execute(
-            select(MatchBrief)
-            .where(MatchBrief.event_id == event.id)
-            .where(MatchBrief.checkpoint == BriefCheckpoint.CONTEXT)
-        )
-        briefs = list(result.scalars().all())
-        assert len(briefs) == 1
-        assert briefs[0].brief_text == "Context analysis"
+        result = await get_match_brief(event_id=event.id)
 
-        # Filter by decision
-        result = await pglite_async_session.execute(
-            select(MatchBrief)
-            .where(MatchBrief.event_id == event.id)
-            .where(MatchBrief.checkpoint == BriefCheckpoint.DECISION)
-        )
-        briefs = list(result.scalars().all())
-        assert len(briefs) == 1
-        assert briefs[0].brief_text == "Decision analysis"
+        assert "error" not in result
+        assert result["brief_count"] == 1
+        assert result["briefs"][0]["brief_text"] == "Context analysis for Arsenal vs Chelsea."
+        assert result["event"]["id"] == event.id
 
     @pytest.mark.asyncio
-    async def test_graceful_empty_results(self, pglite_async_session, epl_event_no_odds):
+    async def test_checkpoint_filtering(self, patch_session_maker, epl_event_with_odds):
+        """Filtering by checkpoint returns only matching briefs."""
+        from odds_mcp.server import get_match_brief, save_match_brief
+
+        event, _ = epl_event_with_odds
+
+        await save_match_brief(
+            event_id=event.id, brief_text="Context analysis", checkpoint="context"
+        )
+        await save_match_brief(
+            event_id=event.id, brief_text="Decision analysis", checkpoint="decision"
+        )
+
+        context_result = await get_match_brief(event_id=event.id, checkpoint="context")
+        assert context_result["brief_count"] == 1
+        assert context_result["briefs"][0]["brief_text"] == "Context analysis"
+
+        decision_result = await get_match_brief(event_id=event.id, checkpoint="decision")
+        assert decision_result["brief_count"] == 1
+        assert decision_result["briefs"][0]["brief_text"] == "Decision analysis"
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self, patch_session_maker, epl_event_no_odds):
         """Querying briefs for an event with none returns empty list."""
+        from odds_mcp.server import get_match_brief
+
         event = epl_event_no_odds
 
-        result = await pglite_async_session.execute(
-            select(MatchBrief).where(MatchBrief.event_id == event.id)
-        )
-        briefs = list(result.scalars().all())
-        assert len(briefs) == 0
+        result = await get_match_brief(event_id=event.id)
+
+        assert "error" not in result
+        assert result["brief_count"] == 0
+        assert result["briefs"] == []
 
     @pytest.mark.asyncio
-    async def test_returns_all_briefs_newest_first(self, pglite_async_session, epl_event_with_odds):
-        """All briefs are returned, ordered newest first."""
+    async def test_newest_first_ordering(self, patch_session_maker, epl_event_with_odds):
+        """Briefs are returned newest first."""
+        from odds_mcp.server import get_match_brief, save_match_brief
+
         event, _ = epl_event_with_odds
 
         for i in range(3):
-            brief = MatchBrief(
-                event_id=event.id,
-                checkpoint=BriefCheckpoint.CONTEXT,
-                brief_text=f"Brief {i}",
-            )
-            pglite_async_session.add(brief)
+            await save_match_brief(event_id=event.id, brief_text=f"Brief {i}", checkpoint="context")
 
-        await pglite_async_session.commit()
+        result = await get_match_brief(event_id=event.id)
 
-        result = await pglite_async_session.execute(
-            select(MatchBrief)
-            .where(MatchBrief.event_id == event.id)
-            .order_by(MatchBrief.created_at.desc())
-        )
-        briefs = list(result.scalars().all())
-        assert len(briefs) == 3
+        assert result["brief_count"] == 3
+        # Newest first: Brief 2 should be first
+        assert result["briefs"][0]["brief_text"] == "Brief 2"
+        assert result["briefs"][2]["brief_text"] == "Brief 0"
+
+    @pytest.mark.asyncio
+    async def test_event_not_found(self, patch_session_maker):
+        """get_match_brief returns error for nonexistent event."""
+        from odds_mcp.server import get_match_brief
+
+        result = await get_match_brief(event_id="nonexistent_event")
+        assert result == {"error": "Event 'nonexistent_event' not found"}
 
 
 class TestSnapshotSharpPrices:
@@ -386,39 +416,71 @@ class TestSnapshotSharpPrices:
 
 
 class TestGetSharpSoftSpread:
-    """Tests for spread computation logic used by get_sharp_soft_spread."""
+    """Tests for the get_sharp_soft_spread MCP tool."""
 
     @pytest.mark.asyncio
-    async def test_spread_computation(self, pglite_async_session, epl_event_with_odds):
+    async def test_happy_path(self, patch_session_maker, epl_event_with_odds):
         """Sharp vs soft spread is computed correctly with divergence values."""
-        from odds_analytics.sequence_loader import extract_odds_from_snapshot
-        from odds_analytics.utils import calculate_implied_probability
+        from odds_mcp.server import get_sharp_soft_spread
 
-        event, snapshot = epl_event_with_odds
-        odds = extract_odds_from_snapshot(snapshot, event.id, market="h2h")
+        event, _ = epl_event_with_odds
 
-        # Group by outcome
-        outcomes: dict[str, list] = {}
-        for o in odds:
-            outcomes.setdefault(o.outcome_name, []).append(o)
+        result = await get_sharp_soft_spread(event_id=event.id)
 
-        # Verify Arsenal outcome has expected sharp/soft prices
-        arsenal_odds = outcomes["Arsenal"]
-        pinnacle_price = next(o.price for o in arsenal_odds if o.bookmaker_key == "pinnacle")
-        bet365_price = next(o.price for o in arsenal_odds if o.bookmaker_key == "bet365")
+        assert "error" not in result
+        assert result["event"]["id"] == event.id
+        assert result["snapshot_time"] is not None
+        spread = result["spread"]
+        assert spread is not None
 
-        assert pinnacle_price == -120
-        assert bet365_price == -130
+        # Check Arsenal outcome
+        arsenal = spread["Arsenal"]
+        assert arsenal["sharp"]["bookmaker"] == "pinnacle"
+        assert arsenal["sharp"]["price"] == -120
+        assert arsenal["sharp"]["implied_prob"] is not None
 
-        sharp_prob = calculate_implied_probability(-120)
-        soft_prob = calculate_implied_probability(-130)
-        assert soft_prob > sharp_prob  # bet365 implies higher prob (wider margin)
+        # Check retail bookmakers present
+        soft_bms = {s["bookmaker"] for s in arsenal["soft"]}
+        assert "bet365" in soft_bms
+        assert "betway" in soft_bms
+
+        # Divergence should be computed
+        for soft_entry in arsenal["soft"]:
+            assert soft_entry["divergence"] is not None
 
     @pytest.mark.asyncio
-    async def test_no_snapshot_returns_gracefully(self, pglite_async_session, epl_event_no_odds):
+    async def test_no_snapshot_graceful(self, patch_session_maker, epl_event_no_odds):
         """Event with no snapshots returns None spread with message."""
-        from odds_lambda.storage.readers import OddsReader
+        from odds_mcp.server import get_sharp_soft_spread
 
-        reader = OddsReader(pglite_async_session)
-        snapshot = await reader.get_latest_snapshot("epl_test_002")
-        assert snapshot is None
+        event = epl_event_no_odds
+
+        result = await get_sharp_soft_spread(event_id=event.id)
+
+        assert "error" not in result
+        assert result["spread"] is None
+        assert "message" in result
+
+    @pytest.mark.asyncio
+    async def test_event_not_found(self, patch_session_maker):
+        """get_sharp_soft_spread returns error for nonexistent event."""
+        from odds_mcp.server import get_sharp_soft_spread
+
+        result = await get_sharp_soft_spread(event_id="nonexistent_event")
+        assert result == {"error": "Event 'nonexistent_event' not found"}
+
+    @pytest.mark.asyncio
+    async def test_per_outcome_sharp_fallback(self, patch_session_maker, partial_sharp_event):
+        """Sharp prices fall through per-outcome (reuses _snapshot_sharp_prices)."""
+        from odds_mcp.server import get_sharp_soft_spread
+
+        event, _ = partial_sharp_event
+
+        result = await get_sharp_soft_spread(event_id=event.id)
+
+        spread = result["spread"]
+        # Tottenham from pinnacle (higher priority)
+        assert spread["Tottenham"]["sharp"]["bookmaker"] == "pinnacle"
+        # Draw/Everton fall through to betfair_exchange
+        assert spread["Draw"]["sharp"]["bookmaker"] == "betfair_exchange"
+        assert spread["Everton"]["sharp"]["bookmaker"] == "betfair_exchange"


### PR DESCRIPTION
## Summary
- Add `MatchBrief` SQLModel with `BriefCheckpoint` enum (`context`/`decision`) and Alembic migration
- Add `save_match_brief` MCP tool — persists briefs with auto-captured sharp prices (Pinnacle/Betfair Exchange priority fallback)
- Add `get_match_brief` MCP tool — retrieves briefs newest-first, optionally filtered by checkpoint
- Add `get_sharp_soft_spread` MCP tool — returns per-outcome sharp vs retail bookmaker price divergence
- Per-outcome sharp bookmaker fallback in `_snapshot_sharp_prices` (not per-bookmaker)
- Integration tests for all new tools and helpers

## Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)