### PR TITLE
Fix MCP tools returning empty data when totals snapshot is newer than h2h

### DIFF
--- a/packages/odds-analytics/odds_analytics/feature_groups.py
+++ b/packages/odds-analytics/odds_analytics/feature_groups.py
@@ -36,6 +36,7 @@ from odds_core.polymarket_models import (
     PolymarketOrderBookSnapshot,
     PolymarketPriceSnapshot,
 )
+from odds_core.utils import raw_data_has_market
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -117,18 +118,6 @@ class EventDataBundle:
     sequences: list[list[Odds]] = field(default_factory=list)
 
 
-def _snapshot_has_market(snapshot: OddsSnapshot, market: str) -> bool:
-    """Check if a snapshot's raw_data contains data for the given market key."""
-    raw = snapshot.raw_data
-    if not raw or "bookmakers" not in raw:
-        return False
-    for bm in raw["bookmakers"]:
-        for mkt in bm.get("markets", []):
-            if mkt.get("key") == market:
-                return True
-    return False
-
-
 def snapshot_has_bookmaker(snapshot: OddsSnapshot, bookmaker_key: str, market: str) -> bool:
     """Check if a snapshot's raw_data contains odds from a specific bookmaker for a market."""
     raw = snapshot.raw_data
@@ -179,7 +168,7 @@ async def collect_event_data(
     # doesn't pick snapshots with data for a different market (e.g. h2h
     # snapshot when we need totals).
     market = config.primary_market
-    all_snapshots = [s for s in all_snapshots_raw if _snapshot_has_market(s, market)]
+    all_snapshots = [s for s in all_snapshots_raw if raw_data_has_market(s.raw_data, market)]
 
     # Derive closing snapshot from already-loaded snapshots (avoid extra DB query)
     closing_tier_value = config.closing_tier.value

--- a/packages/odds-core/odds_core/utils.py
+++ b/packages/odds-core/odds_core/utils.py
@@ -1,0 +1,17 @@
+"""Shared utility functions for odds pipeline."""
+
+from typing import Any
+
+
+def raw_data_has_market(raw_data: dict[str, Any] | None, market: str) -> bool:
+    """Check if raw_data JSON contains data for the given market key.
+
+    Iterates bookmakers -> markets -> key to find a match.
+    """
+    if not raw_data:
+        return False
+    for bookmaker in raw_data.get("bookmakers", []):
+        for m in bookmaker.get("markets", []):
+            if m.get("key") == market:
+                return True
+    return False

--- a/packages/odds-lambda/odds_lambda/storage/readers.py
+++ b/packages/odds-lambda/odds_lambda/storage/readers.py
@@ -6,22 +6,13 @@ from datetime import UTC, datetime, timedelta
 
 import structlog
 from odds_core.models import DataQualityLog, Event, EventStatus, FetchLog, Odds, OddsSnapshot
+from odds_core.utils import raw_data_has_market
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from odds_lambda.fetch_tier import FetchTier
 
 logger = structlog.get_logger()
-
-
-def _snapshot_has_market(snapshot: OddsSnapshot, market: str) -> bool:
-    """Check whether a snapshot's raw_data contains the given market key."""
-    raw = snapshot.raw_data or {}
-    for bookmaker in raw.get("bookmakers", []):
-        for m in bookmaker.get("markets", []):
-            if m.get("key") == market:
-                return True
-    return False
 
 
 class OddsReader:
@@ -316,7 +307,7 @@ class OddsReader:
 
         result = await self.session.execute(query)
         for snapshot in result.scalars():
-            if _snapshot_has_market(snapshot, market):
+            if raw_data_has_market(snapshot.raw_data, market):
                 return snapshot
         return None
 

--- a/packages/odds-lambda/odds_lambda/storage/readers.py
+++ b/packages/odds-lambda/odds_lambda/storage/readers.py
@@ -14,6 +14,16 @@ from odds_lambda.fetch_tier import FetchTier
 logger = structlog.get_logger()
 
 
+def _snapshot_has_market(snapshot: OddsSnapshot, market: str) -> bool:
+    """Check whether a snapshot's raw_data contains the given market key."""
+    raw = snapshot.raw_data or {}
+    for bookmaker in raw.get("bookmakers", []):
+        for m in bookmaker.get("markets", []):
+            if m.get("key") == market:
+                return True
+    return False
+
+
 class OddsReader:
     """Handles all read operations from the database."""
 
@@ -280,12 +290,16 @@ class OddsReader:
         result = await self.session.execute(query)
         return result.scalars().first()
 
-    async def get_latest_snapshot(self, event_id: str) -> OddsSnapshot | None:
+    async def get_latest_snapshot(
+        self, event_id: str, *, market: str | None = None
+    ) -> OddsSnapshot | None:
         """
         Get most recent odds snapshot for an event.
 
         Args:
             event_id: Event identifier
+            market: If provided, only return snapshots containing this market key
+                (e.g. "h2h", "totals") in raw_data->bookmakers->markets.
 
         Returns:
             Latest OddsSnapshot or None
@@ -294,11 +308,17 @@ class OddsReader:
             select(OddsSnapshot)
             .where(OddsSnapshot.event_id == event_id)
             .order_by(OddsSnapshot.snapshot_time.desc())
-            .limit(1)
         )
 
+        if market is None:
+            result = await self.session.execute(query.limit(1))
+            return result.scalar_one_or_none()
+
         result = await self.session.execute(query)
-        return result.scalar_one_or_none()
+        for snapshot in result.scalars():
+            if _snapshot_has_market(snapshot, market):
+                return snapshot
+        return None
 
     async def snapshot_exists(
         self, event_id: str, snapshot_time: datetime, tolerance_minutes: int = 5

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -194,7 +194,7 @@ async def get_current_odds(
         if event is None:
             return {"error": f"Event '{event_id}' not found"}
 
-        snapshot = await reader.get_latest_snapshot(event_id)
+        snapshot = await reader.get_latest_snapshot(event_id, market="h2h")
         if snapshot is None:
             return {
                 "event": _event_to_dict(event),
@@ -378,7 +378,7 @@ async def get_event_features(
         if event is None:
             return {"error": f"Event '{event_id}' not found"}
 
-        snapshot = await reader.get_latest_snapshot(event_id)
+        snapshot = await reader.get_latest_snapshot(event_id, market="h2h")
         if snapshot is None:
             return {
                 "event": _event_to_dict(event),
@@ -641,7 +641,7 @@ async def save_match_brief(
 
         # Snapshot sharp prices from the latest odds
         sharp_prices: SharpPriceMap | None = None
-        snapshot = await reader.get_latest_snapshot(event_id)
+        snapshot = await reader.get_latest_snapshot(event_id, market="h2h")
         if snapshot is not None:
             odds = extract_odds_from_snapshot(snapshot, event_id, market="h2h")
             if odds:
@@ -742,7 +742,7 @@ async def get_sharp_soft_spread(
         if event is None:
             return {"error": f"Event '{event_id}' not found"}
 
-        snapshot = await reader.get_latest_snapshot(event_id)
+        snapshot = await reader.get_latest_snapshot(event_id, market="h2h")
         if snapshot is None:
             return {
                 "event": _event_to_dict(event),

--- a/tests/unit/test_snapshot_market_filter.py
+++ b/tests/unit/test_snapshot_market_filter.py
@@ -1,0 +1,130 @@
+"""Tests for get_latest_snapshot market filtering."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from odds_core.models import Event, EventStatus, OddsSnapshot
+from odds_lambda.storage.readers import OddsReader
+
+
+def _make_event(event_id: str = "test_event_1") -> Event:
+    return Event(
+        id=event_id,
+        sport_key="soccer_epl",
+        sport_title="EPL",
+        commence_time=datetime(2026, 4, 13, 15, 0, tzinfo=UTC),
+        home_team="Man Utd",
+        away_team="Leeds",
+        status=EventStatus.SCHEDULED,
+    )
+
+
+def _make_snapshot(
+    event_id: str,
+    snapshot_time: datetime,
+    market_key: str,
+) -> OddsSnapshot:
+    return OddsSnapshot(
+        event_id=event_id,
+        snapshot_time=snapshot_time,
+        raw_data={
+            "bookmakers": [
+                {
+                    "key": "bet365",
+                    "title": "Bet365",
+                    "last_update": snapshot_time.isoformat(),
+                    "markets": [
+                        {
+                            "key": market_key,
+                            "outcomes": [
+                                {"name": "Man Utd", "price": 1.80},
+                                {"name": "Draw", "price": 3.50},
+                                {"name": "Leeds", "price": 4.20},
+                            ],
+                        }
+                    ],
+                }
+            ],
+            "source": "oddsportal_live",
+        },
+        bookmaker_count=1,
+    )
+
+
+class TestGetLatestSnapshotMarketFilter:
+    """get_latest_snapshot with market parameter filters by raw_data market key."""
+
+    @pytest.mark.asyncio
+    async def test_returns_h2h_when_newer_totals_exists(self, test_session):
+        event = _make_event()
+        test_session.add(event)
+        await test_session.flush()
+
+        t_base = datetime(2026, 4, 13, 10, 0, tzinfo=UTC)
+        h2h_snap = _make_snapshot(event.id, t_base, "h2h")
+        totals_snap = _make_snapshot(event.id, t_base + timedelta(minutes=30), "totals")
+
+        test_session.add_all([h2h_snap, totals_snap])
+        await test_session.flush()
+
+        reader = OddsReader(test_session)
+        result = await reader.get_latest_snapshot(event.id, market="h2h")
+
+        assert result is not None
+        assert result.id == h2h_snap.id
+
+    @pytest.mark.asyncio
+    async def test_without_market_returns_newest(self, test_session):
+        event = _make_event()
+        test_session.add(event)
+        await test_session.flush()
+
+        t_base = datetime(2026, 4, 13, 10, 0, tzinfo=UTC)
+        h2h_snap = _make_snapshot(event.id, t_base, "h2h")
+        totals_snap = _make_snapshot(event.id, t_base + timedelta(minutes=30), "totals")
+
+        test_session.add_all([h2h_snap, totals_snap])
+        await test_session.flush()
+
+        reader = OddsReader(test_session)
+        result = await reader.get_latest_snapshot(event.id)
+
+        assert result is not None
+        assert result.id == totals_snap.id
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_market_not_present(self, test_session):
+        event = _make_event()
+        test_session.add(event)
+        await test_session.flush()
+
+        t_base = datetime(2026, 4, 13, 10, 0, tzinfo=UTC)
+        totals_snap = _make_snapshot(event.id, t_base, "totals")
+
+        test_session.add(totals_snap)
+        await test_session.flush()
+
+        reader = OddsReader(test_session)
+        result = await reader.get_latest_snapshot(event.id, market="h2h")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_most_recent_matching_market(self, test_session):
+        event = _make_event()
+        test_session.add(event)
+        await test_session.flush()
+
+        t_base = datetime(2026, 4, 13, 10, 0, tzinfo=UTC)
+        old_h2h = _make_snapshot(event.id, t_base, "h2h")
+        new_h2h = _make_snapshot(event.id, t_base + timedelta(hours=1), "h2h")
+        totals_snap = _make_snapshot(event.id, t_base + timedelta(hours=2), "totals")
+
+        test_session.add_all([old_h2h, new_h2h, totals_snap])
+        await test_session.flush()
+
+        reader = OddsReader(test_session)
+        result = await reader.get_latest_snapshot(event.id, market="h2h")
+
+        assert result is not None
+        assert result.id == new_h2h.id


### PR DESCRIPTION
## Summary
- Add `market` filter parameter to `OddsReader.get_latest_snapshot()` — when provided, returns the most recent snapshot containing that market in `raw_data`, skipping non-matching snapshots (e.g. totals-only)
- Update all 4 affected MCP tool call sites (`get_current_odds`, `get_sharp_soft_spread`, `get_event_features`, `save_match_brief`) to pass `market="h2h"`
- Extract shared `raw_data_has_market()` helper into `odds_core.utils` to deduplicate logic that existed in both `readers.py` and `feature_groups.py`
- Backwards compatible: `get_latest_snapshot(event_id)` without `market` retains existing behaviour

## Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)