### PR TITLE
Register agent-run job in scheduler

### DIFF
--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -64,6 +64,7 @@ _JOB_MODULE_MAP: dict[str, tuple[str, str]] = {
     "fetch-oddsportal-results": ("odds_lambda.jobs.fetch_oddsportal_results", "main"),
     "score-predictions": ("odds_lambda.jobs.score_predictions", "main"),
     "daily-digest": ("odds_lambda.jobs.daily_digest", "main"),
+    "agent-run": ("odds_lambda.jobs.agent_run", "main"),
 }
 
 # Maps sport suffix to sport_key for per-sport job routing.
@@ -83,6 +84,7 @@ _PER_SPORT_JOBS: frozenset[str] = frozenset(
         "fetch-oddsportal-results",
         "score-predictions",
         "daily-digest",
+        "agent-run",
     }
 )
 

--- a/tests/unit/test_fetch_oddsportal_scheduling.py
+++ b/tests/unit/test_fetch_oddsportal_scheduling.py
@@ -236,6 +236,10 @@ class TestProximityScheduling:
                 new_callable=AsyncMock,
                 side_effect=Exception("DB connection refused"),
             ),
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal._apply_overnight_skip",
+                side_effect=lambda t, **kw: t,
+            ),
         ):
             from odds_lambda.jobs.fetch_oddsportal import IngestionStats
 
@@ -276,6 +280,10 @@ class TestProximityScheduling:
                 new_callable=AsyncMock,
                 return_value=kickoff,
             ),
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal._apply_overnight_skip",
+                side_effect=lambda t, **kw: t,
+            ),
         ):
             from odds_lambda.jobs.fetch_oddsportal import IngestionStats
 
@@ -315,6 +323,10 @@ class TestProximityScheduling:
                 "odds_lambda.jobs.fetch_oddsportal._get_next_kickoff",
                 new_callable=AsyncMock,
                 return_value=kickoff,
+            ),
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal._apply_overnight_skip",
+                side_effect=lambda t, **kw: t,
             ),
         ):
             from odds_lambda.jobs.fetch_oddsportal import IngestionStats

--- a/tests/unit/test_job_routing.py
+++ b/tests/unit/test_job_routing.py
@@ -50,6 +50,16 @@ class TestResolveJobName:
         assert base == "fetch-oddsportal-results"
         assert sport == "baseball_mlb"
 
+    def test_compound_name_agent_run_epl(self) -> None:
+        base, sport = resolve_job_name("agent-run-epl")
+        assert base == "agent-run"
+        assert sport == "soccer_epl"
+
+    def test_compound_name_agent_run_mlb(self) -> None:
+        base, sport = resolve_job_name("agent-run-mlb")
+        assert base == "agent-run"
+        assert sport == "baseball_mlb"
+
     def test_unknown_suffix_returns_no_sport(self) -> None:
         base, sport = resolve_job_name("fetch-odds-nba")
         assert base == "fetch-odds-nba"
@@ -115,4 +125,16 @@ class TestMakeCompoundJobName:
         compound = make_compound_job_name("fetch-oddsportal-results", "baseball_mlb")
         base, sport = resolve_job_name(compound)
         assert base == "fetch-oddsportal-results"
+        assert sport == "baseball_mlb"
+
+    def test_roundtrip_agent_run_epl(self) -> None:
+        compound = make_compound_job_name("agent-run", "soccer_epl")
+        base, sport = resolve_job_name(compound)
+        assert base == "agent-run"
+        assert sport == "soccer_epl"
+
+    def test_roundtrip_agent_run_mlb(self) -> None:
+        compound = make_compound_job_name("agent-run", "baseball_mlb")
+        base, sport = resolve_job_name(compound)
+        assert base == "agent-run"
         assert sport == "baseball_mlb"


### PR DESCRIPTION
## Summary
- Add `"agent-run"` to `_JOB_MODULE_MAP` pointing to `odds_lambda.jobs.agent_run:main`
- Add `"agent-run"` to `_PER_SPORT_JOBS` so it supports sport suffixes (`agent-run-epl`, `agent-run-mlb`)
- Add 4 tests verifying `resolve_job_name` and `make_compound_job_name` roundtrips
- Fix time-of-day-dependent test failures in `test_fetch_oddsportal_scheduling.py` — three tests didn't mock `_apply_overnight_skip`, causing assertions to fail when CI runs between ~20:00-04:00 UTC

The module import is lazy — `odds_lambda.jobs.agent_run` only needs to exist at invocation time, not at registration.

## Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)