### PR TITLE
Wire up MLB league config for OddsPortal scraping (#301)

### DIFF
--- a/packages/odds-core/odds_core/config.py
+++ b/packages/odds-core/odds_core/config.py
@@ -157,6 +157,8 @@ class AlertConfig(BaseSettings):
             "fetch-oddsportal-results-epl": 26,
             "score-predictions-epl": 2,
             "daily-digest-epl": 26,
+            "fetch-oddsportal-mlb": 2,
+            "fetch-oddsportal-results-mlb": 26,
             "check-health": 2,
         },
         description="Max hours between job completions before alerting (job_name -> hours)",

--- a/packages/odds-lambda/odds_lambda/jobs/daily_digest.py
+++ b/packages/odds-lambda/odds_lambda/jobs/daily_digest.py
@@ -243,6 +243,7 @@ def _format_window(hours: float) -> str:
 _SPORT_DISPLAY_NAMES: dict[str, str] = {
     "soccer_epl": "EPL",
     "basketball_nba": "NBA",
+    "baseball_mlb": "MLB",
 }
 
 

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py
@@ -56,11 +56,9 @@ def _db_market_for_spec(spec: LeagueSpec) -> str:
     Maps OddsPortal market names to the pipeline's canonical market key used
     in ``raw_data["bookmakers"][*]["markets"][*]["key"]``.
     """
-    if spec.primary_market == "home_away":
+    if spec.primary_market in ("home_away", "1x2"):
         return "h2h"
-    if spec.primary_market == "1x2":
-        return "h2h"
-    return spec.primary_market
+    raise ValueError(f"Unrecognized primary_market: {spec.primary_market!r}")
 
 
 @dataclass

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py
@@ -1,8 +1,12 @@
-"""Fetch EPL results and closing odds from OddsPortal historical pages.
+"""Fetch results and closing odds from OddsPortal historical pages.
 
 Scrapes recent match results, updates SCHEDULED events to FINAL with scores,
 and stores one closing odds snapshot per event. Designed for daily Lambda
 execution on the scraper Lambda (requires Playwright/Chromium).
+
+Sport-aware: resolves league configuration from the shared ``LeagueSpec``
+registry in ``fetch_oddsportal``. Derives market key, num_outcomes, and
+harvester params from the spec.
 
 Idempotency: only queries SCHEDULED/LIVE events with commence_time in the past,
 so re-runs after events are marked FINAL find nothing to process.
@@ -21,6 +25,7 @@ from odds_core.models import Event, EventStatus
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from odds_lambda.jobs.fetch_oddsportal import _LEAGUE_SPEC_BY_SPORT, LeagueSpec
 from odds_lambda.oddsportal_common import (
     build_raw_data,
     parse_match_date,
@@ -31,12 +36,31 @@ from odds_lambda.storage.writers import OddsWriter
 
 logger = structlog.get_logger()
 
-SPORT_KEY = "soccer_epl"
-SPORT_TITLE = "EPL"
-HARVESTER_SPORT = "football"
-HARVESTER_LEAGUE = "england-premier-league"
-MARKET_KEY = "1x2_market"
+# Default sport key when no --sport is provided (backward-compatible)
+DEFAULT_SPORT_KEY = "soccer_epl"
 API_REQUEST_ID = "oddsportal_closing"
+
+
+def _market_key_for_spec(spec: LeagueSpec) -> str:
+    """Derive the OddsHarvester record key for the spec's primary market.
+
+    OddsHarvester stores market data under ``{market}_market`` keys, e.g.
+    ``"1x2_market"`` or ``"home_away_market"``.
+    """
+    return f"{spec.primary_market}_market"
+
+
+def _db_market_for_spec(spec: LeagueSpec) -> str:
+    """Derive the pipeline ``db_market`` value from the spec's primary market.
+
+    Maps OddsPortal market names to the pipeline's canonical market key used
+    in ``raw_data["bookmakers"][*]["markets"][*]["key"]``.
+    """
+    if spec.primary_market == "home_away":
+        return "h2h"
+    if spec.primary_market == "1x2":
+        return "h2h"
+    return spec.primary_market
 
 
 @dataclass
@@ -50,23 +74,25 @@ class ResultsStats:
     errors: list[str] = field(default_factory=list)
 
 
-async def run_harvester_historic() -> list[dict[str, Any]]:
-    """Scrape historical results for the current EPL season via ``run_scraper_with_retry``."""
+async def run_harvester_historic(spec: LeagueSpec) -> list[dict[str, Any]]:
+    """Scrape historical results for the given league via ``run_scraper_with_retry``."""
     from oddsharvester.utils.command_enum import CommandEnum
 
     result = await run_scraper_with_retry(
         command=CommandEnum.HISTORIC,
-        sport=HARVESTER_SPORT,
-        leagues=[HARVESTER_LEAGUE],
+        sport=spec.sport,
+        leagues=[spec.league],
         season=None,
         max_pages=1,
-        markets=["1x2"],
+        markets=[spec.primary_market],
         headless=True,
     )
     return result.success
 
 
-async def get_pending_events(session: AsyncSession, sport_key: str = SPORT_KEY) -> list[Event]:
+async def get_pending_events(
+    session: AsyncSession, sport_key: str = DEFAULT_SPORT_KEY
+) -> list[Event]:
     """Get SCHEDULED or LIVE events with commence_time in the past for the given sport."""
     query = select(Event).where(
         and_(
@@ -125,10 +151,22 @@ async def process_results(
 
     Args:
         raw_matches: Pre-scraped data (skips harvester call). For testing.
-        sport: Sport key to filter (e.g. "soccer_epl"). Defaults to SPORT_KEY.
+        sport: Sport key to filter (e.g. "soccer_epl"). Defaults to DEFAULT_SPORT_KEY.
     """
     stats = ResultsStats()
-    sport_key = sport or SPORT_KEY
+    sport_key = sport or DEFAULT_SPORT_KEY
+
+    spec = _LEAGUE_SPEC_BY_SPORT.get(sport_key)
+    if spec is None:
+        logger.error(
+            "unknown_sport_key",
+            sport_key=sport_key,
+            available=list(_LEAGUE_SPEC_BY_SPORT),
+        )
+        return stats
+
+    market_key = _market_key_for_spec(spec)
+    db_market = _db_market_for_spec(spec)
 
     async with async_session_maker() as session:
         pending_events = await get_pending_events(session, sport_key=sport_key)
@@ -140,7 +178,7 @@ async def process_results(
         logger.info("pending_events_found", count=len(pending_events))
 
         if raw_matches is None:
-            raw_matches = await run_harvester_historic()
+            raw_matches = await run_harvester_historic(spec)
 
         stats.matches_scraped = len(raw_matches)
 
@@ -183,7 +221,7 @@ async def process_results(
                 pending_events.remove(event)
 
                 # Store closing odds snapshot
-                market_data = record.get(MARKET_KEY, [])
+                market_data = record.get(market_key, [])
                 if not market_data:
                     continue
 
@@ -194,8 +232,8 @@ async def process_results(
                     event.away_team,
                     use_opening=False,
                     match_dt=match_dt,
-                    num_outcomes=3,
-                    db_market="h2h",
+                    num_outcomes=spec.num_outcomes,
+                    db_market=db_market,
                 )
                 if raw_data is None:
                     continue

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -71,6 +71,7 @@ _JOB_MODULE_MAP: dict[str, tuple[str, str]] = {
 # e.g. "fetch-odds-epl" resolves to ("fetch-odds", "soccer_epl")
 _SPORT_SUFFIX_MAP: dict[str, str] = {
     "epl": "soccer_epl",
+    "mlb": "baseball_mlb",
 }
 
 # Jobs that accept a sport parameter. When invoked with a sport suffix

--- a/tests/unit/test_fetch_oddsportal_results.py
+++ b/tests/unit/test_fetch_oddsportal_results.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from odds_core.models import Event, EventStatus
+from odds_lambda.jobs.fetch_oddsportal import LeagueSpec
 from odds_lambda.jobs.fetch_oddsportal_results import (
     DEFAULT_SPORT_KEY,
     _db_market_for_spec,
@@ -366,6 +367,18 @@ class TestSportResolution:
 
         spec = _LEAGUE_SPEC_BY_SPORT["baseball_mlb"]
         assert spec.num_outcomes == 2
+
+    def test_db_market_unknown_raises(self) -> None:
+        spec = LeagueSpec(
+            sport="test",
+            league="test-league",
+            sport_key="test_sport",
+            sport_title="Test",
+            primary_market="unknown_market",
+            num_outcomes=2,
+        )
+        with pytest.raises(ValueError, match="Unrecognized primary_market"):
+            _db_market_for_spec(spec)
 
     @pytest.mark.asyncio
     async def test_unknown_sport_returns_empty_stats(self) -> None:

--- a/tests/unit/test_fetch_oddsportal_results.py
+++ b/tests/unit/test_fetch_oddsportal_results.py
@@ -8,6 +8,9 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from odds_core.models import Event, EventStatus
 from odds_lambda.jobs.fetch_oddsportal_results import (
+    DEFAULT_SPORT_KEY,
+    _db_market_for_spec,
+    _market_key_for_spec,
     _match_record_to_event,
     _parse_score,
     get_pending_events,
@@ -320,3 +323,52 @@ class TestProcessResults:
         assert snap.fetch_tier == "closing"
         assert snap.bookmaker_count == 1
         assert "bookmakers" in snap.raw_data
+
+
+class TestSportResolution:
+    """Tests for sport-aware spec lookup in the results job."""
+
+    def test_default_sport_key_is_epl(self) -> None:
+        assert DEFAULT_SPORT_KEY == "soccer_epl"
+
+    def test_market_key_epl(self) -> None:
+        from odds_lambda.jobs.fetch_oddsportal import _LEAGUE_SPEC_BY_SPORT
+
+        spec = _LEAGUE_SPEC_BY_SPORT["soccer_epl"]
+        assert _market_key_for_spec(spec) == "1x2_market"
+
+    def test_market_key_mlb(self) -> None:
+        from odds_lambda.jobs.fetch_oddsportal import _LEAGUE_SPEC_BY_SPORT
+
+        spec = _LEAGUE_SPEC_BY_SPORT["baseball_mlb"]
+        assert _market_key_for_spec(spec) == "home_away_market"
+
+    def test_db_market_epl(self) -> None:
+        from odds_lambda.jobs.fetch_oddsportal import _LEAGUE_SPEC_BY_SPORT
+
+        spec = _LEAGUE_SPEC_BY_SPORT["soccer_epl"]
+        assert _db_market_for_spec(spec) == "h2h"
+
+    def test_db_market_mlb(self) -> None:
+        from odds_lambda.jobs.fetch_oddsportal import _LEAGUE_SPEC_BY_SPORT
+
+        spec = _LEAGUE_SPEC_BY_SPORT["baseball_mlb"]
+        assert _db_market_for_spec(spec) == "h2h"
+
+    def test_num_outcomes_epl(self) -> None:
+        from odds_lambda.jobs.fetch_oddsportal import _LEAGUE_SPEC_BY_SPORT
+
+        spec = _LEAGUE_SPEC_BY_SPORT["soccer_epl"]
+        assert spec.num_outcomes == 3
+
+    def test_num_outcomes_mlb(self) -> None:
+        from odds_lambda.jobs.fetch_oddsportal import _LEAGUE_SPEC_BY_SPORT
+
+        spec = _LEAGUE_SPEC_BY_SPORT["baseball_mlb"]
+        assert spec.num_outcomes == 2
+
+    @pytest.mark.asyncio
+    async def test_unknown_sport_returns_empty_stats(self) -> None:
+        stats = await process_results(raw_matches=[], sport="unknown_sport")
+        assert stats.matches_scraped == 0
+        assert stats.events_updated == 0

--- a/tests/unit/test_job_routing.py
+++ b/tests/unit/test_job_routing.py
@@ -40,6 +40,16 @@ class TestResolveJobName:
         assert base == "fetch-oddsportal-results"
         assert sport == "soccer_epl"
 
+    def test_compound_name_mlb(self) -> None:
+        base, sport = resolve_job_name("fetch-oddsportal-mlb")
+        assert base == "fetch-oddsportal"
+        assert sport == "baseball_mlb"
+
+    def test_compound_name_mlb_results(self) -> None:
+        base, sport = resolve_job_name("fetch-oddsportal-results-mlb")
+        assert base == "fetch-oddsportal-results"
+        assert sport == "baseball_mlb"
+
     def test_unknown_suffix_returns_no_sport(self) -> None:
         base, sport = resolve_job_name("fetch-odds-nba")
         assert base == "fetch-odds-nba"
@@ -63,6 +73,9 @@ class TestSportKeyToSuffix:
     def test_known_sport(self) -> None:
         assert sport_key_to_suffix("soccer_epl") == "epl"
 
+    def test_known_sport_mlb(self) -> None:
+        assert sport_key_to_suffix("baseball_mlb") == "mlb"
+
     def test_unknown_sport(self) -> None:
         assert sport_key_to_suffix("basketball_nba") is None
 
@@ -72,6 +85,9 @@ class TestMakeCompoundJobName:
 
     def test_with_sport(self) -> None:
         assert make_compound_job_name("fetch-odds", "soccer_epl") == "fetch-odds-epl"
+
+    def test_with_sport_mlb(self) -> None:
+        assert make_compound_job_name("fetch-oddsportal", "baseball_mlb") == "fetch-oddsportal-mlb"
 
     def test_without_sport(self) -> None:
         assert make_compound_job_name("fetch-odds", None) == "fetch-odds"
@@ -88,3 +104,15 @@ class TestMakeCompoundJobName:
         base, sport = resolve_job_name(compound)
         assert base == "fetch-oddsportal-results"
         assert sport == "soccer_epl"
+
+    def test_roundtrip_mlb(self) -> None:
+        compound = make_compound_job_name("fetch-oddsportal", "baseball_mlb")
+        base, sport = resolve_job_name(compound)
+        assert base == "fetch-oddsportal"
+        assert sport == "baseball_mlb"
+
+    def test_roundtrip_mlb_results(self) -> None:
+        compound = make_compound_job_name("fetch-oddsportal-results", "baseball_mlb")
+        base, sport = resolve_job_name(compound)
+        assert base == "fetch-oddsportal-results"
+        assert sport == "baseball_mlb"


### PR DESCRIPTION
## Summary

- Make `fetch_oddsportal_results.py` sport-aware: replace hardcoded EPL constants (`SPORT_KEY`, `HARVESTER_SPORT`, `HARVESTER_LEAGUE`, `MARKET_KEY`) with `LeagueSpec` lookup via `_LEAGUE_SPEC_BY_SPORT`. Derive `market_key`, `db_market`, and `num_outcomes` from spec.
- Add `"mlb": "baseball_mlb"` to `_SPORT_SUFFIX_MAP` so `resolve_job_name("fetch-oddsportal-mlb")` works
- Add MLB heartbeat expectations to `AlertConfig` (`fetch-oddsportal-mlb: 2h`, `fetch-oddsportal-results-mlb: 26h`)
- Add `"baseball_mlb": "MLB"` to `_SPORT_DISPLAY_NAMES` in daily digest
- Unknown `primary_market` values in `_db_market_for_spec` now raise `ValueError` instead of silently passing through

LeagueSpec extension, MLB spec, and overnight skip parameterization were already merged in #300 — this PR completes the remaining config wiring.

**Tests:** 14 new tests covering MLB job routing, sport resolution, market key/db_market derivation, num_outcomes, and unknown market error handling.

## Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)