### PR TITLE
Fix compound name resolution in local scheduler backend

### DIFF
--- a/packages/odds-lambda/odds_lambda/scheduling/backends/local.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/backends/local.py
@@ -222,10 +222,9 @@ class LocalSchedulerBackend(SchedulerBackend):
             # Get job function from centralized registry
             from odds_lambda.scheduling.jobs import JobContext, get_job_function, resolve_job_name
 
-            job_func = get_job_function(job_name)
-
-            # Build JobContext from compound name + payload
-            _, resolved_sport = resolve_job_name(job_name)
+            # Resolve compound name (e.g. "fetch-oddsportal-epl" -> "fetch-oddsportal" + "soccer_epl")
+            base_name, resolved_sport = resolve_job_name(job_name)
+            job_func = get_job_function(base_name)
             ctx_payload: dict[str, object] = {}
             if resolved_sport:
                 ctx_payload["sport"] = resolved_sport

--- a/tests/integration/test_local_backend.py
+++ b/tests/integration/test_local_backend.py
@@ -263,33 +263,24 @@ class TestLocalSchedulerBackend:
     async def test_schedule_compound_job_name(self):
         """Test that compound job names (e.g. fetch-oddsportal-epl) resolve correctly.
 
-        The compound name should be resolved to a base name for get_job_function,
-        and the sport should be extracted into JobContext.
+        Real resolve_job_name runs to exercise actual compound name parsing.
+        Only get_job_function is mocked (to avoid importing real job modules).
         """
         captured_ctx: list[JobContext] = []
 
         async def capturing_job(ctx: JobContext) -> None:
             captured_ctx.append(ctx)
 
-        with (
-            patch(
-                "odds_lambda.scheduling.jobs.resolve_job_name",
-                return_value=("fetch-oddsportal", "soccer_epl"),
-            ) as mock_resolve,
-            patch(
-                "odds_lambda.scheduling.jobs.get_job_function",
-                return_value=capturing_job,
-            ) as mock_get_job,
-        ):
+        with patch(
+            "odds_lambda.scheduling.jobs.get_job_function",
+            return_value=capturing_job,
+        ) as mock_get_job:
             async with LocalSchedulerBackend() as backend:
                 next_time = datetime.now(UTC) + timedelta(milliseconds=100)
 
                 await backend.schedule_next_execution(
                     job_name="fetch-oddsportal-epl", next_time=next_time
                 )
-
-                # resolve_job_name should be called with the compound name
-                mock_resolve.assert_called_once_with("fetch-oddsportal-epl")
 
                 # get_job_function should receive the base name, not compound
                 mock_get_job.assert_called_once_with("fetch-oddsportal")
@@ -313,30 +304,43 @@ class TestLocalSchedulerBackend:
 
     @pytest.mark.asyncio
     async def test_schedule_non_compound_job_name(self):
-        """Test that non-compound job names still work correctly."""
-        mock_job = AsyncMock()
+        """Test that non-compound job names still work correctly.
 
-        with (
-            patch(
-                "odds_lambda.scheduling.jobs.resolve_job_name",
-                return_value=("check-health", None),
-            ),
-            patch(
-                "odds_lambda.scheduling.jobs.get_job_function",
-                return_value=mock_job,
-            ) as mock_get_job,
-        ):
+        Real resolve_job_name runs — for a non-compound name it should
+        return the name unchanged with sport=None.
+        """
+        captured_ctx: list[JobContext] = []
+
+        async def capturing_job(ctx: JobContext) -> None:
+            captured_ctx.append(ctx)
+
+        with patch(
+            "odds_lambda.scheduling.jobs.get_job_function",
+            return_value=capturing_job,
+        ) as mock_get_job:
             async with LocalSchedulerBackend() as backend:
-                next_time = datetime.now(UTC) + timedelta(hours=1)
+                next_time = datetime.now(UTC) + timedelta(milliseconds=100)
 
                 await backend.schedule_next_execution(job_name="check-health", next_time=next_time)
 
-                # get_job_function should receive the same name
+                # get_job_function should receive the same name (no suffix to strip)
                 mock_get_job.assert_called_once_with("check-health")
 
                 jobs = await backend.get_scheduled_jobs()
                 assert len(jobs) == 1
                 assert jobs[0].job_name == "check-health"
+
+                # Wait for job to execute and verify context has no sport
+                try:
+                    await asyncio.wait_for(
+                        asyncio.sleep(0.5),
+                        timeout=2.0,
+                    )
+                except TimeoutError:
+                    pass
+
+                assert len(captured_ctx) == 1
+                assert captured_ctx[0].sport is None
 
     @pytest.mark.asyncio
     async def test_multiple_jobs_execute_independently(self):

--- a/tests/integration/test_local_backend.py
+++ b/tests/integration/test_local_backend.py
@@ -267,9 +267,11 @@ class TestLocalSchedulerBackend:
         Only get_job_function is mocked (to avoid importing real job modules).
         """
         captured_ctx: list[JobContext] = []
+        executed = asyncio.Event()
 
         async def capturing_job(ctx: JobContext) -> None:
             captured_ctx.append(ctx)
+            executed.set()
 
         with patch(
             "odds_lambda.scheduling.jobs.get_job_function",
@@ -292,12 +294,9 @@ class TestLocalSchedulerBackend:
 
                 # Wait for job to execute and verify context has sport
                 try:
-                    await asyncio.wait_for(
-                        asyncio.sleep(0.5),
-                        timeout=2.0,
-                    )
+                    await asyncio.wait_for(executed.wait(), timeout=2.0)
                 except TimeoutError:
-                    pass
+                    pytest.fail("Compound job did not execute within timeout")
 
                 assert len(captured_ctx) == 1
                 assert captured_ctx[0].sport == "soccer_epl"
@@ -310,9 +309,11 @@ class TestLocalSchedulerBackend:
         return the name unchanged with sport=None.
         """
         captured_ctx: list[JobContext] = []
+        executed = asyncio.Event()
 
         async def capturing_job(ctx: JobContext) -> None:
             captured_ctx.append(ctx)
+            executed.set()
 
         with patch(
             "odds_lambda.scheduling.jobs.get_job_function",
@@ -332,12 +333,9 @@ class TestLocalSchedulerBackend:
 
                 # Wait for job to execute and verify context has no sport
                 try:
-                    await asyncio.wait_for(
-                        asyncio.sleep(0.5),
-                        timeout=2.0,
-                    )
+                    await asyncio.wait_for(executed.wait(), timeout=2.0)
                 except TimeoutError:
-                    pass
+                    pytest.fail("Non-compound job did not execute within timeout")
 
                 assert len(captured_ctx) == 1
                 assert captured_ctx[0].sport is None

--- a/tests/integration/test_local_backend.py
+++ b/tests/integration/test_local_backend.py
@@ -260,6 +260,85 @@ class TestLocalSchedulerBackend:
                     pytest.fail("Job did not execute within timeout")
 
     @pytest.mark.asyncio
+    async def test_schedule_compound_job_name(self):
+        """Test that compound job names (e.g. fetch-oddsportal-epl) resolve correctly.
+
+        The compound name should be resolved to a base name for get_job_function,
+        and the sport should be extracted into JobContext.
+        """
+        captured_ctx: list[JobContext] = []
+
+        async def capturing_job(ctx: JobContext) -> None:
+            captured_ctx.append(ctx)
+
+        with (
+            patch(
+                "odds_lambda.scheduling.jobs.resolve_job_name",
+                return_value=("fetch-oddsportal", "soccer_epl"),
+            ) as mock_resolve,
+            patch(
+                "odds_lambda.scheduling.jobs.get_job_function",
+                return_value=capturing_job,
+            ) as mock_get_job,
+        ):
+            async with LocalSchedulerBackend() as backend:
+                next_time = datetime.now(UTC) + timedelta(milliseconds=100)
+
+                await backend.schedule_next_execution(
+                    job_name="fetch-oddsportal-epl", next_time=next_time
+                )
+
+                # resolve_job_name should be called with the compound name
+                mock_resolve.assert_called_once_with("fetch-oddsportal-epl")
+
+                # get_job_function should receive the base name, not compound
+                mock_get_job.assert_called_once_with("fetch-oddsportal")
+
+                # Verify job was scheduled with compound name as ID
+                jobs = await backend.get_scheduled_jobs()
+                assert len(jobs) == 1
+                assert jobs[0].job_name == "fetch-oddsportal-epl"
+
+                # Wait for job to execute and verify context has sport
+                try:
+                    await asyncio.wait_for(
+                        asyncio.sleep(0.5),
+                        timeout=2.0,
+                    )
+                except TimeoutError:
+                    pass
+
+                assert len(captured_ctx) == 1
+                assert captured_ctx[0].sport == "soccer_epl"
+
+    @pytest.mark.asyncio
+    async def test_schedule_non_compound_job_name(self):
+        """Test that non-compound job names still work correctly."""
+        mock_job = AsyncMock()
+
+        with (
+            patch(
+                "odds_lambda.scheduling.jobs.resolve_job_name",
+                return_value=("check-health", None),
+            ),
+            patch(
+                "odds_lambda.scheduling.jobs.get_job_function",
+                return_value=mock_job,
+            ) as mock_get_job,
+        ):
+            async with LocalSchedulerBackend() as backend:
+                next_time = datetime.now(UTC) + timedelta(hours=1)
+
+                await backend.schedule_next_execution(job_name="check-health", next_time=next_time)
+
+                # get_job_function should receive the same name
+                mock_get_job.assert_called_once_with("check-health")
+
+                jobs = await backend.get_scheduled_jobs()
+                assert len(jobs) == 1
+                assert jobs[0].job_name == "check-health"
+
+    @pytest.mark.asyncio
     async def test_multiple_jobs_execute_independently(self):
         """Test that multiple jobs execute independently."""
         job1_executed = asyncio.Event()


### PR DESCRIPTION
## Summary
- Resolve compound job names (e.g. `fetch-oddsportal-epl`) via `resolve_job_name()` **before** calling `get_job_function()` in `schedule_next_execution()`, which only recognizes base names from `_JOB_MODULE_MAP`
- Remove the redundant second `resolve_job_name()` call that previously only extracted the sport
- Add tests for both compound and non-compound job name scheduling

## Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)