### PR TITLE
Add MCP tools for agent scheduling (wakeup + job visibility)

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -4,6 +4,7 @@ import asyncio
 from logging.config import fileConfig
 
 from alembic import context
+from odds_core.agent_wakeup_models import AgentWakeup  # noqa: F401
 from odds_core.config import get_settings
 from odds_core.epl_data_models import EspnFixture, EspnLineup, FplAvailability  # noqa: F401
 from odds_core.game_log_models import NbaTeamGameLog  # noqa: F401

--- a/migrations/versions/a7b3c9d2e1f0_add_agent_wakeups_table.py
+++ b/migrations/versions/a7b3c9d2e1f0_add_agent_wakeups_table.py
@@ -1,0 +1,41 @@
+"""add agent_wakeups table
+
+Revision ID: a7b3c9d2e1f0
+Revises: 920aee156d9c
+Create Date: 2026-04-15 18:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a7b3c9d2e1f0"
+down_revision = "920aee156d9c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_wakeups",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("sport_key", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("requested_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("reason", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("sport_key", name="uq_agent_wakeup_sport_key"),
+    )
+    op.create_index(
+        op.f("ix_agent_wakeups_sport_key"),
+        "agent_wakeups",
+        ["sport_key"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_agent_wakeups_sport_key"), table_name="agent_wakeups")
+    op.drop_table("agent_wakeups")

--- a/migrations/versions/a7b3c9d2e1f0_add_agent_wakeups_table.py
+++ b/migrations/versions/a7b3c9d2e1f0_add_agent_wakeups_table.py
@@ -25,17 +25,11 @@ def upgrade() -> None:
         sa.Column("requested_time", sa.DateTime(timezone=True), nullable=False),
         sa.Column("reason", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("sport_key", name="uq_agent_wakeup_sport_key"),
-    )
-    op.create_index(
-        op.f("ix_agent_wakeups_sport_key"),
-        "agent_wakeups",
-        ["sport_key"],
-        unique=False,
     )
 
 
 def downgrade() -> None:
-    op.drop_index(op.f("ix_agent_wakeups_sport_key"), table_name="agent_wakeups")
     op.drop_table("agent_wakeups")

--- a/packages/odds-core/odds_core/agent_wakeup_models.py
+++ b/packages/odds-core/odds_core/agent_wakeup_models.py
@@ -18,7 +18,7 @@ class AgentWakeup(SQLModel, table=True):
     __tablename__ = "agent_wakeups"
 
     id: int | None = Field(default=None, primary_key=True)
-    sport_key: str = Field(index=True)
+    sport_key: str = Field()
     requested_time: datetime = Field(
         sa_column=Column(DateTime(timezone=True), nullable=False),
     )
@@ -26,6 +26,10 @@ class AgentWakeup(SQLModel, table=True):
     created_at: datetime = Field(
         sa_column=Column(DateTime(timezone=True), nullable=False),
         default_factory=utc_now,
+    )
+    consumed_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
     )
 
     __table_args__ = (UniqueConstraint("sport_key", name="uq_agent_wakeup_sport_key"),)

--- a/packages/odds-core/odds_core/agent_wakeup_models.py
+++ b/packages/odds-core/odds_core/agent_wakeup_models.py
@@ -1,0 +1,31 @@
+"""Agent wakeup scheduling model.
+
+Communication channel between the MCP server process and the scheduler process.
+One active row per sport — upserted, not inserted.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, UniqueConstraint
+from sqlmodel import Field, SQLModel
+
+from odds_core.models import utc_now
+
+
+class AgentWakeup(SQLModel, table=True):
+    """Requested agent wake-up time, written by MCP and consumed by the scheduler."""
+
+    __tablename__ = "agent_wakeups"
+
+    id: int | None = Field(default=None, primary_key=True)
+    sport_key: str = Field(index=True)
+    requested_time: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    reason: str = Field()
+    created_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+        default_factory=utc_now,
+    )
+
+    __table_args__ = (UniqueConstraint("sport_key", name="uq_agent_wakeup_sport_key"),)

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -980,6 +980,7 @@ async def schedule_next_wakeup(
                     "requested_time": requested_time,
                     "reason": reason,
                     "created_at": now,
+                    "consumed_at": None,
                 },
             )
         )

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -28,6 +28,7 @@ from odds_lambda.paper_trading import (
     place_trade,
     settle_trades,
 )
+from odds_lambda.scheduling.backends import BackendUnavailableError, get_scheduler_backend
 from odds_lambda.storage.readers import OddsReader
 from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -906,11 +907,6 @@ async def get_scheduled_jobs(
         Dict with list of scheduled jobs or an informative message.
     """
     try:
-        from odds_lambda.scheduling.backends import (
-            BackendUnavailableError,
-            get_scheduler_backend,
-        )
-
         backend = get_scheduler_backend()
         jobs = await backend.get_scheduled_jobs()
     except BackendUnavailableError as e:
@@ -965,8 +961,9 @@ async def schedule_next_wakeup(
     Returns:
         Dict confirming the scheduled wake-up with the requested UTC time.
     """
+    now = datetime.now(UTC)
     delay_hours = max(0.5, min(delay_hours, 168.0))
-    requested_time = datetime.now(UTC) + timedelta(hours=delay_hours)
+    requested_time = now + timedelta(hours=delay_hours)
 
     async with async_session_maker() as session:
         stmt = (
@@ -975,14 +972,14 @@ async def schedule_next_wakeup(
                 sport_key=sport,
                 requested_time=requested_time,
                 reason=reason,
-                created_at=datetime.now(UTC),
+                created_at=now,
             )
             .on_conflict_do_update(
                 constraint="uq_agent_wakeup_sport_key",
                 set_={
                     "requested_time": requested_time,
                     "reason": reason,
-                    "created_at": datetime.now(UTC),
+                    "created_at": now,
                 },
             )
         )

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -14,6 +14,7 @@ from odds_analytics.backtesting import BacktestEvent
 from odds_analytics.feature_extraction import TabularFeatureExtractor
 from odds_analytics.sequence_loader import extract_odds_from_snapshot
 from odds_analytics.utils import calculate_implied_probability
+from odds_core.agent_wakeup_models import AgentWakeup
 from odds_core.database import async_session_maker
 from odds_core.match_brief_models import BriefCheckpoint, MatchBrief, SharpPriceMap
 from odds_core.models import Event, EventStatus, Odds, OddsSnapshot
@@ -29,6 +30,7 @@ from odds_lambda.paper_trading import (
 )
 from odds_lambda.storage.readers import OddsReader
 from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 logger = structlog.get_logger()
 
@@ -881,6 +883,117 @@ async def get_sharp_soft_spread(
         "event": event_dict,
         "snapshot_time": snapshot_time_iso,
         "spread": spread,
+    }
+
+
+@mcp.tool()
+async def get_scheduled_jobs(
+    sport: str | None = None,
+) -> dict[str, Any]:
+    """List all currently scheduled jobs from the scheduler backend.
+
+    Returns job name, next run time, and status for each job. Optionally
+    filter by sport key (substring match on job name).
+
+    If the scheduler backend is not running (e.g. local APScheduler not
+    started), returns an informative message rather than an error.
+
+    Args:
+        sport: Optional sport key to filter jobs (e.g. "soccer_epl").
+               Matches as substring against job names.
+
+    Returns:
+        Dict with list of scheduled jobs or an informative message.
+    """
+    try:
+        from odds_lambda.scheduling.backends import (
+            BackendUnavailableError,
+            get_scheduler_backend,
+        )
+
+        backend = get_scheduler_backend()
+        jobs = await backend.get_scheduled_jobs()
+    except BackendUnavailableError as e:
+        return {
+            "jobs": [],
+            "message": f"Scheduler backend unavailable: {e}",
+        }
+    except Exception as e:
+        logger.warning("get_scheduled_jobs_failed", error=str(e))
+        return {
+            "jobs": [],
+            "message": (
+                f"Could not query scheduler: {e}. "
+                "The local APScheduler backend requires the scheduler to be "
+                "running in a separate process (odds scheduler start)."
+            ),
+        }
+
+    if sport:
+        jobs = [j for j in jobs if sport in j.job_name]
+
+    return {
+        "job_count": len(jobs),
+        "jobs": [
+            {
+                "job_name": j.job_name,
+                "next_run_time": j.next_run_time.isoformat() if j.next_run_time else None,
+                "status": j.status.value,
+            }
+            for j in jobs
+        ],
+    }
+
+
+@mcp.tool()
+async def schedule_next_wakeup(
+    sport: str,
+    delay_hours: float,
+    reason: str,
+) -> dict[str, Any]:
+    """Request the agent's next wake-up at now + delay_hours.
+
+    Writes an upsert to the agent_wakeups table (one active row per sport).
+    The agent_run job module reads this after the agent subprocess exits and
+    reschedules if the requested time is sooner than the default.
+
+    Args:
+        sport: Sport key (e.g. "soccer_epl", "baseball_mlb").
+        delay_hours: Hours from now until the next wake-up (0.5 to 168).
+        reason: Why this wake-up is being scheduled (shown in logs).
+
+    Returns:
+        Dict confirming the scheduled wake-up with the requested UTC time.
+    """
+    delay_hours = max(0.5, min(delay_hours, 168.0))
+    requested_time = datetime.now(UTC) + timedelta(hours=delay_hours)
+
+    async with async_session_maker() as session:
+        stmt = (
+            pg_insert(AgentWakeup)
+            .values(
+                sport_key=sport,
+                requested_time=requested_time,
+                reason=reason,
+                created_at=datetime.now(UTC),
+            )
+            .on_conflict_do_update(
+                constraint="uq_agent_wakeup_sport_key",
+                set_={
+                    "requested_time": requested_time,
+                    "reason": reason,
+                    "created_at": datetime.now(UTC),
+                },
+            )
+        )
+        await session.execute(stmt)
+        await session.commit()
+
+    return {
+        "sport": sport,
+        "requested_time": requested_time.isoformat(),
+        "delay_hours": delay_hours,
+        "reason": reason,
     }
 
 

--- a/tests/unit/test_agent_wakeup.py
+++ b/tests/unit/test_agent_wakeup.py
@@ -103,6 +103,35 @@ class TestScheduleNextWakeup:
         sports = {w.sport_key for w in wakeups}
         assert sports == {"soccer_epl", "baseball_mlb"}
 
+    @pytest.mark.asyncio
+    async def test_upsert_resets_consumed_at(self, test_session) -> None:
+        from odds_mcp.server import schedule_next_wakeup
+
+        # 1. Insert a wakeup
+        with _patch_session(test_session):
+            await schedule_next_wakeup(sport="soccer_epl", delay_hours=6.0, reason="Initial")
+
+        # 2. Simulate the consumer marking it consumed
+        row = await test_session.execute(
+            select(AgentWakeup).where(AgentWakeup.sport_key == "soccer_epl")
+        )
+        wakeup = row.scalar_one()
+        wakeup.consumed_at = datetime.now(UTC)
+        await test_session.commit()
+
+        # 3. Upsert again for the same sport
+        with _patch_session(test_session):
+            await schedule_next_wakeup(sport="soccer_epl", delay_hours=12.0, reason="Rescheduled")
+
+        # 4. Assert consumed_at was reset to None
+        test_session.expire_all()
+        row = await test_session.execute(
+            select(AgentWakeup).where(AgentWakeup.sport_key == "soccer_epl")
+        )
+        wakeup = row.scalar_one()
+        assert wakeup.consumed_at is None
+        assert wakeup.reason == "Rescheduled"
+
 
 class TestGetScheduledJobs:
     """Tests for the get_scheduled_jobs MCP tool."""

--- a/tests/unit/test_agent_wakeup.py
+++ b/tests/unit/test_agent_wakeup.py
@@ -1,0 +1,186 @@
+"""Tests for agent wakeup scheduling MCP tools."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from odds_core.agent_wakeup_models import AgentWakeup
+from sqlalchemy import select
+
+
+def _patch_session(session):
+    """Patch async_session_maker to yield the test session."""
+
+    @asynccontextmanager
+    async def _fake_session_maker():
+        yield session
+
+    return patch("odds_mcp.server.async_session_maker", _fake_session_maker)
+
+
+class TestScheduleNextWakeup:
+    """Tests for the schedule_next_wakeup MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_inserts_new_wakeup(self, test_session) -> None:
+        from odds_mcp.server import schedule_next_wakeup
+
+        with _patch_session(test_session):
+            result = await schedule_next_wakeup(
+                sport="soccer_epl", delay_hours=6.0, reason="Pre-match context"
+            )
+
+        assert result["sport"] == "soccer_epl"
+        assert result["delay_hours"] == 6.0
+        assert result["reason"] == "Pre-match context"
+        assert "requested_time" in result
+
+        # Verify persisted
+        row = await test_session.execute(
+            select(AgentWakeup).where(AgentWakeup.sport_key == "soccer_epl")
+        )
+        wakeup = row.scalar_one()
+        assert wakeup.reason == "Pre-match context"
+        assert wakeup.consumed_at is None
+
+    @pytest.mark.asyncio
+    async def test_upsert_overwrites_same_sport(self, test_session) -> None:
+        from odds_mcp.server import schedule_next_wakeup
+
+        with _patch_session(test_session):
+            await schedule_next_wakeup(sport="soccer_epl", delay_hours=6.0, reason="First reason")
+            second = await schedule_next_wakeup(
+                sport="soccer_epl", delay_hours=12.0, reason="Updated reason"
+            )
+
+        assert second["delay_hours"] == 12.0
+        assert second["reason"] == "Updated reason"
+
+        # Only one row should exist for this sport
+        rows = await test_session.execute(
+            select(AgentWakeup).where(AgentWakeup.sport_key == "soccer_epl")
+        )
+        wakeups = list(rows.scalars().all())
+        assert len(wakeups) == 1
+        assert wakeups[0].reason == "Updated reason"
+
+    @pytest.mark.asyncio
+    async def test_clamps_delay_below_minimum(self, test_session) -> None:
+        from odds_mcp.server import schedule_next_wakeup
+
+        with _patch_session(test_session):
+            result = await schedule_next_wakeup(
+                sport="soccer_epl", delay_hours=0.1, reason="Too soon"
+            )
+
+        assert result["delay_hours"] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_clamps_delay_above_maximum(self, test_session) -> None:
+        from odds_mcp.server import schedule_next_wakeup
+
+        with _patch_session(test_session):
+            result = await schedule_next_wakeup(
+                sport="soccer_epl", delay_hours=500.0, reason="Too far"
+            )
+
+        assert result["delay_hours"] == 168.0
+
+    @pytest.mark.asyncio
+    async def test_different_sports_coexist(self, test_session) -> None:
+        from odds_mcp.server import schedule_next_wakeup
+
+        with _patch_session(test_session):
+            await schedule_next_wakeup(sport="soccer_epl", delay_hours=6.0, reason="EPL")
+            await schedule_next_wakeup(sport="baseball_mlb", delay_hours=12.0, reason="MLB")
+
+        rows = await test_session.execute(select(AgentWakeup))
+        wakeups = list(rows.scalars().all())
+        assert len(wakeups) == 2
+        sports = {w.sport_key for w in wakeups}
+        assert sports == {"soccer_epl", "baseball_mlb"}
+
+
+class TestGetScheduledJobs:
+    """Tests for the get_scheduled_jobs MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_backend_unavailable_returns_message(self) -> None:
+        from odds_lambda.scheduling.backends import BackendUnavailableError
+        from odds_mcp.server import get_scheduled_jobs
+
+        mock_backend = AsyncMock()
+        mock_backend.get_scheduled_jobs = AsyncMock(
+            side_effect=BackendUnavailableError("Scheduler not running")
+        )
+        with patch("odds_mcp.server.get_scheduler_backend", return_value=mock_backend):
+            result = await get_scheduled_jobs()
+
+        assert result["jobs"] == []
+        assert "unavailable" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_sport_filtering(self) -> None:
+        from odds_lambda.scheduling.backends.base import JobStatus, ScheduledJob
+        from odds_mcp.server import get_scheduled_jobs
+
+        now = datetime.now(UTC)
+        mock_jobs = [
+            ScheduledJob(
+                job_name="fetch_odds_soccer_epl", next_run_time=now, status=JobStatus.SCHEDULED
+            ),
+            ScheduledJob(
+                job_name="fetch_odds_baseball_mlb", next_run_time=now, status=JobStatus.SCHEDULED
+            ),
+            ScheduledJob(
+                job_name="agent_run_soccer_epl", next_run_time=now, status=JobStatus.SCHEDULED
+            ),
+        ]
+        mock_backend = AsyncMock()
+        mock_backend.get_scheduled_jobs = AsyncMock(return_value=mock_jobs)
+
+        with patch("odds_mcp.server.get_scheduler_backend", return_value=mock_backend):
+            result = await get_scheduled_jobs(sport="soccer_epl")
+
+        assert result["job_count"] == 2
+        job_names = [j["job_name"] for j in result["jobs"]]
+        assert "fetch_odds_soccer_epl" in job_names
+        assert "agent_run_soccer_epl" in job_names
+        assert "fetch_odds_baseball_mlb" not in job_names
+
+    @pytest.mark.asyncio
+    async def test_no_filter_returns_all(self) -> None:
+        from odds_lambda.scheduling.backends.base import JobStatus, ScheduledJob
+        from odds_mcp.server import get_scheduled_jobs
+
+        now = datetime.now(UTC)
+        mock_jobs = [
+            ScheduledJob(
+                job_name="fetch_odds_soccer_epl", next_run_time=now, status=JobStatus.SCHEDULED
+            ),
+            ScheduledJob(
+                job_name="fetch_odds_baseball_mlb", next_run_time=now, status=JobStatus.SCHEDULED
+            ),
+        ]
+        mock_backend = AsyncMock()
+        mock_backend.get_scheduled_jobs = AsyncMock(return_value=mock_jobs)
+
+        with patch("odds_mcp.server.get_scheduler_backend", return_value=mock_backend):
+            result = await get_scheduled_jobs()
+
+        assert result["job_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_returns_message(self) -> None:
+        from odds_mcp.server import get_scheduled_jobs
+
+        mock_backend = AsyncMock()
+        mock_backend.get_scheduled_jobs = AsyncMock(side_effect=RuntimeError("Connection refused"))
+        with patch("odds_mcp.server.get_scheduler_backend", return_value=mock_backend):
+            result = await get_scheduled_jobs()
+
+        assert result["jobs"] == []
+        assert "Connection refused" in result["message"]


### PR DESCRIPTION
## Summary
- Add `AgentWakeup` SQLModel and `agent_wakeups` table (one active row per sport, upsert semantics) with `consumed_at` field for consumption tracking
- Add `get_scheduled_jobs(sport?)` MCP tool — reads from scheduler backend with optional sport filter, graceful handling when backend is unavailable
- Add `schedule_next_wakeup(sport, delay_hours, reason)` MCP tool — upserts to `agent_wakeups` table so `agent_run.py` (#315) can read and reschedule after subprocess exits
- Add Alembic migration for new table
- Add 9 unit tests covering upsert behavior, delay clamping, backend unavailability, and sport filtering

## Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)