### PR TITLE
Add home_away market converter and MLB LeagueSpec

### DIFF
--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
@@ -321,6 +321,8 @@ async def main(ctx: JobContext) -> None:
         specs = LEAGUE_SPECS
 
     compound_job_name = make_compound_job_name("fetch-oddsportal", sport)
+    # Combined job (no --sport) uses first spec's overnight window.
+    # Production invokes per-sport; only relevant for local multi-league runs.
     primary_spec = specs[0]
 
     # Defensive pre-schedule at retry cadence BEFORE any DB or browser work.

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
@@ -45,8 +45,6 @@ NORMAL_INTERVAL_HOURS = 1.0
 RETRY_DELAY_MINUTES_MIN = 10
 RETRY_DELAY_MINUTES_MAX = 15
 MAX_FAST_RETRIES = 2
-OVERNIGHT_RESUME_HOUR_UTC = 6
-OVERNIGHT_START_HOUR_UTC = 22
 
 
 @dataclass
@@ -58,6 +56,10 @@ class LeagueSpec:
     sport_key: str  # Pipeline sport key (e.g. "soccer_epl")
     sport_title: str  # Display name (e.g. "EPL")
     markets: list[str] = field(default_factory=lambda: ["1x2"])
+    primary_market: str = "1x2"
+    num_outcomes: int = 3
+    overnight_start_utc: int = 22
+    overnight_resume_utc: int = 6
 
 
 LEAGUE_SPECS: list[LeagueSpec] = [
@@ -67,6 +69,17 @@ LEAGUE_SPECS: list[LeagueSpec] = [
         sport_key="soccer_epl",
         sport_title="EPL",
         markets=["1x2", "over_under_2_5"],
+    ),
+    LeagueSpec(
+        sport="baseball",
+        league="mlb",
+        sport_key="baseball_mlb",
+        sport_title="MLB",
+        markets=["home_away"],
+        primary_market="home_away",
+        num_outcomes=2,
+        overnight_start_utc=5,
+        overnight_resume_utc=14,
     ),
 ]
 
@@ -227,20 +240,24 @@ def _calculate_next_execution(
     return now + timedelta(hours=NORMAL_INTERVAL_HOURS), 0
 
 
-def _apply_overnight_skip(next_time: datetime) -> datetime:
-    """Push next_time to morning if overnight.
-
-    EPL games never kick off during the overnight window (22:00-06:00 UTC),
-    so no game-proximity check is needed.
-    """
-    is_overnight = (
-        next_time.hour >= OVERNIGHT_START_HOUR_UTC or next_time.hour < OVERNIGHT_RESUME_HOUR_UTC
-    )
+def _apply_overnight_skip(
+    next_time: datetime,
+    *,
+    overnight_start_utc: int = 22,
+    overnight_resume_utc: int = 6,
+) -> datetime:
+    """Push next_time to resume hour if it falls in the overnight window."""
+    if overnight_start_utc > overnight_resume_utc:
+        # Window wraps midnight (e.g. 22:00-06:00)
+        is_overnight = (
+            next_time.hour >= overnight_start_utc or next_time.hour < overnight_resume_utc
+        )
+    else:
+        # Window within same day (e.g. 05:00-14:00)
+        is_overnight = overnight_start_utc <= next_time.hour < overnight_resume_utc
 
     if is_overnight:
-        resume = next_time.replace(
-            hour=OVERNIGHT_RESUME_HOUR_UTC, minute=0, second=0, microsecond=0
-        )
+        resume = next_time.replace(hour=overnight_resume_utc, minute=0, second=0, microsecond=0)
         if resume <= next_time:
             resume += timedelta(days=1)
         return resume
@@ -304,6 +321,7 @@ async def main(ctx: JobContext) -> None:
         specs = LEAGUE_SPECS
 
     compound_job_name = make_compound_job_name("fetch-oddsportal", sport)
+    primary_spec = specs[0]
 
     # Defensive pre-schedule at retry cadence BEFORE any DB or browser work.
     # No DB query needed — just now + retry delay. If anything fails (DB down,
@@ -313,7 +331,11 @@ async def main(ctx: JobContext) -> None:
         retry_count=retry_count,
         now=datetime.now(UTC),
     )
-    defensive_next_time = _apply_overnight_skip(defensive_next_time)
+    defensive_next_time = _apply_overnight_skip(
+        defensive_next_time,
+        overnight_start_utc=primary_spec.overnight_start_utc,
+        overnight_resume_utc=primary_spec.overnight_resume_utc,
+    )
     try:
         await _self_schedule(
             job_name=compound_job_name,
@@ -378,6 +400,8 @@ async def main(ctx: JobContext) -> None:
     if total_scraped > 0:
         success_next_time = _apply_overnight_skip(
             datetime.now(UTC) + timedelta(hours=NORMAL_INTERVAL_HOURS),
+            overnight_start_utc=primary_spec.overnight_start_utc,
+            overnight_resume_utc=primary_spec.overnight_resume_utc,
         )
         try:
             await _self_schedule(

--- a/packages/odds-lambda/odds_lambda/oddsportal_adapter.py
+++ b/packages/odds-lambda/odds_lambda/oddsportal_adapter.py
@@ -264,7 +264,65 @@ def _convert_over_under_match(
     return {"bookmakers": bookmakers, "source": "oddsportal_live"}
 
 
+def _convert_home_away_match(
+    bookmaker_odds: list[dict[str, Any]],
+    home_team: str,
+    away_team: str,
+) -> dict[str, Any] | None:
+    """Convert home/away (moneyline) market bookmaker list to raw_data format."""
+    bookmakers: list[dict[str, Any]] = []
+
+    for bk in bookmaker_odds:
+        bk_name = bk.get("bookmaker_name", "")
+        if not bk_name:
+            continue
+
+        home_raw = bk.get("1", "")
+        away_raw = bk.get("2", "")
+
+        if not home_raw or not away_raw:
+            continue
+
+        bk_key = normalize_bookmaker_key(bk_name)
+        is_betfair = bk_name == "Betfair Exchange"
+
+        if is_betfair:
+            home_frac, home_liq = parse_betfair_odds(home_raw)
+            away_frac, away_liq = parse_betfair_odds(away_raw)
+        else:
+            home_frac, away_frac = home_raw, away_raw
+
+        try:
+            home_dec = fractional_to_decimal(home_frac)
+            away_dec = fractional_to_decimal(away_frac)
+        except (ValueError, ZeroDivisionError):
+            continue
+
+        outcomes = [
+            {"name": home_team, "price": decimal_to_american(home_dec)},
+            {"name": away_team, "price": decimal_to_american(away_dec)},
+        ]
+
+        liquidity: dict[str, int] | None = None
+        if is_betfair:
+            liquidity = {}
+            if home_liq is not None:
+                liquidity["home"] = home_liq
+            if away_liq is not None:
+                liquidity["away"] = away_liq
+
+        bookmakers.append(
+            _build_bookmaker_entry(bk_key, bk_name, "h2h", outcomes, betfair_matched=liquidity)
+        )
+
+    if not bookmakers:
+        return None
+
+    return {"bookmakers": bookmakers, "source": "oddsportal_live"}
+
+
 _MARKET_CONVERTERS: dict[str, MarketConverter] = {
     "1x2": _convert_1x2_match,
     "over_under_2_5": _convert_over_under_match,
+    "home_away": _convert_home_away_match,
 }

--- a/packages/odds-lambda/odds_lambda/oddsportal_adapter.py
+++ b/packages/odds-lambda/odds_lambda/oddsportal_adapter.py
@@ -78,7 +78,7 @@ def convert_upcoming_matches(matches: list[dict[str, Any]], market: str) -> list
 
     Args:
         matches: Raw match dicts from OddsHarvester upcoming command.
-        market: Market key — "1x2" or "over_under_2_5".
+        market: Market key — "1x2", "over_under_2_5", or "home_away".
 
     Returns:
         List of MatchOdds with raw_data matching OddsWriter contract.

--- a/packages/odds-lambda/odds_lambda/oddsportal_adapter.py
+++ b/packages/odds-lambda/odds_lambda/oddsportal_adapter.py
@@ -13,25 +13,11 @@ from datetime import UTC, datetime
 from typing import Any
 
 from odds_lambda.oddsportal_common import (
-    BOOKMAKER_KEY_MAP,
     DRAW_OUTCOME,
     decimal_to_american,
+    normalize_bookmaker_key,
     parse_match_date,
-    slugify,
 )
-
-# Upcoming-only bookmakers not seen in historical scrapes.
-UPCOMING_BOOKMAKER_MAP: dict[str, str] = {
-    **BOOKMAKER_KEY_MAP,
-    "7Bet": "7bet",
-    "Paddy Power": "paddypower",
-    "Skybet": "skybet",
-    "Ladbrokes": "ladbrokes",
-    "Coral": "coral",
-    "William Hill": "williamhill",
-    "888sport": "888sport",
-    "BoyleSports": "boylesports",
-}
 
 # Regex: Betfair format is "FRAC_REPEAT(LIQUIDITY)" e.g. "99/10099/100(300)"
 # The fraction is repeated (concatenated), followed by optional (liquidity).
@@ -85,11 +71,6 @@ def parse_betfair_odds(raw: str) -> tuple[str, int | None]:
     if m:
         return m.group(1), int(m.group(2))
     return raw, None
-
-
-def _normalize_upcoming_key(name: str) -> str:
-    """Map bookmaker name to pipeline key, including upcoming-only bookmakers."""
-    return UPCOMING_BOOKMAKER_MAP.get(name, slugify(name))
 
 
 def convert_upcoming_matches(matches: list[dict[str, Any]], market: str) -> list[MatchOdds]:
@@ -183,7 +164,7 @@ def _convert_1x2_match(
         if not home_raw or not draw_raw or not away_raw:
             continue
 
-        bk_key = _normalize_upcoming_key(bk_name)
+        bk_key = normalize_bookmaker_key(bk_name)
         is_betfair = bk_name == "Betfair Exchange"
 
         if is_betfair:
@@ -245,7 +226,7 @@ def _convert_over_under_match(
         if not over_raw or not under_raw:
             continue
 
-        bk_key = _normalize_upcoming_key(bk_name)
+        bk_key = normalize_bookmaker_key(bk_name)
         is_betfair = bk_name == "Betfair Exchange"
 
         if is_betfair:

--- a/packages/odds-lambda/odds_lambda/oddsportal_common.py
+++ b/packages/odds-lambda/odds_lambda/oddsportal_common.py
@@ -53,6 +53,15 @@ BOOKMAKER_KEY_MAP: dict[str, str] = {
     "Marathon Bet": "marathonbet",
     "1xBet": "onexbet",
     "Betfair Exchange": "betfair_exchange",
+    "7Bet": "7bet",
+    "Paddy Power": "paddypower",
+    "SpreadEX": "spreadex",
+    "William Hill": "williamhill",
+    "Skybet": "skybet",
+    "Ladbrokes": "ladbrokes",
+    "Coral": "coral",
+    "888sport": "888sport",
+    "BoyleSports": "boylesports",
 }
 
 

--- a/tests/unit/test_fetch_oddsportal.py
+++ b/tests/unit/test_fetch_oddsportal.py
@@ -1,0 +1,57 @@
+"""Tests for fetch_oddsportal job utilities."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from odds_lambda.jobs.fetch_oddsportal import _apply_overnight_skip
+
+
+class TestApplyOvernightSkip:
+    def test_epl_defaults_during_day(self) -> None:
+        dt = datetime(2026, 4, 13, 14, 0, tzinfo=UTC)
+        assert _apply_overnight_skip(dt) == dt
+
+    def test_epl_defaults_late_night(self) -> None:
+        dt = datetime(2026, 4, 13, 23, 0, tzinfo=UTC)
+        result = _apply_overnight_skip(dt)
+        assert result == datetime(2026, 4, 14, 6, 0, tzinfo=UTC)
+
+    def test_epl_defaults_early_morning(self) -> None:
+        dt = datetime(2026, 4, 13, 3, 0, tzinfo=UTC)
+        result = _apply_overnight_skip(dt)
+        assert result == datetime(2026, 4, 13, 6, 0, tzinfo=UTC)
+
+    def test_epl_defaults_boundary_start(self) -> None:
+        dt = datetime(2026, 4, 13, 22, 0, tzinfo=UTC)
+        result = _apply_overnight_skip(dt)
+        assert result == datetime(2026, 4, 14, 6, 0, tzinfo=UTC)
+
+    def test_epl_defaults_boundary_resume(self) -> None:
+        dt = datetime(2026, 4, 13, 6, 0, tzinfo=UTC)
+        assert _apply_overnight_skip(dt) == dt
+
+    def test_mlb_hours_during_games(self) -> None:
+        dt = datetime(2026, 6, 15, 23, 0, tzinfo=UTC)
+        result = _apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
+        assert result == dt
+
+    def test_mlb_hours_overnight(self) -> None:
+        dt = datetime(2026, 6, 16, 7, 0, tzinfo=UTC)
+        result = _apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
+        assert result == datetime(2026, 6, 16, 14, 0, tzinfo=UTC)
+
+    def test_mlb_hours_boundary_start(self) -> None:
+        dt = datetime(2026, 6, 16, 5, 0, tzinfo=UTC)
+        result = _apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
+        assert result == datetime(2026, 6, 16, 14, 0, tzinfo=UTC)
+
+    def test_mlb_hours_boundary_resume(self) -> None:
+        dt = datetime(2026, 6, 16, 14, 0, tzinfo=UTC)
+        result = _apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
+        assert result == dt
+
+    def test_mlb_hours_before_overnight(self) -> None:
+        dt = datetime(2026, 6, 16, 4, 30, tzinfo=UTC)
+        result = _apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
+        assert result == dt

--- a/tests/unit/test_fetch_oddsportal_scheduling.py
+++ b/tests/unit/test_fetch_oddsportal_scheduling.py
@@ -11,10 +11,8 @@ import pytest
 from odds_lambda.jobs.fetch_oddsportal import (
     MAX_FAST_RETRIES,
     NORMAL_INTERVAL_HOURS,
-    OVERNIGHT_RESUME_HOUR_UTC,
     RETRY_DELAY_MINUTES_MAX,
     RETRY_DELAY_MINUTES_MIN,
-    _apply_overnight_skip,
     _calculate_next_execution,
     main,
 )
@@ -64,33 +62,6 @@ class TestCalculateNextExecution:
         )
         assert next_time == now + timedelta(hours=NORMAL_INTERVAL_HOURS)
         assert retry_count == 0
-
-
-class TestApplyOvernightSkip:
-    """Tests for _apply_overnight_skip logic."""
-
-    def test_overnight_skips_to_morning(self) -> None:
-        next_time = datetime(2026, 4, 7, 23, 0, tzinfo=UTC)
-        result = _apply_overnight_skip(next_time)
-        assert result.hour == OVERNIGHT_RESUME_HOUR_UTC
-        assert result.minute == 0
-        assert result > next_time
-
-    def test_afternoon_no_skip(self) -> None:
-        next_time = datetime(2026, 4, 7, 14, 0, tzinfo=UTC)
-        result = _apply_overnight_skip(next_time)
-        assert result == next_time
-
-    def test_early_morning_skips_to_morning(self) -> None:
-        next_time = datetime(2026, 4, 7, 3, 0, tzinfo=UTC)
-        result = _apply_overnight_skip(next_time)
-        assert result.hour == OVERNIGHT_RESUME_HOUR_UTC
-        assert result.day == next_time.day
-
-    def test_exactly_at_resume_hour_no_skip(self) -> None:
-        next_time = datetime(2026, 4, 7, OVERNIGHT_RESUME_HOUR_UTC, 0, tzinfo=UTC)
-        result = _apply_overnight_skip(next_time)
-        assert result == next_time
 
 
 class TestDefensivePreScheduling:

--- a/tests/unit/test_oddsportal_adapter.py
+++ b/tests/unit/test_oddsportal_adapter.py
@@ -94,18 +94,6 @@ class TestNormalizeBookmakerKey:
         assert key == "somenewbook"
 
 
-class TestNormalizeUpcomingKey:
-    def test_known_from_base_map(self) -> None:
-        assert normalize_bookmaker_key("bet365") == "bet365"
-
-    def test_upcoming_only_bookmaker(self) -> None:
-        assert normalize_bookmaker_key("Paddy Power") == "paddypower"
-        assert normalize_bookmaker_key("Skybet") == "skybet"
-
-    def test_unknown_slugified(self) -> None:
-        assert normalize_bookmaker_key("Brand New Book") == "brandnewbook"
-
-
 class TestDecimalToAmerican:
     def test_plus_odds(self) -> None:
         assert decimal_to_american(3.0) == 200

--- a/tests/unit/test_oddsportal_adapter.py
+++ b/tests/unit/test_oddsportal_adapter.py
@@ -6,6 +6,7 @@ import pytest
 from odds_lambda.oddsportal_adapter import (
     MatchOdds,
     _convert_1x2_match,
+    _convert_home_away_match,
     _convert_over_under_match,
     convert_upcoming_matches,
     fractional_to_decimal,
@@ -316,3 +317,116 @@ class TestConvertUpcomingMatches:
     def test_skips_incomplete_match(self) -> None:
         matches = [{"home_team": "Leeds", "away_team": "", "match_date": ""}]
         assert convert_upcoming_matches(matches, "1x2") == []
+
+    def test_home_away_market_converts(self) -> None:
+        matches = [
+            {
+                "scraped_date": "2026-06-15 20:00:00 UTC",
+                "match_date": "2026-06-16 23:10:00 UTC",
+                "match_link": "https://www.oddsportal.com/baseball/usa/mlb/yankees-red-sox-abc123/",
+                "home_team": "New York Yankees",
+                "away_team": "Boston Red Sox",
+                "league_name": "MLB",
+                "home_away_market": [
+                    {
+                        "1": "5/6",
+                        "2": "EVS",
+                        "bookmaker_name": "bet365",
+                        "period": "FullTime",
+                    },
+                ],
+            }
+        ]
+        results = convert_upcoming_matches(matches, "home_away")
+        assert len(results) == 1
+        outcomes = results[0].raw_data["bookmakers"][0]["markets"][0]["outcomes"]
+        assert len(outcomes) == 2
+        assert outcomes[0]["name"] == "New York Yankees"
+        assert outcomes[1]["name"] == "Boston Red Sox"
+
+
+class TestConvertHomeAwayMatch:
+    @pytest.fixture()
+    def sample_ha_bookmakers(self) -> list[dict]:
+        return [
+            {
+                "1": "5/6",
+                "2": "EVS",
+                "bookmaker_name": "bet365",
+                "period": "FullTime",
+            },
+            {
+                "1": "4/5",
+                "2": "11/10",
+                "bookmaker_name": "10bet",
+                "period": "FullTime",
+            },
+            {
+                "1": "9/109/10(500)",
+                "2": "11/1011/10(400)",
+                "bookmaker_name": "Betfair Exchange",
+                "period": "FullTime",
+            },
+        ]
+
+    def test_basic_conversion(self, sample_ha_bookmakers: list[dict]) -> None:
+        result = _convert_home_away_match(sample_ha_bookmakers, "Yankees", "Red Sox")
+        assert result is not None
+        assert "bookmakers" in result
+        assert len(result["bookmakers"]) == 3
+
+    def test_outcome_names(self, sample_ha_bookmakers: list[dict]) -> None:
+        result = _convert_home_away_match(sample_ha_bookmakers, "Yankees", "Red Sox")
+        assert result is not None
+        outcomes = result["bookmakers"][0]["markets"][0]["outcomes"]
+        assert len(outcomes) == 2
+        assert outcomes[0]["name"] == "Yankees"
+        assert outcomes[1]["name"] == "Red Sox"
+
+    def test_no_draw_outcome(self, sample_ha_bookmakers: list[dict]) -> None:
+        result = _convert_home_away_match(sample_ha_bookmakers, "Yankees", "Red Sox")
+        assert result is not None
+        for bk in result["bookmakers"]:
+            names = [o["name"] for o in bk["markets"][0]["outcomes"]]
+            assert DRAW_OUTCOME not in names
+
+    def test_odds_conversion(self, sample_ha_bookmakers: list[dict]) -> None:
+        result = _convert_home_away_match(sample_ha_bookmakers, "Yankees", "Red Sox")
+        assert result is not None
+        # bet365: home 5/6 = 1.833... decimal
+        home_price = result["bookmakers"][0]["markets"][0]["outcomes"][0]["price"]
+        assert home_price == decimal_to_american(5 / 6 + 1)
+
+    def test_betfair_parsed(self, sample_ha_bookmakers: list[dict]) -> None:
+        result = _convert_home_away_match(sample_ha_bookmakers, "Yankees", "Red Sox")
+        assert result is not None
+        betfair = next(b for b in result["bookmakers"] if b["key"] == "betfair_exchange")
+        # 9/10 = 1.9 decimal
+        home_price = betfair["markets"][0]["outcomes"][0]["price"]
+        assert home_price == decimal_to_american(1.9)
+
+    def test_betfair_liquidity_stored(self, sample_ha_bookmakers: list[dict]) -> None:
+        result = _convert_home_away_match(sample_ha_bookmakers, "Yankees", "Red Sox")
+        assert result is not None
+        betfair = next(b for b in result["bookmakers"] if b["key"] == "betfair_exchange")
+        assert "betfair_matched" in betfair
+        assert betfair["betfair_matched"]["home"] == 500
+        assert betfair["betfair_matched"]["away"] == 400
+        assert "draw" not in betfair["betfair_matched"]
+
+    def test_market_key_is_h2h(self, sample_ha_bookmakers: list[dict]) -> None:
+        result = _convert_home_away_match(sample_ha_bookmakers, "Yankees", "Red Sox")
+        assert result is not None
+        assert result["bookmakers"][0]["markets"][0]["key"] == "h2h"
+
+    def test_source_tag(self, sample_ha_bookmakers: list[dict]) -> None:
+        result = _convert_home_away_match(sample_ha_bookmakers, "Yankees", "Red Sox")
+        assert result is not None
+        assert result["source"] == "oddsportal_live"
+
+    def test_empty_returns_none(self) -> None:
+        assert _convert_home_away_match([], "A", "B") is None
+
+    def test_missing_odds_skipped(self) -> None:
+        data = [{"bookmaker_name": "bet365", "1": "5/6", "2": ""}]
+        assert _convert_home_away_match(data, "A", "B") is None

--- a/tests/unit/test_oddsportal_adapter.py
+++ b/tests/unit/test_oddsportal_adapter.py
@@ -7,7 +7,6 @@ from odds_lambda.oddsportal_adapter import (
     MatchOdds,
     _convert_1x2_match,
     _convert_over_under_match,
-    _normalize_upcoming_key,
     convert_upcoming_matches,
     fractional_to_decimal,
     parse_betfair_odds,
@@ -96,14 +95,14 @@ class TestNormalizeBookmakerKey:
 
 class TestNormalizeUpcomingKey:
     def test_known_from_base_map(self) -> None:
-        assert _normalize_upcoming_key("bet365") == "bet365"
+        assert normalize_bookmaker_key("bet365") == "bet365"
 
     def test_upcoming_only_bookmaker(self) -> None:
-        assert _normalize_upcoming_key("Paddy Power") == "paddypower"
-        assert _normalize_upcoming_key("Skybet") == "skybet"
+        assert normalize_bookmaker_key("Paddy Power") == "paddypower"
+        assert normalize_bookmaker_key("Skybet") == "skybet"
 
     def test_unknown_slugified(self) -> None:
-        assert _normalize_upcoming_key("Brand New Book") == "brandnewbook"
+        assert normalize_bookmaker_key("Brand New Book") == "brandnewbook"
 
 
 class TestDecimalToAmerican:


### PR DESCRIPTION
## Summary
- Consolidate bookmaker key mapping: move `UPCOMING_BOOKMAKER_MAP` into shared `BOOKMAKER_KEY_MAP` in `oddsportal_common.py`, expose single `normalize_bookmaker_key()` function. Add SpreadEX.
- Add `_convert_home_away_match()` to `oddsportal_adapter.py` — 2-way moneyline converter (keys `"1"`/`"2"`, market `"h2h"`), registered as `"home_away"` in `_MARKET_CONVERTERS`
- Extend `LeagueSpec` with `primary_market`, `num_outcomes`, `overnight_start_utc`, `overnight_resume_utc` (backward-compatible defaults)
- Add MLB spec: `baseball/mlb`, `home_away` market, overnight window 05:00-14:00 UTC
- Parameterize `_apply_overnight_skip()` to handle both wrap-midnight (EPL 22-06) and same-day (MLB 05-14) windows
- 11 new converter tests + 10 overnight skip tests

## Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)