### PR TITLE
Add API-Football confirmed lineup MCP tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,12 @@ MARKETS=h2h,spreads,totals
 REGIONS=us
 
 # =============================================================================
+# API-FOOTBALL (api-sports.io) — confirmed lineups
+# =============================================================================
+# Free tier: 100 req/day, 10 req/min. Sign up at api-football.com
+API_FOOTBALL_KEY=
+
+# =============================================================================
 # DATA QUALITY
 # =============================================================================
 # Enable validation checks (default: true)

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -5,7 +5,12 @@ from logging.config import fileConfig
 
 from alembic import context
 from odds_core.config import get_settings
-from odds_core.epl_data_models import EspnFixture, EspnLineup, FplAvailability  # noqa: F401
+from odds_core.epl_data_models import (  # noqa: F401
+    ApiFootballLineup,
+    EspnFixture,
+    EspnLineup,
+    FplAvailability,
+)
 from odds_core.game_log_models import NbaTeamGameLog  # noqa: F401
 from odds_core.injury_models import InjuryReport, InjuryStatus  # noqa: F401
 from odds_core.match_brief_models import MatchBrief  # noqa: F401

--- a/migrations/versions/b44debb4b677_add_api_football_lineups_table.py
+++ b/migrations/versions/b44debb4b677_add_api_football_lineups_table.py
@@ -1,0 +1,51 @@
+"""add api_football_lineups table
+
+Revision ID: b44debb4b677
+Revises: 771d5b1b451c
+Create Date: 2026-04-12 23:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b44debb4b677"
+down_revision = "771d5b1b451c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "api_football_lineups",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("event_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("fixture_id", sa.Integer(), nullable=False),
+        sa.Column("team_name", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("team_id", sa.Integer(), nullable=False),
+        sa.Column("formation", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("coach", sa.JSON(), nullable=True),
+        sa.Column("start_xi", sa.JSON(), nullable=False),
+        sa.Column("substitutes", sa.JSON(), nullable=False),
+        sa.Column("fetched_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("fixture_id", "team_id", name="uq_api_football_lineup_fixture_team"),
+    )
+    op.create_index("ix_api_football_lineup_event", "api_football_lineups", ["event_id"])
+    op.create_index(
+        op.f("ix_api_football_lineups_fixture_id"), "api_football_lineups", ["fixture_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_api_football_lineups_fixture_id"), table_name="api_football_lineups")
+    op.drop_index("ix_api_football_lineup_event", table_name="api_football_lineups")
+    op.drop_table("api_football_lineups")

--- a/packages/odds-core/odds_core/config.py
+++ b/packages/odds-core/odds_core/config.py
@@ -206,6 +206,21 @@ class PolymarketConfig(BaseSettings):
     )
 
 
+class ApiFootballConfig(BaseSettings):
+    """API-Football (api-sports.io) configuration."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="API_FOOTBALL_", env_file=".env", env_file_encoding="utf-8", extra="ignore"
+    )
+
+    key: str | None = Field(default=None, description="API-Football API key")
+    base_url: str = Field(
+        default="https://v3.football.api-sports.io",
+        description="API-Football v3 base URL",
+    )
+    epl_league_id: int = Field(default=39, description="API-Football EPL league ID")
+
+
 class LoggingConfig(BaseSettings):
     """Logging configuration."""
 
@@ -243,6 +258,7 @@ class Settings(BaseSettings):
     alerts: AlertConfig = Field(default_factory=AlertConfig)
     logging: LoggingConfig = Field(default_factory=LoggingConfig)
     polymarket: PolymarketConfig = Field(default_factory=PolymarketConfig)
+    api_football: ApiFootballConfig = Field(default_factory=ApiFootballConfig)
 
 
 @lru_cache

--- a/packages/odds-core/odds_core/epl_data_models.py
+++ b/packages/odds-core/odds_core/epl_data_models.py
@@ -1,9 +1,10 @@
-"""EPL supplementary data tables: ESPN fixtures, ESPN lineups, FPL availability."""
+"""EPL supplementary data tables: ESPN fixtures, ESPN lineups, FPL availability, API-Football."""
 
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
-from sqlalchemy import Column, DateTime, Index, UniqueConstraint, func
+from sqlalchemy import JSON, Column, DateTime, Index, UniqueConstraint, func
 from sqlmodel import Field, SQLModel
 
 from odds_core.models import utc_now
@@ -168,4 +169,39 @@ class FplAvailability(SQLModel, table=True):
             name="uq_fpl_avail_snapshot_gw_player_season",
         ),
         Index("ix_fpl_avail_team_season", "team", "season"),
+    )
+
+
+class ApiFootballLineup(SQLModel, table=True):
+    """Confirmed lineup from API-Football for one team in a fixture.
+
+    One row per (fixture_id, team). Stores the full lineup response including
+    formation, starting XI, substitutes, and coach as structured JSON.
+    """
+
+    __tablename__ = "api_football_lineups"
+
+    id: int | None = Field(default=None, primary_key=True)
+
+    event_id: str = Field(index=True)
+    fixture_id: int = Field(index=True)
+    team_name: str = Field()
+    team_id: int = Field()
+    formation: str | None = Field(default=None)
+    coach: dict[str, Any] | None = Field(sa_column=Column(JSON), default=None)
+    start_xi: list[dict[str, Any]] = Field(sa_column=Column(JSON))
+    substitutes: list[dict[str, Any]] = Field(sa_column=Column(JSON))
+
+    fetched_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True)),
+        default_factory=utc_now,
+    )
+    created_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), server_default=func.now()),
+        default_factory=utc_now,
+    )
+
+    __table_args__ = (
+        UniqueConstraint("fixture_id", "team_id", name="uq_api_football_lineup_fixture_team"),
+        Index("ix_api_football_lineup_event", "event_id"),
     )

--- a/packages/odds-lambda/odds_lambda/api_football_client.py
+++ b/packages/odds-lambda/odds_lambda/api_football_client.py
@@ -16,20 +16,16 @@ from odds_core.team import normalize_team_name
 
 logger = structlog.get_logger(__name__)
 
+
+class ApiFootballRateLimitError(RuntimeError):
+    """Raised when API-Football returns a 429 or rate-limit error message."""
+
+
 # API-Football team name -> pipeline canonical name.
+# Only entries that normalize_team_name() does NOT already handle.
 # Keys are lowercased for case-insensitive lookup.
 _API_FOOTBALL_ALIASES: dict[str, str] = {
-    "manchester united": "Manchester Utd",
-    "newcastle": "Newcastle",
-    "nottingham forest": "Nottingham",
-    "tottenham": "Tottenham",
     "wolverhampton": "Wolves",
-    "wolverhampton wanderers": "Wolves",
-    "west ham": "West Ham",
-    "afc bournemouth": "Bournemouth",
-    "brighton": "Brighton",
-    "leicester": "Leicester",
-    "ipswich": "Ipswich",
     "sheffield utd": "Sheffield Utd",
 }
 
@@ -52,12 +48,15 @@ class ApiFootballClient:
 
     def __init__(self, api_key: str | None = None, base_url: str | None = None) -> None:
         settings = get_settings()
-        self.api_key = api_key or settings.api_football.key
+        resolved_key = api_key or settings.api_football.key
         self.base_url = base_url or settings.api_football.base_url
         self.league_id = settings.api_football.epl_league_id
 
-        if not self.api_key:
+        if not resolved_key:
             raise ValueError("API_FOOTBALL_KEY is not configured")
+
+        self.api_key: str = resolved_key
+        self._fixture_cache: dict[tuple[str, int], list[dict[str, Any]]] = {}
 
     async def _request(self, endpoint: str, params: dict[str, Any]) -> dict[str, Any]:
         """Make an authenticated GET request to API-Football."""
@@ -66,6 +65,16 @@ class ApiFootballClient:
 
         async with aiohttp.ClientSession() as session:
             async with session.get(url, headers=headers, params=params) as resp:
+                if resp.status == 429:
+                    body = await resp.text()
+                    logger.error(
+                        "api_football_rate_limited",
+                        endpoint=endpoint,
+                        body=body[:500],
+                    )
+                    raise ApiFootballRateLimitError(
+                        f"API-Football rate limited (429): {body[:200]}"
+                    )
                 if resp.status != 200:
                     body = await resp.text()
                     logger.error(
@@ -79,6 +88,12 @@ class ApiFootballClient:
 
         errors = data.get("errors")
         if errors:
+            # errors can be a dict like {"rateLimit": "...", "token": "..."}
+            rate_keywords = ("rate", "limit", "too many")
+            error_str = str(errors)
+            if any(kw in error_str.lower() for kw in rate_keywords):
+                logger.error("api_football_rate_limited", endpoint=endpoint, errors=errors)
+                raise ApiFootballRateLimitError(f"API-Football rate limit: {errors}")
             logger.error("api_football_api_error", endpoint=endpoint, errors=errors)
             raise RuntimeError(f"API-Football error: {errors}")
 
@@ -100,16 +115,21 @@ class ApiFootballClient:
         date_str = match_date.strftime("%Y-%m-%d")
         season = _infer_season(match_date)
 
-        data = await self._request(
-            "fixtures",
-            {
-                "league": self.league_id,
-                "season": season,
-                "date": date_str,
-            },
-        )
+        cache_key = (date_str, self.league_id)
+        if cache_key in self._fixture_cache:
+            fixtures = self._fixture_cache[cache_key]
+        else:
+            data = await self._request(
+                "fixtures",
+                {
+                    "league": self.league_id,
+                    "season": season,
+                    "date": date_str,
+                },
+            )
+            fixtures = data.get("response", [])
+            self._fixture_cache[cache_key] = fixtures
 
-        fixtures = data.get("response", [])
         if not fixtures:
             logger.info(
                 "api_football_no_fixtures",
@@ -154,6 +174,8 @@ def _infer_season(dt: datetime) -> int:
     """Infer the EPL season year from a match date.
 
     EPL seasons run Aug-May. A match in Jan 2026 belongs to season 2025.
+    Note: EPL can occasionally start in late July, but Aug is the safe cutoff
+    since API-Football season IDs align to Aug start.
     """
     if dt.month >= 8:
         return dt.year

--- a/packages/odds-lambda/odds_lambda/api_football_client.py
+++ b/packages/odds-lambda/odds_lambda/api_football_client.py
@@ -1,0 +1,250 @@
+"""API-Football v3 client for confirmed lineup data.
+
+Handles fixture ID lookup (team name + date matching) and lineup fetching.
+Free tier: 100 req/day, 10 req/min.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import aiohttp
+import structlog
+from odds_core.config import get_settings
+from odds_core.team import normalize_team_name
+
+logger = structlog.get_logger(__name__)
+
+# API-Football team name -> pipeline canonical name.
+# Keys are lowercased for case-insensitive lookup.
+_API_FOOTBALL_ALIASES: dict[str, str] = {
+    "manchester united": "Manchester Utd",
+    "newcastle": "Newcastle",
+    "nottingham forest": "Nottingham",
+    "tottenham": "Tottenham",
+    "wolverhampton": "Wolves",
+    "wolverhampton wanderers": "Wolves",
+    "west ham": "West Ham",
+    "afc bournemouth": "Bournemouth",
+    "brighton": "Brighton",
+    "leicester": "Leicester",
+    "ipswich": "Ipswich",
+    "sheffield utd": "Sheffield Utd",
+}
+
+
+def _normalize_api_football_name(name: str) -> str:
+    """Normalize an API-Football team name to pipeline canonical form.
+
+    Tries API-Football-specific aliases first, then falls back to the
+    standard normalize_team_name.
+    """
+    cleaned = " ".join(name.split())
+    alias = _API_FOOTBALL_ALIASES.get(cleaned.lower())
+    if alias is not None:
+        return alias
+    return normalize_team_name(cleaned)
+
+
+class ApiFootballClient:
+    """Async client for API-Football v3 endpoints."""
+
+    def __init__(self, api_key: str | None = None, base_url: str | None = None) -> None:
+        settings = get_settings()
+        self.api_key = api_key or settings.api_football.key
+        self.base_url = base_url or settings.api_football.base_url
+        self.league_id = settings.api_football.epl_league_id
+
+        if not self.api_key:
+            raise ValueError("API_FOOTBALL_KEY is not configured")
+
+    async def _request(self, endpoint: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Make an authenticated GET request to API-Football."""
+        url = f"{self.base_url}/{endpoint}"
+        headers = {"x-apisports-key": self.api_key}
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=headers, params=params) as resp:
+                if resp.status != 200:
+                    body = await resp.text()
+                    logger.error(
+                        "api_football_request_failed",
+                        endpoint=endpoint,
+                        status=resp.status,
+                        body=body[:500],
+                    )
+                    raise RuntimeError(f"API-Football request failed: {resp.status} {body[:200]}")
+                data: dict[str, Any] = await resp.json()
+
+        errors = data.get("errors")
+        if errors:
+            logger.error("api_football_api_error", endpoint=endpoint, errors=errors)
+            raise RuntimeError(f"API-Football error: {errors}")
+
+        return data
+
+    async def find_fixture(
+        self,
+        home_team: str,
+        away_team: str,
+        match_date: datetime,
+    ) -> dict[str, Any] | None:
+        """Find an API-Football fixture by team names and date.
+
+        Fetches all EPL fixtures for the match date and fuzzy-matches
+        team names against pipeline canonical names.
+
+        Returns the fixture dict or None if no match found.
+        """
+        date_str = match_date.strftime("%Y-%m-%d")
+        season = _infer_season(match_date)
+
+        data = await self._request(
+            "fixtures",
+            {
+                "league": self.league_id,
+                "season": season,
+                "date": date_str,
+            },
+        )
+
+        fixtures = data.get("response", [])
+        if not fixtures:
+            logger.info(
+                "api_football_no_fixtures",
+                date=date_str,
+                season=season,
+            )
+            return None
+
+        home_canonical = normalize_team_name(home_team)
+        away_canonical = normalize_team_name(away_team)
+
+        for fixture in fixtures:
+            teams = fixture.get("teams", {})
+            api_home = _normalize_api_football_name(teams.get("home", {}).get("name", ""))
+            api_away = _normalize_api_football_name(teams.get("away", {}).get("name", ""))
+
+            if api_home == home_canonical and api_away == away_canonical:
+                return fixture
+
+        logger.warning(
+            "api_football_fixture_not_matched",
+            home_team=home_canonical,
+            away_team=away_canonical,
+            date=date_str,
+            available=[
+                f"{f['teams']['home']['name']} vs {f['teams']['away']['name']}" for f in fixtures
+            ],
+        )
+        return None
+
+    async def get_lineups(self, fixture_id: int) -> list[dict[str, Any]]:
+        """Fetch confirmed lineups for a fixture.
+
+        Returns a list of team lineup dicts (typically 2, one per team).
+        Returns empty list if lineups not yet available.
+        """
+        data = await self._request("fixtures/lineups", {"fixture": fixture_id})
+        return data.get("response", [])
+
+
+def _infer_season(dt: datetime) -> int:
+    """Infer the EPL season year from a match date.
+
+    EPL seasons run Aug-May. A match in Jan 2026 belongs to season 2025.
+    """
+    if dt.month >= 8:
+        return dt.year
+    return dt.year - 1
+
+
+def parse_lineup_response(
+    team_data: dict[str, Any],
+) -> dict[str, Any]:
+    """Parse a single team's lineup from API-Football response into a flat dict.
+
+    Returns dict with: team_name, team_id, formation, coach, start_xi, substitutes.
+    """
+    team_info = team_data.get("team", {})
+    coach_info = team_data.get("coach", {})
+
+    start_xi_raw = team_data.get("startXI", [])
+    subs_raw = team_data.get("substitutes", [])
+
+    start_xi = [_parse_player(p) for p in start_xi_raw]
+    substitutes = [_parse_player(p) for p in subs_raw]
+
+    coach: dict[str, Any] | None = None
+    if coach_info and coach_info.get("id"):
+        coach = {
+            "id": coach_info["id"],
+            "name": coach_info.get("name"),
+        }
+
+    return {
+        "team_name": team_info.get("name", ""),
+        "team_id": team_info.get("id", 0),
+        "formation": team_data.get("formation"),
+        "coach": coach,
+        "start_xi": start_xi,
+        "substitutes": substitutes,
+    }
+
+
+def _parse_player(entry: dict[str, Any]) -> dict[str, Any]:
+    """Parse a player entry from API-Football lineup response."""
+    player = entry.get("player", {})
+    return {
+        "id": player.get("id"),
+        "name": player.get("name"),
+        "number": player.get("number"),
+        "pos": player.get("pos"),
+        "grid": player.get("grid"),
+    }
+
+
+async def fetch_lineups_for_event(
+    event_id: str,
+    home_team: str,
+    away_team: str,
+    commence_time: datetime,
+) -> dict[str, Any]:
+    """High-level: fetch confirmed lineups for a pipeline event.
+
+    Returns a dict with fixture_id, lineups (list of parsed team dicts),
+    or an error/not-available message.
+    """
+    client = ApiFootballClient()
+
+    fixture = await client.find_fixture(home_team, away_team, commence_time)
+    if fixture is None:
+        return {
+            "available": False,
+            "message": f"No API-Football fixture found for {home_team} vs {away_team} "
+            f"on {commence_time.strftime('%Y-%m-%d')}",
+        }
+
+    fixture_id = fixture["fixture"]["id"]
+
+    raw_lineups = await client.get_lineups(fixture_id)
+    if not raw_lineups:
+        hours_until = (commence_time - datetime.now(UTC)).total_seconds() / 3600
+        return {
+            "available": False,
+            "fixture_id": fixture_id,
+            "message": (
+                f"Lineups not yet available for fixture {fixture_id}. "
+                f"EPL lineups typically appear ~55-75 min pre-KO. "
+                f"Kickoff in {hours_until:.1f} hours."
+            ),
+        }
+
+    parsed = [parse_lineup_response(team) for team in raw_lineups]
+
+    return {
+        "available": True,
+        "fixture_id": fixture_id,
+        "lineups": parsed,
+    }

--- a/packages/odds-lambda/odds_lambda/api_football_client.py
+++ b/packages/odds-lambda/odds_lambda/api_football_client.py
@@ -222,6 +222,7 @@ async def fetch_lineups_for_event(
     if fixture is None:
         return {
             "available": False,
+            "event_id": event_id,
             "message": f"No API-Football fixture found for {home_team} vs {away_team} "
             f"on {commence_time.strftime('%Y-%m-%d')}",
         }
@@ -233,6 +234,7 @@ async def fetch_lineups_for_event(
         hours_until = (commence_time - datetime.now(UTC)).total_seconds() / 3600
         return {
             "available": False,
+            "event_id": event_id,
             "fixture_id": fixture_id,
             "message": (
                 f"Lineups not yet available for fixture {fixture_id}. "
@@ -245,6 +247,7 @@ async def fetch_lineups_for_event(
 
     return {
         "available": True,
+        "event_id": event_id,
         "fixture_id": fixture_id,
         "lineups": parsed,
     }

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -805,5 +805,125 @@ async def get_sharp_soft_spread(
     }
 
 
+@mcp.tool()
+async def get_confirmed_lineups(event_id: str) -> dict[str, Any]:
+    """Get confirmed lineups for an EPL match from API-Football.
+
+    Returns formation, starting XI (name, position, number), substitutes,
+    and coach for both teams. Lineups are typically available ~55-75 min
+    before kickoff.
+
+    Results are persisted to DB. If lineups were previously fetched for this
+    fixture, returns the cached version without hitting the API.
+
+    Args:
+        event_id: Event identifier (e.g. "op_live_ARS_CHE_2026-04-13").
+
+    Returns:
+        Dict with lineup data per team, or a message if lineups are not yet available.
+    """
+    from odds_core.epl_data_models import ApiFootballLineup
+    from odds_lambda.api_football_client import fetch_lineups_for_event
+
+    async with async_session_maker() as session:
+        # Look up the event
+        reader = OddsReader(session)
+        event = await reader.get_event_by_id(event_id)
+        if event is None:
+            return {"error": f"Event '{event_id}' not found"}
+
+        # Check for cached lineups first
+        cached_query = select(ApiFootballLineup).where(ApiFootballLineup.event_id == event_id)
+        cached_result = await session.execute(cached_query)
+        cached = list(cached_result.scalars().all())
+
+        if cached:
+            return {
+                "event": _event_to_dict(event),
+                "source": "cached",
+                "lineups": [_lineup_to_dict(row) for row in cached],
+            }
+
+    # Fetch from API-Football
+    try:
+        result = await fetch_lineups_for_event(
+            event_id=event_id,
+            home_team=event.home_team,
+            away_team=event.away_team,
+            commence_time=event.commence_time,
+        )
+    except ValueError as e:
+        return {
+            "event": _event_to_dict(event),
+            "error": str(e),
+            "message": "API_FOOTBALL_KEY is not configured. Set the environment variable.",
+        }
+    except Exception as e:
+        logger.error("get_confirmed_lineups_failed", event_id=event_id, error=str(e), exc_info=True)
+        return {
+            "event": _event_to_dict(event),
+            "error": str(e),
+            "error_type": type(e).__name__,
+        }
+
+    if not result.get("available"):
+        return {
+            "event": _event_to_dict(event),
+            **result,
+        }
+
+    # Persist to DB
+    fixture_id = result["fixture_id"]
+    lineups_data = result["lineups"]
+
+    async with async_session_maker() as session:
+        rows = []
+        for team in lineups_data:
+            row = ApiFootballLineup(
+                event_id=event_id,
+                fixture_id=fixture_id,
+                team_name=team["team_name"],
+                team_id=team["team_id"],
+                formation=team["formation"],
+                coach=team["coach"],
+                start_xi=team["start_xi"],
+                substitutes=team["substitutes"],
+            )
+            rows.append(row)
+
+        # Upsert: delete existing rows for this fixture, then insert fresh
+        from sqlalchemy import delete
+
+        await session.execute(
+            delete(ApiFootballLineup).where(ApiFootballLineup.fixture_id == fixture_id)
+        )
+        session.add_all(rows)
+        await session.commit()
+
+        # Re-read to get DB-assigned IDs
+        for row in rows:
+            await session.refresh(row)
+
+        return {
+            "event": _event_to_dict(event),
+            "source": "api_football",
+            "fixture_id": fixture_id,
+            "lineups": [_lineup_to_dict(row) for row in rows],
+        }
+
+
+def _lineup_to_dict(row: Any) -> dict[str, Any]:
+    """Serialize an ApiFootballLineup row to a JSON-safe dict."""
+    return {
+        "team_name": row.team_name,
+        "team_id": row.team_id,
+        "formation": row.formation,
+        "coach": row.coach,
+        "start_xi": row.start_xi,
+        "substitutes": row.substitutes,
+        "fetched_at": row.fetched_at.isoformat() if row.fetched_at else None,
+    }
+
+
 if __name__ == "__main__":
     mcp.run()

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -15,6 +15,7 @@ from odds_analytics.feature_extraction import TabularFeatureExtractor
 from odds_analytics.sequence_loader import extract_odds_from_snapshot
 from odds_analytics.utils import calculate_implied_probability
 from odds_core.database import async_session_maker
+from odds_core.epl_data_models import ApiFootballLineup
 from odds_core.match_brief_models import BriefCheckpoint, MatchBrief, SharpPriceMap
 from odds_core.models import Event, EventStatus, Odds, OddsSnapshot
 from odds_core.paper_trade_models import PaperTrade
@@ -28,6 +29,7 @@ from odds_lambda.paper_trading import (
 )
 from odds_lambda.storage.readers import OddsReader
 from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert
 
 logger = structlog.get_logger()
 
@@ -822,7 +824,6 @@ async def get_confirmed_lineups(event_id: str) -> dict[str, Any]:
     Returns:
         Dict with lineup data per team, or a message if lineups are not yet available.
     """
-    from odds_core.epl_data_models import ApiFootballLineup
     from odds_lambda.api_football_client import fetch_lineups_for_event
 
     async with async_session_maker() as session:
@@ -877,32 +878,46 @@ async def get_confirmed_lineups(event_id: str) -> dict[str, Any]:
     lineups_data = result["lineups"]
 
     async with async_session_maker() as session:
-        rows = []
         for team in lineups_data:
-            row = ApiFootballLineup(
-                event_id=event_id,
-                fixture_id=fixture_id,
-                team_name=team["team_name"],
-                team_id=team["team_id"],
-                formation=team["formation"],
-                coach=team["coach"],
-                start_xi=team["start_xi"],
-                substitutes=team["substitutes"],
+            values = {
+                "event_id": event_id,
+                "fixture_id": fixture_id,
+                "team_name": team["team_name"],
+                "team_id": team["team_id"],
+                "formation": team["formation"],
+                "coach": team["coach"],
+                "start_xi": team["start_xi"],
+                "substitutes": team["substitutes"],
+                "fetched_at": datetime.now(UTC),
+            }
+            set_ = {
+                col: values[col]
+                for col in (
+                    "event_id",
+                    "team_name",
+                    "formation",
+                    "coach",
+                    "start_xi",
+                    "substitutes",
+                    "fetched_at",
+                )
+            }
+            stmt = (
+                insert(ApiFootballLineup)
+                .values(**values)
+                .on_conflict_do_update(
+                    constraint="uq_api_football_lineup_fixture_team",
+                    set_=set_,
+                )
             )
-            rows.append(row)
+            await session.execute(stmt)
 
-        # Upsert: delete existing rows for this fixture, then insert fresh
-        from sqlalchemy import delete
-
-        await session.execute(
-            delete(ApiFootballLineup).where(ApiFootballLineup.fixture_id == fixture_id)
-        )
-        session.add_all(rows)
         await session.commit()
 
-        # Re-read to get DB-assigned IDs
-        for row in rows:
-            await session.refresh(row)
+        # Read back persisted rows
+        query = select(ApiFootballLineup).where(ApiFootballLineup.fixture_id == fixture_id)
+        result = await session.execute(query)
+        rows = list(result.scalars().all())
 
         return {
             "event": _event_to_dict(event),
@@ -912,7 +927,7 @@ async def get_confirmed_lineups(event_id: str) -> dict[str, Any]:
         }
 
 
-def _lineup_to_dict(row: Any) -> dict[str, Any]:
+def _lineup_to_dict(row: ApiFootballLineup) -> dict[str, Any]:
     """Serialize an ApiFootballLineup row to a JSON-safe dict."""
     return {
         "team_name": row.team_name,

--- a/tests/unit/test_api_football_client.py
+++ b/tests/unit/test_api_football_client.py
@@ -1,0 +1,71 @@
+"""Tests for API-Football client: name normalization, response parsing, season inference."""
+
+from datetime import UTC, datetime
+
+from odds_lambda.api_football_client import (
+    _infer_season,
+    _normalize_api_football_name,
+    parse_lineup_response,
+)
+
+
+class TestNormalizeApiFootballName:
+    def test_direct_alias(self) -> None:
+        assert _normalize_api_football_name("Manchester United") == "Manchester Utd"
+
+    def test_falls_through_to_team_module(self) -> None:
+        assert _normalize_api_football_name("Wolverhampton Wanderers") == "Wolves"
+
+    def test_already_canonical(self) -> None:
+        assert _normalize_api_football_name("Arsenal") == "Arsenal"
+
+    def test_whitespace_cleanup(self) -> None:
+        assert _normalize_api_football_name("  Newcastle  ") == "Newcastle"
+
+
+class TestInferSeason:
+    def test_august_onwards(self) -> None:
+        assert _infer_season(datetime(2025, 8, 16, tzinfo=UTC)) == 2025
+
+    def test_january(self) -> None:
+        assert _infer_season(datetime(2026, 1, 15, tzinfo=UTC)) == 2025
+
+    def test_may(self) -> None:
+        assert _infer_season(datetime(2026, 5, 25, tzinfo=UTC)) == 2025
+
+
+class TestParseLineupResponse:
+    def test_parses_full_response(self) -> None:
+        raw = {
+            "team": {"id": 42, "name": "Arsenal"},
+            "coach": {"id": 1, "name": "Mikel Arteta"},
+            "formation": "4-3-3",
+            "startXI": [
+                {"player": {"id": 100, "name": "Saka", "number": 7, "pos": "M", "grid": "3:4"}},
+                {"player": {"id": 101, "name": "Rice", "number": 41, "pos": "M", "grid": "3:2"}},
+            ],
+            "substitutes": [
+                {"player": {"id": 200, "name": "Nketiah", "number": 14, "pos": "F", "grid": None}},
+            ],
+        }
+        result = parse_lineup_response(raw)
+
+        assert result["team_name"] == "Arsenal"
+        assert result["team_id"] == 42
+        assert result["formation"] == "4-3-3"
+        assert result["coach"] == {"id": 1, "name": "Mikel Arteta"}
+        assert len(result["start_xi"]) == 2
+        assert result["start_xi"][0]["name"] == "Saka"
+        assert result["start_xi"][0]["pos"] == "M"
+        assert len(result["substitutes"]) == 1
+
+    def test_handles_missing_coach(self) -> None:
+        raw = {
+            "team": {"id": 42, "name": "Arsenal"},
+            "coach": {},
+            "formation": "4-4-2",
+            "startXI": [],
+            "substitutes": [],
+        }
+        result = parse_lineup_response(raw)
+        assert result["coach"] is None


### PR DESCRIPTION
## Summary
- Add `get_confirmed_lineups(event_id)` MCP tool that fetches confirmed starting XIs from API-Football v3
- New `ApiFootballClient` with fixture ID mapping (team name fuzzy match + date), lineup fetching, in-memory fixture cache, and rate limit handling (`ApiFootballRateLimitError` for 429s)
- New `ApiFootballLineup` DB model (`api_football_lineups` table) for persisting fetched lineups with atomic upsert (`ON CONFLICT DO UPDATE`)
- DB caching: checks for existing lineups before hitting the API, avoiding repeat calls for the same match
- `ApiFootballConfig` added to settings (`API_FOOTBALL_KEY` env var)
- 9 unit tests covering name normalization, season inference, and response parsing

## Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)