### PR TITLE
Replace fixed-interval scraper scheduling with proximity-based intervals

### DIFF
--- a/packages/odds-lambda/odds_lambda/fetch_tier.py
+++ b/packages/odds-lambda/odds_lambda/fetch_tier.py
@@ -26,6 +26,24 @@ class FetchTier(Enum):
     OPENING = "opening"  # 3+ days before: every 48 hours
 
     @property
+    def max_hours(self) -> float:
+        """Upper boundary (hours before kickoff) for this tier.
+
+        A game falls into a tier when hours_before < tier.max_hours (and
+        >= the next-lower tier's max_hours).  OPENING has no upper bound
+        so returns inf.
+        """
+        bounds: dict[FetchTier, float] = {
+            FetchTier.IN_PLAY: 0.0,
+            FetchTier.CLOSING: 3.0,
+            FetchTier.PREGAME: 12.0,
+            FetchTier.SHARP: 24.0,
+            FetchTier.EARLY: 72.0,
+            FetchTier.OPENING: float("inf"),
+        }
+        return bounds[self]
+
+    @property
     def interval_hours(self) -> float:
         """Get interval in hours for this tier."""
         intervals = {

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
@@ -27,6 +27,7 @@ from odds_core.database import async_session_maker
 from sqlalchemy import select
 from sqlmodel import col
 
+from odds_lambda.fetch_tier import FetchTier
 from odds_lambda.oddsportal_adapter import (
     MatchOdds,
     convert_upcoming_matches,
@@ -43,10 +44,6 @@ CLOSING_INTERVAL_HOURS = 0.5  # < 3h to kickoff
 PREGAME_INTERVAL_HOURS = 1.0  # 3–12h to kickoff
 FAR_INTERVAL_HOURS = 2.0  # 12h+ or no upcoming games
 DB_FALLBACK_INTERVAL_HOURS = 1.0  # DB unreachable
-
-# Proximity thresholds (hours until kickoff)
-CLOSING_THRESHOLD_HOURS = 3.0
-PREGAME_THRESHOLD_HOURS = 12.0
 
 
 @dataclass
@@ -249,9 +246,9 @@ def _interval_for_kickoff(
 
     hours_until = (next_kickoff - now).total_seconds() / 3600
 
-    if hours_until < CLOSING_THRESHOLD_HOURS:
+    if hours_until < FetchTier.CLOSING.max_hours:
         return CLOSING_INTERVAL_HOURS
-    if hours_until < PREGAME_THRESHOLD_HOURS:
+    if hours_until < FetchTier.PREGAME.max_hours:
         return PREGAME_INTERVAL_HOURS
     return FAR_INTERVAL_HOURS
 

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
@@ -1,33 +1,31 @@
 """Fetch upcoming odds from OddsPortal via OddsHarvester.
 
 Scrapes pre-match odds for configured leagues, converts to pipeline format,
-and stores via OddsWriter. Self-schedules next execution based on scrape
-outcome.
+and stores via OddsWriter. Self-schedules based on proximity to next kickoff.
 
-Self-scheduling strategy: defensively schedule at retry cadence before any
-work (no DB needed), then reschedule at normal cadence on success. If
-anything fails — DB, browser, Lambda timeout — the retry schedule is already
-set and the chain survives.
+Scheduling strategy: query DB for next kickoff, compute interval from game
+proximity, pre-schedule before any browser work so the chain survives Lambda
+timeouts. After a successful scrape, re-query (scrape may have created new
+events) and reschedule at the updated interval.
 
-This job:
-1. Pre-schedules next run at retry cadence (no DB, survives any failure)
-2. Scrapes upcoming matches from OddsPortal (via OddsHarvester)
-3. Converts fractional odds to pipeline raw_data format
-4. Matches or creates Event records
-5. Stores snapshots via OddsWriter.store_odds_snapshot()
-6. On success, reschedules at normal cadence (1h) with overnight skip
+Interval table:
+  < 3h  (CLOSING)   → 30 min
+  3–12h (PREGAME)   → 1h
+  12h+  or no games → 2h
+  DB unreachable    → 1h (fallback)
 """
 
 from __future__ import annotations
 
 import asyncio
-import random
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import structlog
 from odds_core.database import async_session_maker
+from sqlalchemy import select
+from sqlmodel import col
 
 from odds_lambda.oddsportal_adapter import (
     MatchOdds,
@@ -40,11 +38,15 @@ from odds_lambda.storage.writers import OddsWriter
 
 logger = structlog.get_logger()
 
-# Self-scheduling constants
-NORMAL_INTERVAL_HOURS = 1.0
-RETRY_DELAY_MINUTES_MIN = 10
-RETRY_DELAY_MINUTES_MAX = 15
-MAX_FAST_RETRIES = 2
+# Proximity-based scheduling intervals (hours)
+CLOSING_INTERVAL_HOURS = 0.5  # < 3h to kickoff
+PREGAME_INTERVAL_HOURS = 1.0  # 3–12h to kickoff
+FAR_INTERVAL_HOURS = 2.0  # 12h+ or no upcoming games
+DB_FALLBACK_INTERVAL_HOURS = 1.0  # DB unreachable
+
+# Proximity thresholds (hours until kickoff)
+CLOSING_THRESHOLD_HOURS = 3.0
+PREGAME_THRESHOLD_HOURS = 12.0
 
 
 @dataclass
@@ -214,30 +216,44 @@ async def ingest_league(
     return stats
 
 
-def _calculate_next_execution(
-    *,
-    success: bool,
-    retry_count: int,
-    now: datetime | None = None,
-) -> tuple[datetime, int]:
-    """Determine next execution time and updated retry_count.
+async def _get_next_kickoff(sport_key: str) -> datetime | None:
+    """Query DB for the earliest upcoming event commence_time for a sport."""
+    from odds_core.models import Event, EventStatus
 
-    Returns:
-        (next_time, next_retry_count)
-    """
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(Event.commence_time)
+            .where(
+                col(Event.sport_key) == sport_key,
+                col(Event.commence_time) > datetime.now(UTC),
+                col(Event.status) == EventStatus.SCHEDULED,
+            )
+            .order_by(col(Event.commence_time))
+            .limit(1)
+        )
+        row = result.scalar_one_or_none()
+    return row
+
+
+def _interval_for_kickoff(
+    next_kickoff: datetime | None,
+    *,
+    now: datetime | None = None,
+) -> float:
+    """Compute scheduling interval (hours) based on proximity to next kickoff."""
+    if next_kickoff is None:
+        return FAR_INTERVAL_HOURS
+
     if now is None:
         now = datetime.now(UTC)
 
-    if success:
-        return now + timedelta(hours=NORMAL_INTERVAL_HOURS), 0
+    hours_until = (next_kickoff - now).total_seconds() / 3600
 
-    # Fast failure path
-    if retry_count < MAX_FAST_RETRIES:
-        jitter_minutes = random.randint(RETRY_DELAY_MINUTES_MIN, RETRY_DELAY_MINUTES_MAX)
-        return now + timedelta(minutes=jitter_minutes), retry_count + 1
-
-    # Exhausted retries — back to normal cadence
-    return now + timedelta(hours=NORMAL_INTERVAL_HOURS), 0
+    if hours_until < CLOSING_THRESHOLD_HOURS:
+        return CLOSING_INTERVAL_HOURS
+    if hours_until < PREGAME_THRESHOLD_HOURS:
+        return PREGAME_INTERVAL_HOURS
+    return FAR_INTERVAL_HOURS
 
 
 def _apply_overnight_skip(
@@ -269,16 +285,14 @@ async def _self_schedule(
     *,
     job_name: str,
     next_time: datetime,
-    next_retry_count: int,
     dry_run: bool,
     sport: str | None = None,
+    interval_hours: float | None = None,
 ) -> None:
     """Schedule the next execution via the scheduler backend."""
     backend = get_scheduler_backend(dry_run=dry_run)
 
     payload: dict[str, object] = {}
-    if next_retry_count > 0:
-        payload["retry_count"] = next_retry_count
     if sport:
         payload["sport"] = sport
 
@@ -291,7 +305,7 @@ async def _self_schedule(
     logger.info(
         "fetch_oddsportal_next_scheduled",
         next_time=next_time.isoformat(),
-        retry_count=next_retry_count,
+        interval_hours=interval_hours,
         backend=backend.get_backend_name(),
     )
 
@@ -299,16 +313,15 @@ async def _self_schedule(
 async def main(ctx: JobContext) -> None:
     """Main job execution — scrapes configured league(s), then self-schedules.
 
-    Scheduling strategy: defensively pre-schedule at retry cadence (no DB
-    needed) so the chain survives any failure including Lambda timeouts. On
-    success, reschedule at normal cadence with overnight skip.
+    Scheduling strategy: query DB for next kickoff, compute proximity-based
+    interval, pre-schedule before browser work. After successful scrape,
+    re-query (new events may have appeared) and reschedule.
     """
     from odds_core.alerts import job_alert_context, send_job_warning
     from odds_core.config import get_settings
 
     settings = get_settings()
     sport = ctx.sport
-    retry_count = ctx.retry_count
 
     # Resolve which leagues to scrape
     if sport:
@@ -325,26 +338,34 @@ async def main(ctx: JobContext) -> None:
     # Production invokes per-sport; only relevant for local multi-league runs.
     primary_spec = specs[0]
 
-    # Defensive pre-schedule at retry cadence BEFORE any DB or browser work.
-    # No DB query needed — just now + retry delay. If anything fails (DB down,
-    # browser crash, Lambda timeout), this schedule is already set.
-    defensive_next_time, defensive_retry_count = _calculate_next_execution(
-        success=False,
-        retry_count=retry_count,
-        now=datetime.now(UTC),
-    )
-    defensive_next_time = _apply_overnight_skip(
-        defensive_next_time,
+    # Query DB for next kickoff to determine scheduling interval.
+    # On failure, fall back to 1h so we don't block on DB availability.
+    pre_interval = DB_FALLBACK_INTERVAL_HOURS
+    try:
+        next_kickoff = await _get_next_kickoff(primary_spec.sport_key)
+        pre_interval = _interval_for_kickoff(next_kickoff)
+        logger.info(
+            "proximity_schedule",
+            next_kickoff=next_kickoff.isoformat() if next_kickoff else None,
+            interval_hours=pre_interval,
+        )
+    except Exception as e:
+        logger.warning("next_kickoff_query_failed", error=str(e), exc_info=True)
+
+    # Pre-schedule before any browser work so the chain survives Lambda
+    # timeouts or browser crashes.
+    pre_next_time = _apply_overnight_skip(
+        datetime.now(UTC) + timedelta(hours=pre_interval),
         overnight_start_utc=primary_spec.overnight_start_utc,
         overnight_resume_utc=primary_spec.overnight_resume_utc,
     )
     try:
         await _self_schedule(
             job_name=compound_job_name,
-            next_time=defensive_next_time,
-            next_retry_count=defensive_retry_count,
+            next_time=pre_next_time,
             dry_run=settings.scheduler.dry_run,
             sport=sport,
+            interval_hours=pre_interval,
         )
     except Exception as e:
         logger.error("fetch_oddsportal_scheduling_failed", error=str(e), exc_info=True)
@@ -355,7 +376,6 @@ async def main(ctx: JobContext) -> None:
             "fetch_oddsportal_started",
             sport=sport,
             leagues=len(specs),
-            retry_count=retry_count,
         )
 
         all_stats: list[IngestionStats] = []
@@ -395,13 +415,21 @@ async def main(ctx: JobContext) -> None:
             )
             await send_job_warning(
                 alert_type=f"scrape_empty:{compound_job_name}",
-                message=f"⚠️ OddsPortal scrape empty ({detail}), retry #{retry_count}",
+                message=f"⚠️ OddsPortal scrape empty ({detail})",
             )
 
-    # On success, push schedule out to normal cadence
+    # On success, re-query next kickoff (scrape may have created new events)
+    # and reschedule at the updated interval.
     if total_scraped > 0:
+        post_interval = DB_FALLBACK_INTERVAL_HOURS
+        try:
+            post_kickoff = await _get_next_kickoff(primary_spec.sport_key)
+            post_interval = _interval_for_kickoff(post_kickoff)
+        except Exception as e:
+            logger.warning("post_scrape_kickoff_query_failed", error=str(e), exc_info=True)
+
         success_next_time = _apply_overnight_skip(
-            datetime.now(UTC) + timedelta(hours=NORMAL_INTERVAL_HOURS),
+            datetime.now(UTC) + timedelta(hours=post_interval),
             overnight_start_utc=primary_spec.overnight_start_utc,
             overnight_resume_utc=primary_spec.overnight_resume_utc,
         )
@@ -409,9 +437,9 @@ async def main(ctx: JobContext) -> None:
             await _self_schedule(
                 job_name=compound_job_name,
                 next_time=success_next_time,
-                next_retry_count=0,
                 dry_run=settings.scheduler.dry_run,
                 sport=sport,
+                interval_hours=post_interval,
             )
         except Exception as e:
             logger.error("fetch_oddsportal_success_scheduling_failed", error=str(e), exc_info=True)

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -22,7 +22,6 @@ class JobContext:
     """
 
     sport: str | None = None
-    retry_count: int = 0
 
     # backfill-polymarket manual invocation params
     include_spreads: bool = False

--- a/tests/unit/test_fetch_oddsportal_scheduling.py
+++ b/tests/unit/test_fetch_oddsportal_scheduling.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from odds_lambda.jobs.fetch_oddsportal import (
@@ -88,7 +88,7 @@ class TestProximityScheduling:
             call_order.append("schedule")
 
         mock_backend = AsyncMock()
-        mock_backend.get_backend_name.return_value = "test"
+        mock_backend.get_backend_name = Mock(return_value="test")
         mock_backend.schedule_next_execution = AsyncMock(side_effect=fake_schedule)
 
         with (
@@ -117,7 +117,7 @@ class TestProximityScheduling:
     async def test_success_reschedules_with_updated_interval(self) -> None:
         """On success, a second schedule call fires with re-queried interval."""
         mock_backend = AsyncMock()
-        mock_backend.get_backend_name.return_value = "test"
+        mock_backend.get_backend_name = Mock(return_value="test")
 
         with (
             patch(
@@ -156,7 +156,7 @@ class TestProximityScheduling:
     async def test_failure_keeps_prescheduled(self) -> None:
         """On failure, no second schedule call — the pre-scheduled one stands."""
         mock_backend = AsyncMock()
-        mock_backend.get_backend_name.return_value = "test"
+        mock_backend.get_backend_name = Mock(return_value="test")
 
         with (
             patch(
@@ -189,7 +189,7 @@ class TestProximityScheduling:
     async def test_chain_survives_ingest_exception(self) -> None:
         """If ingest_league raises, the pre-schedule is already set."""
         mock_backend = AsyncMock()
-        mock_backend.get_backend_name.return_value = "test"
+        mock_backend.get_backend_name = Mock(return_value="test")
 
         with (
             patch(
@@ -220,7 +220,7 @@ class TestProximityScheduling:
     async def test_db_failure_falls_back_to_1h(self) -> None:
         """If DB query fails, pre-schedule uses DB_FALLBACK_INTERVAL_HOURS."""
         mock_backend = AsyncMock()
-        mock_backend.get_backend_name.return_value = "test"
+        mock_backend.get_backend_name = Mock(return_value="test")
 
         with (
             patch(
@@ -258,7 +258,7 @@ class TestProximityScheduling:
     async def test_closing_game_schedules_30min(self) -> None:
         """Game within 3h should produce a 30-min interval."""
         mock_backend = AsyncMock()
-        mock_backend.get_backend_name.return_value = "test"
+        mock_backend.get_backend_name = Mock(return_value="test")
 
         kickoff = datetime.now(UTC) + timedelta(hours=1)
 
@@ -298,7 +298,7 @@ class TestProximityScheduling:
     async def test_far_game_schedules_2h(self) -> None:
         """Game 24h+ away should produce a 2h interval."""
         mock_backend = AsyncMock()
-        mock_backend.get_backend_name.return_value = "test"
+        mock_backend.get_backend_name = Mock(return_value="test")
 
         kickoff = datetime.now(UTC) + timedelta(hours=24)
 

--- a/tests/unit/test_fetch_oddsportal_scheduling.py
+++ b/tests/unit/test_fetch_oddsportal_scheduling.py
@@ -8,13 +8,12 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from odds_lambda.fetch_tier import FetchTier
 from odds_lambda.jobs.fetch_oddsportal import (
     CLOSING_INTERVAL_HOURS,
-    CLOSING_THRESHOLD_HOURS,
     DB_FALLBACK_INTERVAL_HOURS,
     FAR_INTERVAL_HOURS,
     PREGAME_INTERVAL_HOURS,
-    PREGAME_THRESHOLD_HOURS,
     _interval_for_kickoff,
     main,
 )
@@ -35,7 +34,7 @@ class TestIntervalForKickoff:
     def test_game_at_closing_boundary(self) -> None:
         now = datetime(2026, 4, 7, 14, 0, tzinfo=UTC)
         # Exactly at 3h boundary — should be closing (< 3h is false, so pregame)
-        kickoff = now + timedelta(hours=CLOSING_THRESHOLD_HOURS)
+        kickoff = now + timedelta(hours=FetchTier.CLOSING.max_hours)
         assert _interval_for_kickoff(kickoff, now=now) == PREGAME_INTERVAL_HOURS
 
     def test_game_just_under_closing_threshold(self) -> None:
@@ -50,7 +49,7 @@ class TestIntervalForKickoff:
 
     def test_game_at_pregame_boundary(self) -> None:
         now = datetime(2026, 4, 7, 14, 0, tzinfo=UTC)
-        kickoff = now + timedelta(hours=PREGAME_THRESHOLD_HOURS)
+        kickoff = now + timedelta(hours=FetchTier.PREGAME.max_hours)
         assert _interval_for_kickoff(kickoff, now=now) == FAR_INTERVAL_HOURS
 
     def test_game_far_away(self) -> None:

--- a/tests/unit/test_fetch_oddsportal_scheduling.py
+++ b/tests/unit/test_fetch_oddsportal_scheduling.py
@@ -1,4 +1,4 @@
-"""Tests for fetch_oddsportal self-scheduling logic."""
+"""Tests for fetch_oddsportal proximity-based scheduling logic."""
 
 from __future__ import annotations
 
@@ -9,63 +9,64 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from odds_lambda.jobs.fetch_oddsportal import (
-    MAX_FAST_RETRIES,
-    NORMAL_INTERVAL_HOURS,
-    RETRY_DELAY_MINUTES_MAX,
-    RETRY_DELAY_MINUTES_MIN,
-    _calculate_next_execution,
+    CLOSING_INTERVAL_HOURS,
+    CLOSING_THRESHOLD_HOURS,
+    DB_FALLBACK_INTERVAL_HOURS,
+    FAR_INTERVAL_HOURS,
+    PREGAME_INTERVAL_HOURS,
+    PREGAME_THRESHOLD_HOURS,
+    _interval_for_kickoff,
     main,
 )
 from odds_lambda.scheduling.jobs import JobContext
 
 
-class TestCalculateNextExecution:
-    """Tests for _calculate_next_execution scheduling logic."""
+class TestIntervalForKickoff:
+    """Tests for _interval_for_kickoff proximity logic."""
 
-    def test_success_schedules_normal_interval(self) -> None:
+    def test_no_upcoming_games_returns_far_interval(self) -> None:
+        assert _interval_for_kickoff(None) == FAR_INTERVAL_HOURS
+
+    def test_game_within_closing_window(self) -> None:
         now = datetime(2026, 4, 7, 14, 0, tzinfo=UTC)
-        next_time, retry_count = _calculate_next_execution(success=True, retry_count=0, now=now)
-        assert next_time == now + timedelta(hours=NORMAL_INTERVAL_HOURS)
-        assert retry_count == 0
+        kickoff = now + timedelta(hours=1)
+        assert _interval_for_kickoff(kickoff, now=now) == CLOSING_INTERVAL_HOURS
 
-    def test_success_resets_retry_count(self) -> None:
+    def test_game_at_closing_boundary(self) -> None:
         now = datetime(2026, 4, 7, 14, 0, tzinfo=UTC)
-        _, retry_count = _calculate_next_execution(success=True, retry_count=2, now=now)
-        assert retry_count == 0
+        # Exactly at 3h boundary — should be closing (< 3h is false, so pregame)
+        kickoff = now + timedelta(hours=CLOSING_THRESHOLD_HOURS)
+        assert _interval_for_kickoff(kickoff, now=now) == PREGAME_INTERVAL_HOURS
 
-    def test_first_failure_retries_quickly(self) -> None:
+    def test_game_just_under_closing_threshold(self) -> None:
         now = datetime(2026, 4, 7, 14, 0, tzinfo=UTC)
-        next_time, retry_count = _calculate_next_execution(success=False, retry_count=0, now=now)
-        delay_minutes = (next_time - now).total_seconds() / 60
-        assert RETRY_DELAY_MINUTES_MIN <= delay_minutes <= RETRY_DELAY_MINUTES_MAX
-        assert retry_count == 1
+        kickoff = now + timedelta(hours=2.99)
+        assert _interval_for_kickoff(kickoff, now=now) == CLOSING_INTERVAL_HOURS
 
-    def test_second_failure_retries_quickly(self) -> None:
+    def test_game_in_pregame_window(self) -> None:
         now = datetime(2026, 4, 7, 14, 0, tzinfo=UTC)
-        next_time, retry_count = _calculate_next_execution(success=False, retry_count=1, now=now)
-        delay_minutes = (next_time - now).total_seconds() / 60
-        assert RETRY_DELAY_MINUTES_MIN <= delay_minutes <= RETRY_DELAY_MINUTES_MAX
-        assert retry_count == 2
+        kickoff = now + timedelta(hours=6)
+        assert _interval_for_kickoff(kickoff, now=now) == PREGAME_INTERVAL_HOURS
 
-    def test_exhausted_retries_returns_normal_interval(self) -> None:
+    def test_game_at_pregame_boundary(self) -> None:
         now = datetime(2026, 4, 7, 14, 0, tzinfo=UTC)
-        next_time, retry_count = _calculate_next_execution(
-            success=False, retry_count=MAX_FAST_RETRIES, now=now
-        )
-        assert next_time == now + timedelta(hours=NORMAL_INTERVAL_HOURS)
-        assert retry_count == 0
+        kickoff = now + timedelta(hours=PREGAME_THRESHOLD_HOURS)
+        assert _interval_for_kickoff(kickoff, now=now) == FAR_INTERVAL_HOURS
 
-    def test_exhausted_retries_above_max(self) -> None:
+    def test_game_far_away(self) -> None:
         now = datetime(2026, 4, 7, 14, 0, tzinfo=UTC)
-        next_time, retry_count = _calculate_next_execution(
-            success=False, retry_count=MAX_FAST_RETRIES + 5, now=now
-        )
-        assert next_time == now + timedelta(hours=NORMAL_INTERVAL_HOURS)
-        assert retry_count == 0
+        kickoff = now + timedelta(hours=24)
+        assert _interval_for_kickoff(kickoff, now=now) == FAR_INTERVAL_HOURS
+
+    def test_game_already_started(self) -> None:
+        now = datetime(2026, 4, 7, 14, 0, tzinfo=UTC)
+        kickoff = now - timedelta(hours=1)
+        # Negative hours_until — should still return closing interval
+        assert _interval_for_kickoff(kickoff, now=now) == CLOSING_INTERVAL_HOURS
 
 
-class TestDefensivePreScheduling:
-    """Verify defensive scheduling: pre-schedule at retry cadence, reschedule on success."""
+class TestProximityScheduling:
+    """Verify proximity-based scheduling in main()."""
 
     @staticmethod
     @asynccontextmanager
@@ -73,8 +74,8 @@ class TestDefensivePreScheduling:
         yield
 
     @pytest.mark.asyncio
-    async def test_preschedule_at_retry_cadence_before_scrape(self) -> None:
-        """Pre-schedule must use retry cadence and fire before ingest_league."""
+    async def test_preschedule_before_scrape(self) -> None:
+        """Pre-schedule must fire before ingest_league."""
         call_order: list[str] = []
 
         async def fake_ingest(spec):
@@ -98,9 +99,14 @@ class TestDefensivePreScheduling:
             ),
             patch("odds_core.config.get_settings") as mock_settings,
             patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal._get_next_kickoff",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
         ):
             mock_settings.return_value.scheduler.dry_run = False
-            await main(JobContext(retry_count=0))
+            await main(JobContext())
 
         assert call_order[0] == "schedule", (
             "schedule_next_execution must be called before ingest_league"
@@ -108,8 +114,8 @@ class TestDefensivePreScheduling:
         assert "ingest" in call_order
 
     @pytest.mark.asyncio
-    async def test_success_reschedules_at_normal_cadence(self) -> None:
-        """On success, a second schedule call pushes to normal cadence."""
+    async def test_success_reschedules_with_updated_interval(self) -> None:
+        """On success, a second schedule call fires with re-queried interval."""
         mock_backend = AsyncMock()
         mock_backend.get_backend_name.return_value = "test"
 
@@ -123,6 +129,11 @@ class TestDefensivePreScheduling:
             ),
             patch("odds_core.config.get_settings") as mock_settings,
             patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal._get_next_kickoff",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
         ):
             from odds_lambda.jobs.fetch_oddsportal import IngestionStats
 
@@ -131,17 +142,19 @@ class TestDefensivePreScheduling:
                 league="test", matches_scraped=5, snapshots_stored=3
             )
 
-            await main(JobContext(retry_count=0))
+            await main(JobContext())
 
-        # Pre-schedule (retry cadence) + success reschedule (normal cadence)
+        # Pre-schedule + success reschedule
         assert mock_backend.schedule_next_execution.call_count == 2
-        # Last call should have no retry payload (success resets)
-        last_call = mock_backend.schedule_next_execution.call_args
-        assert last_call.kwargs.get("payload") is None
+        # No retry_count in any payload
+        for call in mock_backend.schedule_next_execution.call_args_list:
+            payload = call.kwargs.get("payload")
+            if payload:
+                assert "retry_count" not in payload
 
     @pytest.mark.asyncio
-    async def test_failure_keeps_defensive_schedule(self) -> None:
-        """On failure, no second schedule call — the defensive one stands."""
+    async def test_failure_keeps_prescheduled(self) -> None:
+        """On failure, no second schedule call — the pre-scheduled one stands."""
         mock_backend = AsyncMock()
         mock_backend.get_backend_name.return_value = "test"
 
@@ -156,20 +169,25 @@ class TestDefensivePreScheduling:
             patch("odds_core.config.get_settings") as mock_settings,
             patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
             patch("odds_core.alerts.send_job_warning", new_callable=AsyncMock),
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal._get_next_kickoff",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
         ):
             from odds_lambda.jobs.fetch_oddsportal import IngestionStats
 
             mock_settings.return_value.scheduler.dry_run = False
             mock_ingest.return_value = IngestionStats(league="test", matches_scraped=0)
 
-            await main(JobContext(retry_count=0))
+            await main(JobContext())
 
-        # Only the defensive pre-schedule fires
+        # Only the pre-schedule fires
         assert mock_backend.schedule_next_execution.call_count == 1
 
     @pytest.mark.asyncio
     async def test_chain_survives_ingest_exception(self) -> None:
-        """If ingest_league raises, the defensive schedule is already set."""
+        """If ingest_league raises, the pre-schedule is already set."""
         mock_backend = AsyncMock()
         mock_backend.get_backend_name.return_value = "test"
 
@@ -186,31 +204,27 @@ class TestDefensivePreScheduling:
             patch("odds_core.config.get_settings") as mock_settings,
             patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
             patch("odds_core.alerts.send_job_warning", new_callable=AsyncMock),
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal._get_next_kickoff",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
         ):
             mock_settings.return_value.scheduler.dry_run = False
-            await main(JobContext(retry_count=0))
+            await main(JobContext())
 
-        # Only the defensive pre-schedule fires (no success reschedule)
+        # Only the pre-schedule fires
         assert mock_backend.schedule_next_execution.call_count == 1
 
-
-class TestRetryCountIntegration:
-    """Verify retry_count flows correctly through main()."""
-
-    @staticmethod
-    @asynccontextmanager
-    async def _noop_alert_context(name: str) -> AsyncIterator[None]:
-        yield
-
     @pytest.mark.asyncio
-    async def test_failure_increments_retry_count(self) -> None:
+    async def test_db_failure_falls_back_to_1h(self) -> None:
+        """If DB query fails, pre-schedule uses DB_FALLBACK_INTERVAL_HOURS."""
         mock_backend = AsyncMock()
         mock_backend.get_backend_name.return_value = "test"
 
         with (
             patch(
-                "odds_lambda.jobs.fetch_oddsportal.ingest_league",
-                new_callable=AsyncMock,
+                "odds_lambda.jobs.fetch_oddsportal.ingest_league", new_callable=AsyncMock
             ) as mock_ingest,
             patch(
                 "odds_lambda.jobs.fetch_oddsportal.get_scheduler_backend",
@@ -218,35 +232,11 @@ class TestRetryCountIntegration:
             ),
             patch("odds_core.config.get_settings") as mock_settings,
             patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
-            patch("odds_core.alerts.send_job_warning", new_callable=AsyncMock),
-        ):
-            from odds_lambda.jobs.fetch_oddsportal import IngestionStats
-
-            mock_settings.return_value.scheduler.dry_run = False
-            mock_ingest.return_value = IngestionStats(league="test", matches_scraped=0)
-
-            await main(JobContext(retry_count=0))
-
-            # Defensive pre-schedule has retry_count=1
-            call_kwargs = mock_backend.schedule_next_execution.call_args
-            assert call_kwargs.kwargs["payload"] == {"retry_count": 1}
-
-    @pytest.mark.asyncio
-    async def test_success_resets_retry_count(self) -> None:
-        mock_backend = AsyncMock()
-        mock_backend.get_backend_name.return_value = "test"
-
-        with (
             patch(
-                "odds_lambda.jobs.fetch_oddsportal.ingest_league",
+                "odds_lambda.jobs.fetch_oddsportal._get_next_kickoff",
                 new_callable=AsyncMock,
-            ) as mock_ingest,
-            patch(
-                "odds_lambda.jobs.fetch_oddsportal.get_scheduler_backend",
-                return_value=mock_backend,
+                side_effect=Exception("DB connection refused"),
             ),
-            patch("odds_core.config.get_settings") as mock_settings,
-            patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
         ):
             from odds_lambda.jobs.fetch_oddsportal import IngestionStats
 
@@ -255,9 +245,91 @@ class TestRetryCountIntegration:
                 league="test", matches_scraped=5, snapshots_stored=3
             )
 
-            await main(JobContext(retry_count=2))
+            now = datetime.now(UTC)
+            await main(JobContext())
 
-            # Last call is the success reschedule with no retry payload
-            assert mock_backend.schedule_next_execution.call_count == 2
-            last_call = mock_backend.schedule_next_execution.call_args
-            assert last_call.kwargs.get("payload") is None
+        # Pre-schedule should use fallback interval (~1h from now)
+        first_call = mock_backend.schedule_next_execution.call_args_list[0]
+        scheduled_time = first_call.kwargs["next_time"]
+        delta_hours = (scheduled_time - now).total_seconds() / 3600
+        assert 0.9 <= delta_hours <= DB_FALLBACK_INTERVAL_HOURS + 0.1
+
+    @pytest.mark.asyncio
+    async def test_closing_game_schedules_30min(self) -> None:
+        """Game within 3h should produce a 30-min interval."""
+        mock_backend = AsyncMock()
+        mock_backend.get_backend_name.return_value = "test"
+
+        kickoff = datetime.now(UTC) + timedelta(hours=1)
+
+        with (
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal.ingest_league", new_callable=AsyncMock
+            ) as mock_ingest,
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal.get_scheduler_backend",
+                return_value=mock_backend,
+            ),
+            patch("odds_core.config.get_settings") as mock_settings,
+            patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal._get_next_kickoff",
+                new_callable=AsyncMock,
+                return_value=kickoff,
+            ),
+        ):
+            from odds_lambda.jobs.fetch_oddsportal import IngestionStats
+
+            mock_settings.return_value.scheduler.dry_run = False
+            mock_ingest.return_value = IngestionStats(
+                league="test", matches_scraped=5, snapshots_stored=3
+            )
+
+            now = datetime.now(UTC)
+            await main(JobContext())
+
+        # Pre-schedule at ~30 min
+        first_call = mock_backend.schedule_next_execution.call_args_list[0]
+        scheduled_time = first_call.kwargs["next_time"]
+        delta_minutes = (scheduled_time - now).total_seconds() / 60
+        assert 25 <= delta_minutes <= 35
+
+    @pytest.mark.asyncio
+    async def test_far_game_schedules_2h(self) -> None:
+        """Game 24h+ away should produce a 2h interval."""
+        mock_backend = AsyncMock()
+        mock_backend.get_backend_name.return_value = "test"
+
+        kickoff = datetime.now(UTC) + timedelta(hours=24)
+
+        with (
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal.ingest_league", new_callable=AsyncMock
+            ) as mock_ingest,
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal.get_scheduler_backend",
+                return_value=mock_backend,
+            ),
+            patch("odds_core.config.get_settings") as mock_settings,
+            patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal._get_next_kickoff",
+                new_callable=AsyncMock,
+                return_value=kickoff,
+            ),
+        ):
+            from odds_lambda.jobs.fetch_oddsportal import IngestionStats
+
+            mock_settings.return_value.scheduler.dry_run = False
+            mock_ingest.return_value = IngestionStats(
+                league="test", matches_scraped=5, snapshots_stored=3
+            )
+
+            now = datetime.now(UTC)
+            await main(JobContext())
+
+        # Pre-schedule at ~2h
+        first_call = mock_backend.schedule_next_execution.call_args_list[0]
+        scheduled_time = first_call.kwargs["next_time"]
+        delta_hours = (scheduled_time - now).total_seconds() / 3600
+        assert 1.9 <= delta_hours <= 2.1


### PR DESCRIPTION
## Summary

- Replace fixed 1h success / 10-15min retry cadence with proximity-based scheduling: 30min when a game is within 3h, 1h for 3-12h, 2h for 12h+ or no upcoming games
- Remove `retry_count`, `MAX_FAST_RETRIES`, and success/failure branching from `_calculate_next_execution`
- Add `_get_next_kickoff()` DB query and `_interval_for_kickoff()` threshold mapping
- Restructure `main()`: pre-schedule before scraping (DB failure falls back to 1h), reschedule after successful scrape to pick up newly created events
- Remove `retry_count` from `JobContext` payload
- Rewrite tests: 15 tests covering all interval tiers, boundary cases, DB fallback, and end-to-end scheduling flows

## Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)