### PR TITLE
Separate 1x2 and h2h market keys to prevent odds conflation

### DIFF
--- a/experiments/configs/xgboost_epl_baseline_tuning.yaml
+++ b/experiments/configs/xgboost_epl_baseline_tuning.yaml
@@ -54,7 +54,7 @@ training:
     - betfred
     - bwin
     markets:
-    - h2h
+    - 1x2
     outcome: home
     closing_tier: closing
     sampling:

--- a/experiments/configs/xgboost_epl_betfair_sharp.yaml
+++ b/experiments/configs/xgboost_epl_betfair_sharp.yaml
@@ -55,7 +55,7 @@ training:
     - betfred
     - bwin
     markets:
-    - h2h
+    - 1x2
     outcome: home
     closing_tier: closing
     closing_source_priority:

--- a/experiments/configs/xgboost_epl_combined_all_tuning.yaml
+++ b/experiments/configs/xgboost_epl_combined_all_tuning.yaml
@@ -59,7 +59,7 @@ training:
     - betfred
     - bwin
     markets:
-    - h2h
+    - 1x2
     outcome: home
     closing_tier: closing
     closing_source_priority:

--- a/experiments/configs/xgboost_epl_combined_bet365sharp_tuning.yaml
+++ b/experiments/configs/xgboost_epl_combined_bet365sharp_tuning.yaml
@@ -55,7 +55,7 @@ training:
     - betfred
     - bwin
     markets:
-    - h2h
+    - 1x2
     outcome: home
     closing_tier: closing
     closing_source_priority:

--- a/experiments/configs/xgboost_epl_combined_match_stats_tuning.yaml
+++ b/experiments/configs/xgboost_epl_combined_match_stats_tuning.yaml
@@ -59,7 +59,7 @@ training:
     - betfred
     - bwin
     markets:
-    - h2h
+    - 1x2
     outcome: home
     closing_tier: closing
     closing_source_priority:

--- a/experiments/configs/xgboost_epl_combined_schedule_tuning.yaml
+++ b/experiments/configs/xgboost_epl_combined_schedule_tuning.yaml
@@ -57,7 +57,7 @@ training:
     - betfred
     - bwin
     markets:
-    - h2h
+    - 1x2
     outcome: home
     closing_tier: closing
     closing_source_priority:

--- a/experiments/configs/xgboost_epl_combined_standings_schedule_tuning.yaml
+++ b/experiments/configs/xgboost_epl_combined_standings_schedule_tuning.yaml
@@ -58,7 +58,7 @@ training:
     - betfred
     - bwin
     markets:
-    - h2h
+    - 1x2
     outcome: home
     closing_tier: closing
     closing_source_priority:

--- a/experiments/configs/xgboost_epl_combined_standings_tuning.yaml
+++ b/experiments/configs/xgboost_epl_combined_standings_tuning.yaml
@@ -59,7 +59,7 @@ training:
     - betfred
     - bwin
     markets:
-    - h2h
+    - 1x2
     outcome: home
     closing_tier: closing
     closing_source_priority:

--- a/experiments/configs/xgboost_epl_combined_tuning.yaml
+++ b/experiments/configs/xgboost_epl_combined_tuning.yaml
@@ -57,7 +57,7 @@ training:
     - betfred
     - bwin
     markets:
-    - h2h
+    - 1x2
     outcome: home
     closing_tier: closing
     closing_source_priority:

--- a/experiments/configs/xgboost_epl_hybrid_sharp.yaml
+++ b/experiments/configs/xgboost_epl_hybrid_sharp.yaml
@@ -62,7 +62,7 @@ training:
     - betfred
     - bwin
     markets:
-    - h2h
+    - 1x2
     outcome: home
     closing_tier: closing
     closing_source_priority:

--- a/experiments/configs/xgboost_epl_lineup.yaml
+++ b/experiments/configs/xgboost_epl_lineup.yaml
@@ -57,7 +57,7 @@ training:
     - betfred
     - bwin
     markets:
-    - h2h
+    - 1x2
     outcome: home
     closing_tier: closing
     closing_source_priority:

--- a/experiments/configs/xgboost_epl_pinnacle_sharp_2024.yaml
+++ b/experiments/configs/xgboost_epl_pinnacle_sharp_2024.yaml
@@ -54,7 +54,7 @@ training:
     - betfred
     - bwin
     markets:
-    - h2h
+    - 1x2
     outcome: home
     closing_tier: closing
     closing_source_priority:

--- a/experiments/scripts/lineup_signal_check.py
+++ b/experiments/scripts/lineup_signal_check.py
@@ -879,19 +879,20 @@ async def analyze_closing_tier_target_variance(early_targets: np.ndarray) -> Non
         # Sort by snapshot_time descending — first is the actual close
         snap_event_pairs.sort(key=lambda x: x[0].snapshot_time, reverse=True)
         closing_snapshot, event = snap_event_pairs[0]
-        closing_odds = extract_odds_from_snapshot(closing_snapshot, event_id, market="h2h")
+        closing_odds = extract_odds_from_snapshot(closing_snapshot, event_id, market="1x2")
 
         # Compute target for every snapshot in this event (including close vs itself = 0)
         for snapshot, _ in snap_event_pairs:
             if snapshot.id == closing_snapshot.id:
                 continue  # skip close vs itself
-            snapshot_odds = extract_odds_from_snapshot(snapshot, event_id, market="h2h")
+            snapshot_odds = extract_odds_from_snapshot(snapshot, event_id, market="1x2")
             target = calculate_devigged_bookmaker_target(
                 snapshot_odds,
                 closing_odds,
                 event.home_team,
                 event.away_team,
                 bookmaker_key="bet365",
+                market_key="1x2",
             )
             if target is not None:
                 closing_targets.append(target)

--- a/migrations/versions/920aee156d9c_relabel_1x2_market_key_from_h2h_to_1x2.py
+++ b/migrations/versions/920aee156d9c_relabel_1x2_market_key_from_h2h_to_1x2.py
@@ -1,0 +1,134 @@
+"""relabel 1x2 market_key from h2h to 1x2
+
+Odds rows with outcome_name='Draw' are 1x2 (3-way) data that was stored
+under market_key='h2h'. This migration relabels them to '1x2', including
+sibling home/away rows in the same snapshot group, and patches the
+raw_data JSON on the parent odds_snapshots.
+
+Revision ID: 920aee156d9c
+Revises: 5eca7168d060
+Create Date: 2026-04-15 14:10:32.881407
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "920aee156d9c"
+down_revision = "5eca7168d060"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Step 1: Update odds table — relabel all h2h rows that share a
+    # (event_id, bookmaker_key, odds_timestamp) group with a Draw outcome.
+    op.execute("""
+        UPDATE odds
+        SET market_key = '1x2'
+        WHERE market_key = 'h2h'
+          AND (event_id, bookmaker_key, odds_timestamp) IN (
+            SELECT event_id, bookmaker_key, odds_timestamp
+            FROM odds
+            WHERE market_key = 'h2h' AND outcome_name = 'Draw'
+          )
+    """)
+
+    # Step 2: Update raw_data JSON in odds_snapshots — replace "h2h" with
+    # "1x2" in any bookmaker market entry that contains a Draw outcome.
+    # Uses jsonb_set on each matching market object.
+    op.execute("""
+        UPDATE odds_snapshots
+        SET raw_data = (
+            SELECT jsonb_set(
+                raw_data,
+                '{bookmakers}',
+                (
+                    SELECT jsonb_agg(
+                        CASE
+                            WHEN (
+                                SELECT bool_or(outcome->>'name' = 'Draw')
+                                FROM jsonb_array_elements(bk->'markets') AS m,
+                                     jsonb_array_elements(m->'outcomes') AS outcome
+                            )
+                            THEN jsonb_set(
+                                bk,
+                                '{markets}',
+                                (
+                                    SELECT jsonb_agg(
+                                        CASE
+                                            WHEN m->>'key' = 'h2h'
+                                                 AND (
+                                                     SELECT bool_or(o->>'name' = 'Draw')
+                                                     FROM jsonb_array_elements(m->'outcomes') AS o
+                                                 )
+                                            THEN jsonb_set(m, '{key}', '"1x2"')
+                                            ELSE m
+                                        END
+                                    )
+                                    FROM jsonb_array_elements(bk->'markets') AS m
+                                )
+                            )
+                            ELSE bk
+                        END
+                    )
+                    FROM jsonb_array_elements(raw_data->'bookmakers') AS bk
+                )
+            )
+        )
+        WHERE id IN (
+            SELECT s.id
+            FROM odds_snapshots s,
+                 jsonb_array_elements(s.raw_data->'bookmakers') AS bk,
+                 jsonb_array_elements(bk->'markets') AS m,
+                 jsonb_array_elements(m->'outcomes') AS outcome
+            WHERE m->>'key' = 'h2h'
+              AND outcome->>'name' = 'Draw'
+        )
+    """)
+
+
+def downgrade() -> None:
+    # Reverse: relabel 1x2 back to h2h in odds table
+    op.execute("""
+        UPDATE odds
+        SET market_key = 'h2h'
+        WHERE market_key = '1x2'
+    """)
+
+    # Reverse: patch raw_data JSON back
+    op.execute("""
+        UPDATE odds_snapshots
+        SET raw_data = (
+            SELECT jsonb_set(
+                raw_data,
+                '{bookmakers}',
+                (
+                    SELECT jsonb_agg(
+                        jsonb_set(
+                            bk,
+                            '{markets}',
+                            (
+                                SELECT jsonb_agg(
+                                    CASE
+                                        WHEN m->>'key' = '1x2'
+                                        THEN jsonb_set(m, '{key}', '"h2h"')
+                                        ELSE m
+                                    END
+                                )
+                                FROM jsonb_array_elements(bk->'markets') AS m
+                            )
+                        )
+                    )
+                    FROM jsonb_array_elements(raw_data->'bookmakers') AS bk
+                )
+            )
+        )
+        WHERE id IN (
+            SELECT s.id
+            FROM odds_snapshots s,
+                 jsonb_array_elements(s.raw_data->'bookmakers') AS bk,
+                 jsonb_array_elements(bk->'markets') AS m
+            WHERE m->>'key' = '1x2'
+        )
+    """)

--- a/packages/odds-analytics/odds_analytics/backtesting/services.py
+++ b/packages/odds-analytics/odds_analytics/backtesting/services.py
@@ -162,10 +162,7 @@ class BacktestEngine:
                     event, odds_snapshot, self.config, self.reader.session
                 )
 
-                is_three_way_h2h = any(
-                    o.market_key == "h2h" and o.outcome_name.lower() == "draw"
-                    for o in odds_snapshot
-                )
+                is_three_way_h2h = any(o.market_key == "1x2" for o in odds_snapshot)
 
                 for opportunity in opportunities:
                     stake = self._calculate_stake(opportunity, bankroll)
@@ -279,7 +276,7 @@ class BacktestEngine:
         is_three_way: bool = False,
     ) -> tuple[str, float]:
         """Evaluate bet result using opportunity details and event outcome."""
-        if opportunity.market == "h2h":
+        if opportunity.market in ("h2h", "1x2"):
             won = self._evaluate_moneyline_outcome(
                 opportunity.outcome, event, is_three_way=is_three_way
             )

--- a/packages/odds-analytics/odds_analytics/feature_groups.py
+++ b/packages/odds-analytics/odds_analytics/feature_groups.py
@@ -917,6 +917,7 @@ def _compute_target(
             event.home_team,
             event.away_team,
             bookmaker_key=config.target_bookmaker,
+            market_key=market,
         )
     else:
         # "raw": avg implied prob delta (snapshot → closing)
@@ -939,10 +940,10 @@ def _has_bookmaker_closing(
     closing_odds_all = extract_odds_from_snapshot(closing_snapshot, event.id, market=market)
     if market == "totals":
         return extract_devigged_totals_probs(closing_odds_all, bookmaker_key) is not None
-    if market == "h2h":
+    if market in ("h2h", "1x2"):
         return (
             extract_devigged_h2h_probs(
-                closing_odds_all, event.home_team, event.away_team, bookmaker_key
+                closing_odds_all, event.home_team, event.away_team, bookmaker_key, market
             )
             is not None
         )

--- a/packages/odds-analytics/odds_analytics/sequence_loader.py
+++ b/packages/odds-analytics/odds_analytics/sequence_loader.py
@@ -134,18 +134,19 @@ def extract_devigged_h2h_probs(
     home_team: str,
     away_team: str,
     bookmaker_key: str = "pinnacle",
+    market_key: str = "h2h",
 ) -> DeviggedProbs | None:
-    """Extract devigged h2h probabilities from a specific bookmaker.
+    """Extract devigged moneyline probabilities from a specific bookmaker.
 
-    Supports both 2-way (NBA: home/away) and 3-way (soccer: home/draw/away) markets.
-    Filters odds to the given bookmaker's h2h market, finds all outcomes,
+    Supports both 2-way (h2h: home/away) and 3-way (1x2: home/draw/away) markets.
+    Filters odds to the given bookmaker and market, finds all outcomes,
     converts to implied probabilities, and applies proportional devigging.
 
     Returns:
         DeviggedProbs with home, draw (None for 2-way), and away fields.
         None if home or away outcome is missing for the bookmaker.
     """
-    bm_h2h = [o for o in odds if o.bookmaker_key == bookmaker_key and o.market_key == "h2h"]
+    bm_h2h = [o for o in odds if o.bookmaker_key == bookmaker_key and o.market_key == market_key]
     if not bm_h2h:
         return None
 
@@ -181,6 +182,7 @@ def calculate_devigged_bookmaker_target(
     home_team: str,
     away_team: str,
     bookmaker_key: str = "pinnacle",
+    market_key: str = "h2h",
 ) -> float | None:
     """Calculate target as devigged bookmaker close minus devigged bookmaker at snapshot.
 
@@ -188,8 +190,12 @@ def calculate_devigged_bookmaker_target(
         fair_close_home - fair_snapshot_home, or None if bookmaker data missing
         on either side.
     """
-    snapshot_probs = extract_devigged_h2h_probs(snapshot_odds, home_team, away_team, bookmaker_key)
-    closing_probs = extract_devigged_h2h_probs(closing_odds, home_team, away_team, bookmaker_key)
+    snapshot_probs = extract_devigged_h2h_probs(
+        snapshot_odds, home_team, away_team, bookmaker_key, market_key
+    )
+    closing_probs = extract_devigged_h2h_probs(
+        closing_odds, home_team, away_team, bookmaker_key, market_key
+    )
 
     if snapshot_probs is None or closing_probs is None:
         return None

--- a/packages/odds-analytics/odds_analytics/strategies.py
+++ b/packages/odds-analytics/odds_analytics/strategies.py
@@ -278,7 +278,7 @@ class ArbitrageStrategy(BettingStrategy):
         bookmakers = self.params["bookmakers"]
 
         # Check each market type
-        for market in ["h2h", "spreads", "totals"]:
+        for market in ["h2h", "1x2", "spreads", "totals"]:
             market_odds = [
                 o for o in odds_snapshot if o.market_key == market and o.bookmaker_key in bookmakers
             ]
@@ -286,7 +286,7 @@ class ArbitrageStrategy(BettingStrategy):
             if not market_odds:
                 continue
 
-            if market == "h2h":
+            if market in ("h2h", "1x2"):
                 home_odds = [o for o in market_odds if o.outcome_name == event.home_team]
                 away_odds = [o for o in market_odds if o.outcome_name == event.away_team]
                 draw_odds = [o for o in market_odds if o.outcome_name.lower() == "draw"]

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py
@@ -56,8 +56,10 @@ def _db_market_for_spec(spec: LeagueSpec) -> str:
     Maps OddsPortal market names to the pipeline's canonical market key used
     in ``raw_data["bookmakers"][*]["markets"][*]["key"]``.
     """
-    if spec.primary_market in ("home_away", "1x2"):
+    if spec.primary_market == "home_away":
         return "h2h"
+    if spec.primary_market == "1x2":
+        return "1x2"
     raise ValueError(f"Unrecognized primary_market: {spec.primary_market!r}")
 
 

--- a/packages/odds-lambda/odds_lambda/oddsportal_adapter.py
+++ b/packages/odds-lambda/odds_lambda/oddsportal_adapter.py
@@ -198,7 +198,7 @@ def _convert_1x2_match(
                 liquidity["away"] = away_liq
 
         bookmakers.append(
-            _build_bookmaker_entry(bk_key, bk_name, "h2h", outcomes, betfair_matched=liquidity)
+            _build_bookmaker_entry(bk_key, bk_name, "1x2", outcomes, betfair_matched=liquidity)
         )
 
     if not bookmakers:

--- a/packages/odds-mcp/agents/epl/base.md
+++ b/packages/odds-mcp/agents/epl/base.md
@@ -12,6 +12,8 @@ The XGBoost CLV model is a supplementary signal. Its strongest feature is the sh
 
 When a tool call returns an error, adapt: retry with corrected parameters, try an alternative tool, or note the gap and proceed with what you have.
 
+EPL is a 3-way market (home/draw/away). Use `market="1x2"` for all MCP tools that require a market parameter.
+
 ## Data Sources
 
 **OddsPortal** is the active odds source. OddsPortal scrapes can create duplicate event IDs for the same match (one from the upcoming page, one from the live/results page). When you see duplicates, always prefer the `op_live_*` event ID — these have UK bookmakers (bet365, betway, betfred) and sharp references (Betfair Exchange). Non-OP events will have missing sharp data.

--- a/packages/odds-mcp/agents/mlb/base.md
+++ b/packages/odds-mcp/agents/mlb/base.md
@@ -12,6 +12,8 @@ There is no CLV prediction model for MLB. Your analysis is purely information-dr
 
 When a tool call returns an error, adapt: retry with corrected parameters, try an alternative tool, or note the gap and proceed with what you have.
 
+MLB is a 2-way market (home/away, no draw). Use `market="h2h"` for all MCP tools that require a market parameter.
+
 ## Sport-Specific Tool Defaults
 
 When calling MCP tools, use these MLB-specific parameters:

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -32,6 +32,8 @@ from sqlalchemy import func, select
 
 logger = structlog.get_logger()
 
+MarketKey = Literal["h2h", "1x2", "totals", "spreads"]
+
 mcp = FastMCP(
     "odds-mcp",
     instructions=(
@@ -171,12 +173,15 @@ async def get_upcoming_fixtures(
 @mcp.tool()
 async def get_current_odds(
     event_id: str,
+    market: MarketKey,
     include_raw_data: bool = False,
 ) -> dict[str, Any]:
     """Get the latest odds snapshot for an event, showing current bookmaker prices.
 
     Args:
         event_id: Event identifier.
+        market: Market type — "h2h" (2-way moneyline), "1x2" (3-way with
+            draw), "totals", or "spreads".
         include_raw_data: If True, also include the full raw_data JSON blob.
 
     Returns:
@@ -188,7 +193,7 @@ async def get_current_odds(
         if event is None:
             return {"error": f"Event '{event_id}' not found"}
 
-        snapshot = await reader.get_latest_snapshot(event_id, market="h2h")
+        snapshot = await reader.get_latest_snapshot(event_id, market=market)
         if snapshot is None:
             return {
                 "event": _event_to_dict(event),
@@ -196,7 +201,7 @@ async def get_current_odds(
                 "message": "No odds snapshots available for this event",
             }
 
-    odds = extract_odds_from_snapshot(snapshot, event_id, market="h2h")
+    odds = extract_odds_from_snapshot(snapshot, event_id, market=market)
     return {
         "event": _event_to_dict(event),
         "snapshot": _snapshot_to_dict(
@@ -206,7 +211,7 @@ async def get_current_odds(
 
 
 @mcp.tool()
-async def get_odds_history(event_id: str) -> dict[str, Any]:
+async def get_odds_history(event_id: str, market: MarketKey) -> dict[str, Any]:
     """Get the full odds movement timeline for an event (all snapshots).
 
     Returns structured bookmaker odds per snapshot instead of raw JSON blobs
@@ -214,6 +219,7 @@ async def get_odds_history(event_id: str) -> dict[str, Any]:
 
     Args:
         event_id: Event identifier.
+        market: Market type — "h2h", "1x2", "totals", or "spreads".
 
     Returns:
         Dict with event info and chronologically ordered list of snapshots.
@@ -228,7 +234,7 @@ async def get_odds_history(event_id: str) -> dict[str, Any]:
 
     serialized = []
     for s in snapshots:
-        odds = extract_odds_from_snapshot(s, event_id, market="h2h")
+        odds = extract_odds_from_snapshot(s, event_id, market=market)
         serialized.append(_snapshot_to_dict(s, extracted_odds=odds))
 
     return {
@@ -410,6 +416,7 @@ async def get_predictions(
 @mcp.tool()
 async def get_event_features(
     event_id: str,
+    market: MarketKey,
     outcome: Literal["home", "away"] = "home",
     sharp_bookmakers: list[str] | None = None,
     retail_bookmakers: list[str] | None = None,
@@ -423,6 +430,7 @@ async def get_event_features(
 
     Args:
         event_id: Event identifier.
+        market: Market type — "h2h", "1x2", "totals", or "spreads".
         outcome: Which outcome to extract features for ("home" or "away").
         sharp_bookmakers: Sharp bookmaker keys (default: ["pinnacle", "betfair_exchange"]).
         retail_bookmakers: Retail bookmaker keys (default: ["bet365", "betway", "betfred"]).
@@ -436,7 +444,7 @@ async def get_event_features(
         if event is None:
             return {"error": f"Event '{event_id}' not found"}
 
-        snapshot = await reader.get_latest_snapshot(event_id, market="h2h")
+        snapshot = await reader.get_latest_snapshot(event_id, market=market)
         if snapshot is None:
             return {
                 "event": _event_to_dict(event),
@@ -450,6 +458,7 @@ async def get_event_features(
         features = _extract_features_for_event(
             event,
             snapshot,
+            market=market,
             outcome_name=outcome_name,
             sharp_bookmakers=sharp_bookmakers or _DEFAULT_SHARP_BOOKMAKERS,
             retail_bookmakers=retail_bookmakers or _DEFAULT_RETAIL_BOOKMAKERS,
@@ -473,14 +482,15 @@ def _extract_features_for_event(
     event: Event,
     snapshot: OddsSnapshot,
     *,
+    market: MarketKey,
     outcome_name: str,
     sharp_bookmakers: list[str],
     retail_bookmakers: list[str],
 ) -> dict[str, float | None]:
     """Extract feature dict from an event and its latest snapshot."""
-    odds = extract_odds_from_snapshot(snapshot, event.id, market="h2h")
+    odds = extract_odds_from_snapshot(snapshot, event.id, market=market)
     if not odds:
-        return {"error": "No h2h odds data in snapshot"}
+        return {"error": f"No {market} odds data in snapshot"}
 
     backtest_event = BacktestEvent(
         id=event.id,
@@ -500,7 +510,7 @@ def _extract_features_for_event(
         event=backtest_event,
         odds_data=odds,
         outcome=outcome_name,
-        market="h2h",
+        market=market,
     )
 
     feature_names = extractor.get_feature_names()
@@ -675,6 +685,7 @@ def _snapshot_sharp_prices(
 @mcp.tool()
 async def save_match_brief(
     event_id: str,
+    market: MarketKey,
     brief_text: str,
     checkpoint: Literal["context", "decision"],
 ) -> dict[str, Any]:
@@ -685,6 +696,7 @@ async def save_match_brief(
 
     Args:
         event_id: Event identifier.
+        market: Market type — "h2h", "1x2", "totals", or "spreads".
         brief_text: Freeform brief content (structure controlled by agent prompt).
         checkpoint: Workflow checkpoint: "context" (day before) or "decision" (KO-90min).
 
@@ -699,9 +711,9 @@ async def save_match_brief(
 
         # Snapshot sharp prices from the latest odds
         sharp_prices: SharpPriceMap | None = None
-        snapshot = await reader.get_latest_snapshot(event_id, market="h2h")
+        snapshot = await reader.get_latest_snapshot(event_id, market=market)
         if snapshot is not None:
-            odds = extract_odds_from_snapshot(snapshot, event_id, market="h2h")
+            odds = extract_odds_from_snapshot(snapshot, event_id, market=market)
             if odds:
                 sharp_prices = _snapshot_sharp_prices(odds, _DEFAULT_SHARP_BOOKMAKERS)
 
@@ -775,6 +787,7 @@ async def get_match_brief(
 @mcp.tool()
 async def get_sharp_soft_spread(
     event_id: str,
+    market: MarketKey,
     sharp_bookmakers: list[str] | None = None,
     retail_bookmakers: list[str] | None = None,
 ) -> dict[str, Any]:
@@ -785,6 +798,7 @@ async def get_sharp_soft_spread(
 
     Args:
         event_id: Event identifier.
+        market: Market type — "h2h", "1x2", "totals", or "spreads".
         sharp_bookmakers: Sharp bookmaker keys (default: ["pinnacle", "betfair_exchange"]).
         retail_bookmakers: Retail bookmaker keys (default: ["bet365", "betway", "betfred"]).
 
@@ -800,7 +814,7 @@ async def get_sharp_soft_spread(
         if event is None:
             return {"error": f"Event '{event_id}' not found"}
 
-        snapshot = await reader.get_latest_snapshot(event_id, market="h2h")
+        snapshot = await reader.get_latest_snapshot(event_id, market=market)
         if snapshot is None:
             return {
                 "event": _event_to_dict(event),
@@ -809,7 +823,7 @@ async def get_sharp_soft_spread(
             }
 
         # Extract odds and snapshot metadata inside session while ORM objects are live
-        odds = extract_odds_from_snapshot(snapshot, event_id, market="h2h")
+        odds = extract_odds_from_snapshot(snapshot, event_id, market=market)
         snapshot_time_iso = snapshot.snapshot_time.isoformat()
         event_dict = _event_to_dict(event)
 
@@ -817,7 +831,7 @@ async def get_sharp_soft_spread(
         return {
             "event": event_dict,
             "spread": None,
-            "message": "No h2h odds in latest snapshot",
+            "message": f"No {market} odds in latest snapshot",
         }
 
     # Reuse shared sharp price extraction

--- a/scripts/ingest_oddsportal.py
+++ b/scripts/ingest_oddsportal.py
@@ -89,7 +89,7 @@ MARKET_CONFIGS: dict[str, dict[str, Any]] = {
     },
     "1x2": {
         "num_outcomes": 3,
-        "db_market": "h2h",
+        "db_market": "1x2",
         "outcome_names": None,  # Home, Draw, Away
         "line": None,
     },

--- a/tests/unit/test_fetch_oddsportal_results.py
+++ b/tests/unit/test_fetch_oddsportal_results.py
@@ -348,7 +348,7 @@ class TestSportResolution:
         from odds_lambda.jobs.fetch_oddsportal import _LEAGUE_SPEC_BY_SPORT
 
         spec = _LEAGUE_SPEC_BY_SPORT["soccer_epl"]
-        assert _db_market_for_spec(spec) == "h2h"
+        assert _db_market_for_spec(spec) == "1x2"
 
     def test_db_market_mlb(self) -> None:
         from odds_lambda.jobs.fetch_oddsportal import _LEAGUE_SPEC_BY_SPORT

--- a/tests/unit/test_oddsportal_adapter.py
+++ b/tests/unit/test_oddsportal_adapter.py
@@ -182,10 +182,10 @@ class TestConvert1x2Match:
         bet365 = next(b for b in result["bookmakers"] if b["key"] == "bet365")
         assert "betfair_matched" not in bet365
 
-    def test_market_key_is_h2h(self, sample_1x2_bookmakers: list[dict]) -> None:
+    def test_market_key_is_1x2(self, sample_1x2_bookmakers: list[dict]) -> None:
         result = _convert_1x2_match(sample_1x2_bookmakers, "Leeds", "Sunderland")
         assert result is not None
-        assert result["bookmakers"][0]["markets"][0]["key"] == "h2h"
+        assert result["bookmakers"][0]["markets"][0]["key"] == "1x2"
 
     def test_source_tag(self, sample_1x2_bookmakers: list[dict]) -> None:
         result = _convert_1x2_match(sample_1x2_bookmakers, "Leeds", "Sunderland")

--- a/tests/unit/test_sequence_loader.py
+++ b/tests/unit/test_sequence_loader.py
@@ -616,13 +616,13 @@ class TestExtractDeviggedH2hProbs:
         assert extract_devigged_h2h_probs([], "Lakers", "Celtics") is None
 
     def test_three_way_soccer_market(self, timestamp):
-        """3-way soccer h2h returns DeviggedProbs with draw populated."""
+        """3-way soccer 1x2 returns DeviggedProbs with draw populated."""
         odds = [
-            self._make_odds("pinnacle", "Arsenal", -120, timestamp),
-            self._make_odds("pinnacle", "Draw", 250, timestamp),
-            self._make_odds("pinnacle", "Chelsea", 300, timestamp),
+            self._make_odds("pinnacle", "Arsenal", -120, timestamp, market="1x2"),
+            self._make_odds("pinnacle", "Draw", 250, timestamp, market="1x2"),
+            self._make_odds("pinnacle", "Chelsea", 300, timestamp, market="1x2"),
         ]
-        result = extract_devigged_h2h_probs(odds, "Arsenal", "Chelsea")
+        result = extract_devigged_h2h_probs(odds, "Arsenal", "Chelsea", market_key="1x2")
         assert result is not None
         assert result.draw is not None
         assert result.home + result.draw + result.away == pytest.approx(1.0)
@@ -643,18 +643,18 @@ class TestExtractDeviggedH2hProbs:
     def test_three_way_missing_home_returns_none(self, timestamp):
         """3-way market missing home team returns None."""
         odds = [
-            self._make_odds("pinnacle", "Draw", 250, timestamp),
-            self._make_odds("pinnacle", "Chelsea", 300, timestamp),
+            self._make_odds("pinnacle", "Draw", 250, timestamp, market="1x2"),
+            self._make_odds("pinnacle", "Chelsea", 300, timestamp, market="1x2"),
         ]
-        assert extract_devigged_h2h_probs(odds, "Arsenal", "Chelsea") is None
+        assert extract_devigged_h2h_probs(odds, "Arsenal", "Chelsea", market_key="1x2") is None
 
     def test_three_way_missing_away_returns_none(self, timestamp):
         """3-way market missing away team returns None."""
         odds = [
-            self._make_odds("pinnacle", "Arsenal", -120, timestamp),
-            self._make_odds("pinnacle", "Draw", 250, timestamp),
+            self._make_odds("pinnacle", "Arsenal", -120, timestamp, market="1x2"),
+            self._make_odds("pinnacle", "Draw", 250, timestamp, market="1x2"),
         ]
-        assert extract_devigged_h2h_probs(odds, "Arsenal", "Chelsea") is None
+        assert extract_devigged_h2h_probs(odds, "Arsenal", "Chelsea", market_key="1x2") is None
 
 
 class TestCalculateDeviggedBookmakerTarget:
@@ -664,12 +664,14 @@ class TestCalculateDeviggedBookmakerTarget:
     def timestamp(self):
         return datetime(2024, 11, 1, 12, 0, 0, tzinfo=UTC)
 
-    def _make_odds(self, outcome: str, price: int, timestamp: datetime) -> Odds:
+    def _make_odds(
+        self, outcome: str, price: int, timestamp: datetime, market: str = "h2h"
+    ) -> Odds:
         return Odds(
             event_id="test",
             bookmaker_key="pinnacle",
             bookmaker_title="Pinnacle",
-            market_key="h2h",
+            market_key=market,
             outcome_name=outcome,
             price=price,
             point=None,
@@ -749,41 +751,21 @@ class TestCalculateDeviggedBookmakerTarget:
     def test_three_way_target_uses_home_prob(self, timestamp):
         """3-way market target is close.home - snapshot.home."""
         snapshot_odds = [
-            self._make_odds("Arsenal", -120, timestamp),
-            Odds(
-                event_id="test",
-                bookmaker_key="pinnacle",
-                bookmaker_title="Pinnacle",
-                market_key="h2h",
-                outcome_name="Draw",
-                price=250,
-                point=None,
-                odds_timestamp=timestamp,
-                last_update=timestamp,
-            ),
-            self._make_odds("Chelsea", 300, timestamp),
+            self._make_odds("Arsenal", -120, timestamp, market="1x2"),
+            self._make_odds("Draw", 250, timestamp, market="1x2"),
+            self._make_odds("Chelsea", 300, timestamp, market="1x2"),
         ]
         closing_odds = [
-            self._make_odds("Arsenal", -150, timestamp),
-            Odds(
-                event_id="test",
-                bookmaker_key="pinnacle",
-                bookmaker_title="Pinnacle",
-                market_key="h2h",
-                outcome_name="Draw",
-                price=280,
-                point=None,
-                odds_timestamp=timestamp,
-                last_update=timestamp,
-            ),
-            self._make_odds("Chelsea", 350, timestamp),
+            self._make_odds("Arsenal", -150, timestamp, market="1x2"),
+            self._make_odds("Draw", 280, timestamp, market="1x2"),
+            self._make_odds("Chelsea", 350, timestamp, market="1x2"),
         ]
         result = calculate_devigged_bookmaker_target(
-            snapshot_odds, closing_odds, "Arsenal", "Chelsea"
+            snapshot_odds, closing_odds, "Arsenal", "Chelsea", market_key="1x2"
         )
         assert result is not None
-        snap = extract_devigged_h2h_probs(snapshot_odds, "Arsenal", "Chelsea")
-        close = extract_devigged_h2h_probs(closing_odds, "Arsenal", "Chelsea")
+        snap = extract_devigged_h2h_probs(snapshot_odds, "Arsenal", "Chelsea", market_key="1x2")
+        close = extract_devigged_h2h_probs(closing_odds, "Arsenal", "Chelsea", market_key="1x2")
         assert snap is not None and close is not None
         assert snap.draw is not None
         assert close.draw is not None

--- a/tests/unit/test_three_way_outcomes.py
+++ b/tests/unit/test_three_way_outcomes.py
@@ -167,7 +167,7 @@ class TestBetResultThreeWay:
     def test_draw_bet_wins_in_three_way(self, engine, football_draw_event):
         opp = BetOpportunity(
             event_id="football_draw_1",
-            market="h2h",
+            market="1x2",
             outcome="Draw",
             bookmaker="bet365",
             odds=250,
@@ -184,7 +184,7 @@ class TestBetResultThreeWay:
     def test_team_bet_loses_on_draw_in_three_way(self, engine, football_draw_event):
         opp = BetOpportunity(
             event_id="football_draw_1",
-            market="h2h",
+            market="1x2",
             outcome="Liverpool",
             bookmaker="bet365",
             odds=-120,
@@ -251,16 +251,16 @@ class TestFlatBettingDrawPattern:
     def three_way_odds(self) -> list[Odds]:
         eid = "football_draw_1"
         return [
-            _make_odds(eid, "bet365", "h2h", "Liverpool", -150),
-            _make_odds(eid, "bet365", "h2h", "Manchester City", 200),
-            _make_odds(eid, "bet365", "h2h", "Draw", 250),
+            _make_odds(eid, "bet365", "1x2", "Liverpool", -150),
+            _make_odds(eid, "bet365", "1x2", "Manchester City", 200),
+            _make_odds(eid, "bet365", "1x2", "Draw", 250),
         ]
 
     @pytest.mark.asyncio
     async def test_draw_pattern_selects_draw_odds(
         self, football_draw_event, three_way_odds, backtest_config
     ):
-        strategy = FlatBettingStrategy(market="h2h", outcome_pattern="draw", bookmaker="bet365")
+        strategy = FlatBettingStrategy(market="1x2", outcome_pattern="draw", bookmaker="bet365")
         opps = await strategy.evaluate_opportunity(
             football_draw_event, three_way_odds, backtest_config
         )
@@ -273,10 +273,10 @@ class TestFlatBettingDrawPattern:
         self, football_draw_event, backtest_config
     ):
         two_way_odds = [
-            _make_odds("football_draw_1", "bet365", "h2h", "Liverpool", -150),
-            _make_odds("football_draw_1", "bet365", "h2h", "Manchester City", 200),
+            _make_odds("football_draw_1", "bet365", "1x2", "Liverpool", -150),
+            _make_odds("football_draw_1", "bet365", "1x2", "Manchester City", 200),
         ]
-        strategy = FlatBettingStrategy(market="h2h", outcome_pattern="draw", bookmaker="bet365")
+        strategy = FlatBettingStrategy(market="1x2", outcome_pattern="draw", bookmaker="bet365")
         opps = await strategy.evaluate_opportunity(
             football_draw_event, two_way_odds, backtest_config
         )
@@ -292,13 +292,13 @@ class TestBasicEVThreeWay:
         eid = "football_home_1"
         return [
             # Sharp book (pinnacle)
-            _make_odds(eid, "pinnacle", "h2h", "Liverpool", -130),
-            _make_odds(eid, "pinnacle", "h2h", "Manchester City", 200),
-            _make_odds(eid, "pinnacle", "h2h", "Draw", 260),
+            _make_odds(eid, "pinnacle", "1x2", "Liverpool", -130),
+            _make_odds(eid, "pinnacle", "1x2", "Manchester City", 200),
+            _make_odds(eid, "pinnacle", "1x2", "Draw", 260),
             # Retail book (bet365) with inflated draw odds
-            _make_odds(eid, "bet365", "h2h", "Liverpool", -125),
-            _make_odds(eid, "bet365", "h2h", "Manchester City", 210),
-            _make_odds(eid, "bet365", "h2h", "Draw", 350),
+            _make_odds(eid, "bet365", "1x2", "Liverpool", -125),
+            _make_odds(eid, "bet365", "1x2", "Manchester City", 210),
+            _make_odds(eid, "bet365", "1x2", "Draw", 350),
         ]
 
     @pytest.mark.asyncio
@@ -309,7 +309,7 @@ class TestBasicEVThreeWay:
             sharp_book="pinnacle",
             retail_books=["bet365"],
             min_ev_threshold=0.01,
-            markets=["h2h"],
+            markets=["1x2"],
         )
         opps = await strategy.evaluate_opportunity(
             football_home_win_event, three_way_sharp_and_retail, backtest_config
@@ -330,14 +330,14 @@ class TestArbitrageThreeWay:
         eid = "football_home_1"
         return [
             # Best home odds at bookA
-            _make_odds(eid, "bookA", "h2h", "Liverpool", 300),
-            _make_odds(eid, "bookB", "h2h", "Liverpool", 250),
+            _make_odds(eid, "bookA", "1x2", "Liverpool", 300),
+            _make_odds(eid, "bookB", "1x2", "Liverpool", 250),
             # Best away odds at bookB
-            _make_odds(eid, "bookA", "h2h", "Manchester City", 350),
-            _make_odds(eid, "bookB", "h2h", "Manchester City", 400),
+            _make_odds(eid, "bookA", "1x2", "Manchester City", 350),
+            _make_odds(eid, "bookB", "1x2", "Manchester City", 400),
             # Best draw odds at bookA
-            _make_odds(eid, "bookA", "h2h", "Draw", 500),
-            _make_odds(eid, "bookB", "h2h", "Draw", 350),
+            _make_odds(eid, "bookA", "1x2", "Draw", 500),
+            _make_odds(eid, "bookB", "1x2", "Draw", 350),
         ]
 
     @pytest.fixture
@@ -363,7 +363,7 @@ class TestArbitrageThreeWay:
         opps = await strategy.evaluate_opportunity(
             football_home_win_event, three_way_arb_odds, backtest_config
         )
-        h2h_opps = [o for o in opps if o.market == "h2h"]
+        h2h_opps = [o for o in opps if o.market == "1x2"]
         outcomes = {o.outcome for o in h2h_opps}
         assert outcomes == {"Liverpool", "Manchester City", "Draw"}
         assert all("3-way arb" in o.rationale for o in h2h_opps)
@@ -395,7 +395,7 @@ class TestArbitrageThreeWay:
         opps = await strategy.evaluate_opportunity(
             football_home_win_event, three_way_arb_odds, backtest_config
         )
-        h2h_opps = {o.outcome: o for o in opps if o.market == "h2h"}
+        h2h_opps = {o.outcome: o for o in opps if o.market == "1x2"}
         assert h2h_opps["Liverpool"].odds == 300  # bookA best
         assert h2h_opps["Liverpool"].bookmaker == "bookA"
         assert h2h_opps["Manchester City"].odds == 400  # bookB best


### PR DESCRIPTION
## Summary

- **Problem**: 3-way (1x2) and 2-way (h2h) moneyline odds were both stored under `market_key="h2h"`. When an MLB `1x2` scrape job ran, regulation-time 3-way odds (with Draw outcomes at +700/+900) were stored alongside full-game 2-way moneyline data with no way to distinguish them at query time.
- **Fix**: 1x2 write paths now use `market_key="1x2"`. A data migration relabels 82K EPL + 171 MLB existing rows in both the `odds` table and `raw_data` JSON. Read paths (`extract_devigged_h2h_probs`, backtesting, arb strategy) accept both market keys where appropriate.
- EPL experiment configs updated from `markets: [h2h]` to `markets: [1x2]`.

## Changed files

**Write paths** (3 files): `oddsportal_adapter.py`, `fetch_oddsportal_results.py`, `ingest_oddsportal.py`
**Read paths** (4 files): `sequence_loader.py`, `feature_groups.py`, `backtesting/services.py`, `strategies.py`
**Migration**: `920aee156d9c` — relabels odds rows + patches raw_data JSON where Draw outcomes exist
**Configs**: 12 EPL experiment YAML files
**Tests**: `test_three_way_outcomes.py` fixtures updated to use `"1x2"`

## Test plan

- [x] All 168 unit tests pass (1 pre-existing failure in `test_settings_defaults`)
- [x] Migration verified: zero Draw outcomes remain under `market_key="h2h"`
- [x] EPL raw_data JSON patched correctly (`market_key: "1x2"`)
- [ ] Run EPL training pipeline with updated configs to verify feature extraction
- [ ] Run production migration on remote DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)