### PR TITLE
Fix BriefCheckpoint enum case mismatch in PostgreSQL

### DIFF
--- a/migrations/versions/771d5b1b451c_fix_briefcheckpoint_enum_labels_to_.py
+++ b/migrations/versions/771d5b1b451c_fix_briefcheckpoint_enum_labels_to_.py
@@ -1,19 +1,15 @@
 """fix briefcheckpoint enum labels to uppercase
 
-SQLAlchemy sends the Python enum .name (CONTEXT, DECISION) not .value
-(context, decision). The initial migration created lowercase labels,
-causing InvalidTextRepresentationError on insert.
-
-Revision ID: a1b2c3d4e5f6
+Revision ID: 771d5b1b451c
 Revises: fc55da171cdb
-Create Date: 2026-04-12 21:00:00.000000
+Create Date: 2026-04-12 20:48:32.183640
 
 """
 
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "a1b2c3d4e5f6"
+revision = "771d5b1b451c"
 down_revision = "fc55da171cdb"
 branch_labels = None
 depends_on = None

--- a/migrations/versions/a1b2c3d4e5f6_fix_briefcheckpoint_enum_case.py
+++ b/migrations/versions/a1b2c3d4e5f6_fix_briefcheckpoint_enum_case.py
@@ -1,0 +1,29 @@
+"""fix briefcheckpoint enum labels to uppercase
+
+SQLAlchemy sends the Python enum .name (CONTEXT, DECISION) not .value
+(context, decision). The initial migration created lowercase labels,
+causing InvalidTextRepresentationError on insert.
+
+Revision ID: a1b2c3d4e5f6
+Revises: fc55da171cdb
+Create Date: 2026-04-12 21:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "fc55da171cdb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE briefcheckpoint RENAME VALUE 'context' TO 'CONTEXT'")
+    op.execute("ALTER TYPE briefcheckpoint RENAME VALUE 'decision' TO 'DECISION'")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TYPE briefcheckpoint RENAME VALUE 'CONTEXT' TO 'context'")
+    op.execute("ALTER TYPE briefcheckpoint RENAME VALUE 'DECISION' TO 'decision'")

--- a/migrations/versions/fc55da171cdb_add_match_briefs_table.py
+++ b/migrations/versions/fc55da171cdb_add_match_briefs_table.py
@@ -24,7 +24,7 @@ def upgrade() -> None:
         sa.Column("event_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
         sa.Column(
             "checkpoint",
-            sa.Enum("context", "decision", name="briefcheckpoint"),
+            sa.Enum("CONTEXT", "DECISION", name="briefcheckpoint"),
             nullable=False,
         ),
         sa.Column("brief_text", sqlmodel.sql.sqltypes.AutoString(), nullable=False),


### PR DESCRIPTION
## Summary
- Fix `save_match_brief` failing with `InvalidTextRepresentationError` due to PostgreSQL receiving lowercase enum labels while SQLAlchemy sends uppercase `.name` values
- Add migration to rename existing `briefcheckpoint` enum labels from lowercase to uppercase (`context` → `CONTEXT`, `decision` → `DECISION`)
- Fix original migration (`fc55da171cdb`) to use uppercase labels so fresh installs are correct from the start

## Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)