### PR TITLE
Add agent-run job with fixture-proximity self-scheduling

### DIFF
--- a/packages/odds-core/odds_core/config.py
+++ b/packages/odds-core/odds_core/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from pathlib import Path
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -234,6 +235,9 @@ class Settings(BaseSettings):
     """
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+
+    # Repository root (walk up from packages/odds-core/odds_core/config.py)
+    project_root: Path = Field(default=Path(__file__).resolve().parents[3])
 
     # Composed configuration sections
     api: APIConfig = Field(default_factory=APIConfig)

--- a/packages/odds-lambda/odds_lambda/jobs/agent_run.py
+++ b/packages/odds-lambda/odds_lambda/jobs/agent_run.py
@@ -1,0 +1,288 @@
+"""Run the betting agent and self-schedule based on fixture proximity.
+
+Scheduling strategy: query DB for next kickoff, compute wake interval from
+proximity tiers, pre-schedule before launching the agent subprocess (survives
+crashes). After the agent exits, check the agent_wakeups table for an
+agent-requested override and reschedule if it's sooner.
+
+Wake interval tiers:
+  > 48h to KO   -> 24h  (far out)
+  24-48h        -> 12h  (research window opening)
+  6-24h         ->  4h  (active research)
+  1.5-6h        ->  1h  (lineups dropping)
+  < 1.5h        -> skip (too close)
+  no fixtures   -> 12h  (off-season check-in)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from odds_core.database import async_session_maker
+from sqlalchemy import select
+from sqlmodel import col
+
+from odds_lambda.scheduling.backends import get_scheduler_backend
+from odds_lambda.scheduling.jobs import JobContext, make_compound_job_name
+
+logger = structlog.get_logger()
+
+# Wake interval tiers (hours)
+TIER_FAR_HOURS = 24.0  # > 48h to KO
+TIER_RESEARCH_HOURS = 12.0  # 24-48h to KO
+TIER_ACTIVE_HOURS = 4.0  # 6-24h to KO
+TIER_LINEUP_HOURS = 1.0  # 1.5-6h to KO
+TIER_NO_FIXTURES_HOURS = 12.0  # no fixtures within 7 days
+SKIP_THRESHOLD_HOURS = 1.5  # too close to KO — don't wake
+
+# Overnight suppression window (UTC)
+OVERNIGHT_START_UTC = 22
+OVERNIGHT_RESUME_UTC = 6
+
+# Agent subprocess limits
+AGENT_TIMEOUT_SECONDS = 15 * 60  # 15 minutes
+
+# Horizon for "no fixtures" classification
+FIXTURE_HORIZON_DAYS = 7
+
+
+async def _get_next_kickoff(sport_key: str) -> datetime | None:
+    """Earliest scheduled event commence_time for a sport."""
+    from odds_core.models import Event, EventStatus
+
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(Event.commence_time)
+            .where(
+                col(Event.sport_key) == sport_key,
+                col(Event.commence_time) > datetime.now(UTC),
+                col(Event.status) == EventStatus.SCHEDULED,
+            )
+            .order_by(col(Event.commence_time))
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+
+def _compute_wake_interval(hours_until_ko: float | None) -> float:
+    """Return wake interval in hours based on fixture proximity tier."""
+    if hours_until_ko is None:
+        return TIER_NO_FIXTURES_HOURS
+    if hours_until_ko > 48:
+        return TIER_FAR_HOURS
+    if hours_until_ko > 24:
+        return TIER_RESEARCH_HOURS
+    if hours_until_ko > 6:
+        return TIER_ACTIVE_HOURS
+    if hours_until_ko > SKIP_THRESHOLD_HOURS:
+        return TIER_LINEUP_HOURS
+    # Too close — skip this cycle, check again later
+    return TIER_NO_FIXTURES_HOURS
+
+
+def _should_skip_run(hours_until_ko: float | None) -> bool:
+    """Return True if too close to kickoff to justify a wake-up."""
+    return hours_until_ko is not None and hours_until_ko <= SKIP_THRESHOLD_HOURS
+
+
+def _apply_overnight_skip(next_time: datetime) -> datetime:
+    """Push next_time to resume hour if it falls in the overnight window."""
+    if next_time.hour >= OVERNIGHT_START_UTC or next_time.hour < OVERNIGHT_RESUME_UTC:
+        resume = next_time.replace(hour=OVERNIGHT_RESUME_UTC, minute=0, second=0, microsecond=0)
+        if resume <= next_time:
+            resume += timedelta(days=1)
+        return resume
+    return next_time
+
+
+async def _run_claude_agent(sport: str) -> int:
+    """Spawn ``claude -p`` subprocess and return exit code.
+
+    Stdout is logged line-by-line at INFO level. Timeout after
+    ``AGENT_TIMEOUT_SECONDS``. Returns -1 on timeout.
+    """
+    cmd = ["claude", "-p", f"/agent {sport}", "--dangerously-skip-permissions"]
+
+    logger.info("agent_subprocess_starting", sport=sport, cmd=cmd)
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        cwd="/home/andrew/code/odds",
+    )
+
+    try:
+        assert proc.stdout is not None  # noqa: S101
+        async for line in proc.stdout:
+            text = line.decode("utf-8", errors="replace").rstrip()
+            if text:
+                logger.info("agent_output", line=text)
+
+        await asyncio.wait_for(proc.wait(), timeout=AGENT_TIMEOUT_SECONDS)
+    except TimeoutError:
+        logger.error("agent_subprocess_timeout", sport=sport, timeout=AGENT_TIMEOUT_SECONDS)
+        proc.kill()
+        await proc.wait()
+        return -1
+
+    exit_code = proc.returncode or 0
+    logger.info("agent_subprocess_finished", sport=sport, exit_code=exit_code)
+    return exit_code
+
+
+async def _check_agent_requested_wakeup(sport_key: str) -> datetime | None:
+    """Read and consume any agent-requested wake-up from the agent_wakeups table.
+
+    Returns the requested time if a row exists for this sport, then marks it
+    consumed. Returns None if no pending request.
+    """
+    from odds_core.agent_wakeup_models import AgentWakeup
+
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(AgentWakeup).where(
+                col(AgentWakeup.sport_key) == sport_key,
+                col(AgentWakeup.consumed_at).is_(None),
+            )
+        )
+        wakeup = result.scalar_one_or_none()
+
+        if wakeup is None:
+            return None
+
+        requested_time = wakeup.requested_time
+        logger.info(
+            "agent_wakeup_found",
+            sport_key=sport_key,
+            requested_time=requested_time.isoformat(),
+            reason=wakeup.reason,
+        )
+
+        wakeup.consumed_at = datetime.now(UTC)
+        session.add(wakeup)
+        await session.commit()
+
+    return requested_time
+
+
+async def _self_schedule(
+    *,
+    job_name: str,
+    next_time: datetime,
+    dry_run: bool,
+    sport: str | None = None,
+    interval_hours: float | None = None,
+    reason: str = "",
+) -> None:
+    """Schedule the next execution via the scheduler backend."""
+    backend = get_scheduler_backend(dry_run=dry_run)
+
+    payload: dict[str, object] = {}
+    if sport:
+        payload["sport"] = sport
+
+    await backend.schedule_next_execution(
+        job_name=job_name,
+        next_time=next_time,
+        payload=payload or None,
+    )
+
+    logger.info(
+        "agent_run_scheduled",
+        next_time=next_time.isoformat(),
+        interval_hours=interval_hours,
+        reason=reason,
+        backend=backend.get_backend_name(),
+    )
+
+
+async def main(ctx: JobContext) -> None:
+    """Orchestrate agent wake-up: schedule, run, check override."""
+    from odds_core.config import get_settings
+
+    settings = get_settings()
+    sport = ctx.sport
+
+    if not sport:
+        logger.error("agent_run_no_sport", msg="sport is required for agent-run job")
+        return
+
+    compound_job_name = make_compound_job_name("agent-run", sport)
+
+    # --- Determine default wake interval from fixture proximity ---
+    hours_until_ko: float | None = None
+    try:
+        next_kickoff = await _get_next_kickoff(sport)
+        if next_kickoff is not None:
+            hours_until_ko = (next_kickoff - datetime.now(UTC)).total_seconds() / 3600
+        logger.info(
+            "agent_proximity",
+            next_kickoff=next_kickoff.isoformat() if next_kickoff else None,
+            hours_until_ko=round(hours_until_ko, 2) if hours_until_ko is not None else None,
+        )
+    except Exception as e:
+        logger.warning("agent_kickoff_query_failed", error=str(e), exc_info=True)
+
+    default_interval = _compute_wake_interval(hours_until_ko)
+    skip_run = _should_skip_run(hours_until_ko)
+
+    # --- Pre-schedule before work (crash-safe) ---
+    default_next_time = _apply_overnight_skip(datetime.now(UTC) + timedelta(hours=default_interval))
+    try:
+        await _self_schedule(
+            job_name=compound_job_name,
+            next_time=default_next_time,
+            dry_run=settings.scheduler.dry_run,
+            sport=sport,
+            interval_hours=default_interval,
+            reason="pre-schedule (default tier)",
+        )
+    except Exception as e:
+        logger.error("agent_run_preschedule_failed", error=str(e), exc_info=True)
+        raise
+
+    # --- Run the agent (unless too close to KO) ---
+    if skip_run:
+        logger.info(
+            "agent_run_skipped",
+            hours_until_ko=round(hours_until_ko, 2) if hours_until_ko is not None else None,
+            reason="too close to kickoff",
+        )
+        return
+
+    exit_code = await _run_claude_agent(sport)
+
+    if exit_code != 0:
+        logger.warning("agent_run_nonzero_exit", exit_code=exit_code, sport=sport)
+
+    # --- Check for agent-requested wake-up override ---
+    try:
+        requested_time = await _check_agent_requested_wakeup(sport)
+    except Exception as e:
+        logger.warning("agent_wakeup_check_failed", error=str(e), exc_info=True)
+        requested_time = None
+
+    if requested_time is not None and requested_time < default_next_time:
+        override_next_time = _apply_overnight_skip(requested_time)
+        try:
+            await _self_schedule(
+                job_name=compound_job_name,
+                next_time=override_next_time,
+                dry_run=settings.scheduler.dry_run,
+                sport=sport,
+                reason="agent-requested override",
+            )
+            logger.info(
+                "agent_run_rescheduled",
+                default_time=default_next_time.isoformat(),
+                override_time=override_next_time.isoformat(),
+            )
+        except Exception as e:
+            logger.error("agent_run_override_schedule_failed", error=str(e), exc_info=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main(JobContext(sport="soccer_epl")))

--- a/packages/odds-lambda/odds_lambda/jobs/agent_run.py
+++ b/packages/odds-lambda/odds_lambda/jobs/agent_run.py
@@ -18,14 +18,11 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
 
 import structlog
-from odds_core.database import async_session_maker
-from sqlalchemy import select
-from sqlmodel import col
+from odds_core.config import get_settings
 
-from odds_lambda.scheduling.backends import get_scheduler_backend
+from odds_lambda.scheduling.helpers import apply_overnight_skip, get_next_kickoff, self_schedule
 from odds_lambda.scheduling.jobs import JobContext, make_compound_job_name
 
 logger = structlog.get_logger()
@@ -51,27 +48,6 @@ TIER_TOO_CLOSE_HOURS = 3.0
 # Horizon for "no fixtures" classification
 FIXTURE_HORIZON_DAYS = 7
 
-# Project root (walk up from packages/odds-lambda/odds_lambda/jobs/)
-_PROJECT_ROOT = Path(__file__).resolve().parents[4]
-
-
-async def _get_next_kickoff(sport_key: str) -> datetime | None:
-    """Earliest scheduled event commence_time for a sport."""
-    from odds_core.models import Event, EventStatus
-
-    async with async_session_maker() as session:
-        result = await session.execute(
-            select(Event.commence_time)
-            .where(
-                col(Event.sport_key) == sport_key,
-                col(Event.commence_time) > datetime.now(UTC),
-                col(Event.status) == EventStatus.SCHEDULED,
-            )
-            .order_by(col(Event.commence_time))
-            .limit(1)
-        )
-        return result.scalar_one_or_none()
-
 
 def _compute_wake_interval(hours_until_ko: float | None) -> float:
     """Return wake interval in hours based on fixture proximity tier."""
@@ -94,16 +70,6 @@ def _should_skip_run(hours_until_ko: float | None) -> bool:
     return hours_until_ko is not None and hours_until_ko <= SKIP_THRESHOLD_HOURS
 
 
-def _apply_overnight_skip(next_time: datetime) -> datetime:
-    """Push next_time to resume hour if it falls in the overnight window."""
-    if next_time.hour >= OVERNIGHT_START_UTC or next_time.hour < OVERNIGHT_RESUME_UTC:
-        resume = next_time.replace(hour=OVERNIGHT_RESUME_UTC, minute=0, second=0, microsecond=0)
-        if resume <= next_time:
-            resume += timedelta(days=1)
-        return resume
-    return next_time
-
-
 async def _run_claude_agent(sport: str) -> int:
     """Spawn ``claude -p`` subprocess and return exit code.
 
@@ -112,13 +78,14 @@ async def _run_claude_agent(sport: str) -> int:
     """
     cmd = ["claude", "-p", f"/agent {sport}", "--dangerously-skip-permissions"]
 
+    settings = get_settings()
     logger.info("agent_subprocess_starting", sport=sport, cmd=cmd)
 
     proc = await asyncio.create_subprocess_exec(
         *cmd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
-        cwd=str(_PROJECT_ROOT),
+        cwd=str(settings.project_root),
     )
 
     try:
@@ -148,6 +115,9 @@ async def _check_agent_requested_wakeup(sport_key: str) -> datetime | None:
     consumed. Returns None if no pending request.
     """
     from odds_core.agent_wakeup_models import AgentWakeup
+    from odds_core.database import async_session_maker
+    from sqlalchemy import select
+    from sqlmodel import col
 
     async with async_session_maker() as session:
         result = await session.execute(
@@ -176,41 +146,8 @@ async def _check_agent_requested_wakeup(sport_key: str) -> datetime | None:
     return requested_time
 
 
-async def _self_schedule(
-    *,
-    job_name: str,
-    next_time: datetime,
-    dry_run: bool,
-    sport: str | None = None,
-    interval_hours: float | None = None,
-    reason: str = "",
-) -> None:
-    """Schedule the next execution via the scheduler backend."""
-    backend = get_scheduler_backend(dry_run=dry_run)
-
-    payload: dict[str, object] = {}
-    if sport:
-        payload["sport"] = sport
-
-    await backend.schedule_next_execution(
-        job_name=job_name,
-        next_time=next_time,
-        payload=payload or None,
-    )
-
-    logger.info(
-        "agent_run_scheduled",
-        next_time=next_time.isoformat(),
-        interval_hours=interval_hours,
-        reason=reason,
-        backend=backend.get_backend_name(),
-    )
-
-
 async def main(ctx: JobContext) -> None:
     """Orchestrate agent wake-up: schedule, run, check override."""
-    from odds_core.config import get_settings
-
     settings = get_settings()
     sport = ctx.sport
 
@@ -223,7 +160,7 @@ async def main(ctx: JobContext) -> None:
     # --- Determine default wake interval from fixture proximity ---
     hours_until_ko: float | None = None
     try:
-        next_kickoff = await _get_next_kickoff(sport)
+        next_kickoff = await get_next_kickoff(sport)
         if next_kickoff is not None:
             hours_until_ko = (next_kickoff - datetime.now(UTC)).total_seconds() / 3600
         logger.info(
@@ -238,9 +175,9 @@ async def main(ctx: JobContext) -> None:
     skip_run = _should_skip_run(hours_until_ko)
 
     # --- Pre-schedule before work (crash-safe) ---
-    default_next_time = _apply_overnight_skip(datetime.now(UTC) + timedelta(hours=default_interval))
+    default_next_time = apply_overnight_skip(datetime.now(UTC) + timedelta(hours=default_interval))
     try:
-        await _self_schedule(
+        await self_schedule(
             job_name=compound_job_name,
             next_time=default_next_time,
             dry_run=settings.scheduler.dry_run,
@@ -282,9 +219,9 @@ async def main(ctx: JobContext) -> None:
         requested_time = None
 
     if requested_time is not None and requested_time < default_next_time:
-        override_next_time = _apply_overnight_skip(requested_time)
+        override_next_time = apply_overnight_skip(requested_time)
         try:
-            await _self_schedule(
+            await self_schedule(
                 job_name=compound_job_name,
                 next_time=override_next_time,
                 dry_run=settings.scheduler.dry_run,

--- a/packages/odds-lambda/odds_lambda/jobs/agent_run.py
+++ b/packages/odds-lambda/odds_lambda/jobs/agent_run.py
@@ -35,9 +35,13 @@ TIER_LINEUP_HOURS = 1.0  # 1.5-6h to KO
 TIER_NO_FIXTURES_HOURS = 12.0  # no fixtures within 7 days
 SKIP_THRESHOLD_HOURS = 1.5  # too close to KO — don't wake
 
-# Overnight suppression window (UTC)
-OVERNIGHT_START_UTC = 22
-OVERNIGHT_RESUME_UTC = 6
+# Overnight suppression windows (start_utc, resume_utc) per sport
+# EPL: last KO ~20:00 UTC, suppress 22:00-06:00
+# MLB: last pitch ~04:00 UTC, suppress 06:00-14:00
+OVERNIGHT_WINDOWS: dict[str, tuple[int, int]] = {
+    "soccer_epl": (22, 6),
+    "baseball_mlb": (6, 14),
+}
 
 # Agent subprocess limits
 AGENT_TIMEOUT_SECONDS = 15 * 60  # 15 minutes
@@ -157,6 +161,13 @@ async def main(ctx: JobContext) -> None:
 
     compound_job_name = make_compound_job_name("agent-run", sport)
 
+    # --- Resolve overnight window for this sport ---
+    if sport not in OVERNIGHT_WINDOWS:
+        raise ValueError(
+            f"No overnight window configured for {sport} — add it to OVERNIGHT_WINDOWS"
+        )
+    overnight_start_utc, overnight_resume_utc = OVERNIGHT_WINDOWS[sport]
+
     # --- Determine default wake interval from fixture proximity ---
     hours_until_ko: float | None = None
     try:
@@ -177,8 +188,8 @@ async def main(ctx: JobContext) -> None:
     # --- Pre-schedule before work (crash-safe) ---
     default_next_time = apply_overnight_skip(
         datetime.now(UTC) + timedelta(hours=default_interval),
-        overnight_start_utc=OVERNIGHT_START_UTC,
-        overnight_resume_utc=OVERNIGHT_RESUME_UTC,
+        overnight_start_utc=overnight_start_utc,
+        overnight_resume_utc=overnight_resume_utc,
     )
     try:
         await self_schedule(
@@ -225,8 +236,8 @@ async def main(ctx: JobContext) -> None:
     if requested_time is not None and requested_time < default_next_time:
         override_next_time = apply_overnight_skip(
             requested_time,
-            overnight_start_utc=OVERNIGHT_START_UTC,
-            overnight_resume_utc=OVERNIGHT_RESUME_UTC,
+            overnight_start_utc=overnight_start_utc,
+            overnight_resume_utc=overnight_resume_utc,
         )
         try:
             await self_schedule(

--- a/packages/odds-lambda/odds_lambda/jobs/agent_run.py
+++ b/packages/odds-lambda/odds_lambda/jobs/agent_run.py
@@ -175,7 +175,11 @@ async def main(ctx: JobContext) -> None:
     skip_run = _should_skip_run(hours_until_ko)
 
     # --- Pre-schedule before work (crash-safe) ---
-    default_next_time = apply_overnight_skip(datetime.now(UTC) + timedelta(hours=default_interval))
+    default_next_time = apply_overnight_skip(
+        datetime.now(UTC) + timedelta(hours=default_interval),
+        overnight_start_utc=OVERNIGHT_START_UTC,
+        overnight_resume_utc=OVERNIGHT_RESUME_UTC,
+    )
     try:
         await self_schedule(
             job_name=compound_job_name,
@@ -219,7 +223,11 @@ async def main(ctx: JobContext) -> None:
         requested_time = None
 
     if requested_time is not None and requested_time < default_next_time:
-        override_next_time = apply_overnight_skip(requested_time)
+        override_next_time = apply_overnight_skip(
+            requested_time,
+            overnight_start_utc=OVERNIGHT_START_UTC,
+            overnight_resume_utc=OVERNIGHT_RESUME_UTC,
+        )
         try:
             await self_schedule(
                 job_name=compound_job_name,

--- a/packages/odds-lambda/odds_lambda/jobs/agent_run.py
+++ b/packages/odds-lambda/odds_lambda/jobs/agent_run.py
@@ -10,7 +10,7 @@ Wake interval tiers:
   24-48h        -> 12h  (research window opening)
   6-24h         ->  4h  (active research)
   1.5-6h        ->  1h  (lineups dropping)
-  < 1.5h        -> skip (too close)
+  < 1.5h        ->  3h  (too close — check back post-match)
   no fixtures   -> 12h  (off-season check-in)
 """
 
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import structlog
 from odds_core.database import async_session_maker
@@ -44,8 +45,14 @@ OVERNIGHT_RESUME_UTC = 6
 # Agent subprocess limits
 AGENT_TIMEOUT_SECONDS = 15 * 60  # 15 minutes
 
+# Post-match check-in (too close to KO — match about to start / in progress)
+TIER_TOO_CLOSE_HOURS = 3.0
+
 # Horizon for "no fixtures" classification
 FIXTURE_HORIZON_DAYS = 7
+
+# Project root (walk up from packages/odds-lambda/odds_lambda/jobs/)
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
 
 
 async def _get_next_kickoff(sport_key: str) -> datetime | None:
@@ -78,8 +85,8 @@ def _compute_wake_interval(hours_until_ko: float | None) -> float:
         return TIER_ACTIVE_HOURS
     if hours_until_ko > SKIP_THRESHOLD_HOURS:
         return TIER_LINEUP_HOURS
-    # Too close — skip this cycle, check again later
-    return TIER_NO_FIXTURES_HOURS
+    # Too close — match is about to start; check back after it ends
+    return TIER_TOO_CLOSE_HOURS
 
 
 def _should_skip_run(hours_until_ko: float | None) -> bool:
@@ -111,19 +118,20 @@ async def _run_claude_agent(sport: str) -> int:
         *cmd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
-        cwd="/home/andrew/code/odds",
+        cwd=str(_PROJECT_ROOT),
     )
 
     try:
-        assert proc.stdout is not None  # noqa: S101
-        async for line in proc.stdout:
-            text = line.decode("utf-8", errors="replace").rstrip()
-            if text:
-                logger.info("agent_output", line=text)
+        async with asyncio.timeout(AGENT_TIMEOUT_SECONDS):
+            assert proc.stdout is not None  # noqa: S101
+            async for line in proc.stdout:
+                text = line.decode("utf-8", errors="replace").rstrip()
+                if text:
+                    logger.info("agent_output", line=text)
 
-        await asyncio.wait_for(proc.wait(), timeout=AGENT_TIMEOUT_SECONDS)
+            await proc.wait()
     except TimeoutError:
-        logger.error("agent_subprocess_timeout", sport=sport, timeout=AGENT_TIMEOUT_SECONDS)
+        logger.warning("agent_subprocess_timeout", sport=sport, timeout=AGENT_TIMEOUT_SECONDS)
         proc.kill()
         await proc.wait()
         return -1
@@ -263,6 +271,14 @@ async def main(ctx: JobContext) -> None:
         requested_time = await _check_agent_requested_wakeup(sport)
     except Exception as e:
         logger.warning("agent_wakeup_check_failed", error=str(e), exc_info=True)
+        requested_time = None
+
+    if requested_time is not None and requested_time <= datetime.now(UTC):
+        logger.warning(
+            "agent_wakeup_in_past",
+            requested_time=requested_time.isoformat(),
+            msg="ignoring agent-requested wakeup that is in the past",
+        )
         requested_time = None
 
     if requested_time is not None and requested_time < default_next_time:

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
@@ -24,8 +24,6 @@ from typing import Any
 
 import structlog
 from odds_core.database import async_session_maker
-from sqlalchemy import select
-from sqlmodel import col
 
 from odds_lambda.fetch_tier import FetchTier
 from odds_lambda.oddsportal_adapter import (
@@ -33,7 +31,7 @@ from odds_lambda.oddsportal_adapter import (
     convert_upcoming_matches,
 )
 from odds_lambda.oddsportal_common import hours_to_tier, run_scraper_with_retry
-from odds_lambda.scheduling.backends import get_scheduler_backend
+from odds_lambda.scheduling.helpers import apply_overnight_skip, get_next_kickoff, self_schedule
 from odds_lambda.scheduling.jobs import JobContext, make_compound_job_name
 from odds_lambda.storage.writers import OddsWriter
 
@@ -216,25 +214,6 @@ async def ingest_league(
     return stats
 
 
-async def _get_next_kickoff(sport_key: str) -> datetime | None:
-    """Query DB for the earliest upcoming event commence_time for a sport."""
-    from odds_core.models import Event, EventStatus
-
-    async with async_session_maker() as session:
-        result = await session.execute(
-            select(Event.commence_time)
-            .where(
-                col(Event.sport_key) == sport_key,
-                col(Event.commence_time) > datetime.now(UTC),
-                col(Event.status) == EventStatus.SCHEDULED,
-            )
-            .order_by(col(Event.commence_time))
-            .limit(1)
-        )
-        row = result.scalar_one_or_none()
-    return row
-
-
 def _interval_for_kickoff(
     next_kickoff: datetime | None,
     *,
@@ -254,60 +233,6 @@ def _interval_for_kickoff(
     if hours_until < FetchTier.PREGAME.max_hours:
         return PREGAME_INTERVAL_HOURS
     return FAR_INTERVAL_HOURS
-
-
-def _apply_overnight_skip(
-    next_time: datetime,
-    *,
-    overnight_start_utc: int = 22,
-    overnight_resume_utc: int = 6,
-) -> datetime:
-    """Push next_time to resume hour if it falls in the overnight window."""
-    if overnight_start_utc > overnight_resume_utc:
-        # Window wraps midnight (e.g. 22:00-06:00)
-        is_overnight = (
-            next_time.hour >= overnight_start_utc or next_time.hour < overnight_resume_utc
-        )
-    else:
-        # Window within same day (e.g. 05:00-14:00)
-        is_overnight = overnight_start_utc <= next_time.hour < overnight_resume_utc
-
-    if is_overnight:
-        resume = next_time.replace(hour=overnight_resume_utc, minute=0, second=0, microsecond=0)
-        if resume <= next_time:
-            resume += timedelta(days=1)
-        return resume
-
-    return next_time
-
-
-async def _self_schedule(
-    *,
-    job_name: str,
-    next_time: datetime,
-    dry_run: bool,
-    sport: str | None = None,
-    interval_hours: float | None = None,
-) -> None:
-    """Schedule the next execution via the scheduler backend."""
-    backend = get_scheduler_backend(dry_run=dry_run)
-
-    payload: dict[str, object] = {}
-    if sport:
-        payload["sport"] = sport
-
-    await backend.schedule_next_execution(
-        job_name=job_name,
-        next_time=next_time,
-        payload=payload or None,
-    )
-
-    logger.info(
-        "fetch_oddsportal_next_scheduled",
-        next_time=next_time.isoformat(),
-        interval_hours=interval_hours,
-        backend=backend.get_backend_name(),
-    )
 
 
 async def main(ctx: JobContext) -> None:
@@ -342,7 +267,7 @@ async def main(ctx: JobContext) -> None:
     # On failure, fall back to 1h so we don't block on DB availability.
     pre_interval = DB_FALLBACK_INTERVAL_HOURS
     try:
-        next_kickoff = await _get_next_kickoff(primary_spec.sport_key)
+        next_kickoff = await get_next_kickoff(primary_spec.sport_key)
         pre_interval = _interval_for_kickoff(next_kickoff)
         logger.info(
             "proximity_schedule",
@@ -354,13 +279,13 @@ async def main(ctx: JobContext) -> None:
 
     # Pre-schedule before any browser work so the chain survives Lambda
     # timeouts or browser crashes.
-    pre_next_time = _apply_overnight_skip(
+    pre_next_time = apply_overnight_skip(
         datetime.now(UTC) + timedelta(hours=pre_interval),
         overnight_start_utc=primary_spec.overnight_start_utc,
         overnight_resume_utc=primary_spec.overnight_resume_utc,
     )
     try:
-        await _self_schedule(
+        await self_schedule(
             job_name=compound_job_name,
             next_time=pre_next_time,
             dry_run=settings.scheduler.dry_run,
@@ -423,18 +348,18 @@ async def main(ctx: JobContext) -> None:
     if total_scraped > 0:
         post_interval = DB_FALLBACK_INTERVAL_HOURS
         try:
-            post_kickoff = await _get_next_kickoff(primary_spec.sport_key)
+            post_kickoff = await get_next_kickoff(primary_spec.sport_key)
             post_interval = _interval_for_kickoff(post_kickoff)
         except Exception as e:
             logger.warning("post_scrape_kickoff_query_failed", error=str(e), exc_info=True)
 
-        success_next_time = _apply_overnight_skip(
+        success_next_time = apply_overnight_skip(
             datetime.now(UTC) + timedelta(hours=post_interval),
             overnight_start_utc=primary_spec.overnight_start_utc,
             overnight_resume_utc=primary_spec.overnight_resume_utc,
         )
         try:
-            await _self_schedule(
+            await self_schedule(
                 job_name=compound_job_name,
                 next_time=success_next_time,
                 dry_run=settings.scheduler.dry_run,

--- a/packages/odds-lambda/odds_lambda/scheduling/helpers.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/helpers.py
@@ -1,0 +1,91 @@
+"""Shared scheduling helpers used by multiple jobs."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import structlog
+
+from odds_lambda.scheduling.backends import get_scheduler_backend
+
+logger = structlog.get_logger()
+
+
+async def get_next_kickoff(sport_key: str) -> datetime | None:
+    """Earliest scheduled event commence_time for a sport."""
+    from datetime import UTC
+
+    from odds_core.database import async_session_maker
+    from odds_core.models import Event, EventStatus
+    from sqlalchemy import select
+    from sqlmodel import col
+
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(Event.commence_time)
+            .where(
+                col(Event.sport_key) == sport_key,
+                col(Event.commence_time) > datetime.now(UTC),
+                col(Event.status) == EventStatus.SCHEDULED,
+            )
+            .order_by(col(Event.commence_time))
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+
+def apply_overnight_skip(
+    next_time: datetime,
+    *,
+    overnight_start_utc: int = 22,
+    overnight_resume_utc: int = 6,
+) -> datetime:
+    """Push next_time to resume hour if it falls in the overnight window."""
+    if overnight_start_utc > overnight_resume_utc:
+        # Window wraps midnight (e.g. 22:00-06:00)
+        is_overnight = (
+            next_time.hour >= overnight_start_utc or next_time.hour < overnight_resume_utc
+        )
+    else:
+        # Window within same day (e.g. 05:00-14:00)
+        is_overnight = overnight_start_utc <= next_time.hour < overnight_resume_utc
+
+    if is_overnight:
+        resume = next_time.replace(hour=overnight_resume_utc, minute=0, second=0, microsecond=0)
+        if resume <= next_time:
+            resume += timedelta(days=1)
+        return resume
+
+    return next_time
+
+
+async def self_schedule(
+    *,
+    job_name: str,
+    next_time: datetime,
+    dry_run: bool,
+    sport: str | None = None,
+    interval_hours: float | None = None,
+    reason: str = "",
+) -> None:
+    """Schedule the next execution via the scheduler backend."""
+    backend = get_scheduler_backend(dry_run=dry_run)
+
+    payload: dict[str, object] = {}
+    if sport:
+        payload["sport"] = sport
+
+    await backend.schedule_next_execution(
+        job_name=job_name,
+        next_time=next_time,
+        payload=payload or None,
+    )
+
+    logger.info(
+        "job_next_scheduled",
+        job_name=job_name,
+        next_time=next_time.isoformat(),
+        interval_hours=interval_hours,
+        reason=reason,
+        backend=backend.get_backend_name(),
+    )

--- a/tests/unit/test_agent_run.py
+++ b/tests/unit/test_agent_run.py
@@ -1,0 +1,195 @@
+"""Tests for the agent-run job module."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from odds_lambda.jobs.agent_run import (
+    OVERNIGHT_RESUME_UTC,
+    OVERNIGHT_START_UTC,
+    SKIP_THRESHOLD_HOURS,
+    TIER_ACTIVE_HOURS,
+    TIER_FAR_HOURS,
+    TIER_LINEUP_HOURS,
+    TIER_NO_FIXTURES_HOURS,
+    TIER_RESEARCH_HOURS,
+    _apply_overnight_skip,
+    _compute_wake_interval,
+    _should_skip_run,
+    main,
+)
+from odds_lambda.scheduling.jobs import JobContext
+
+
+class TestComputeWakeInterval:
+    """Tests for fixture-proximity wake interval tiers."""
+
+    def test_no_fixtures_returns_no_fixtures_tier(self) -> None:
+        assert _compute_wake_interval(None) == TIER_NO_FIXTURES_HOURS
+
+    def test_far_out_over_48h(self) -> None:
+        assert _compute_wake_interval(72.0) == TIER_FAR_HOURS
+
+    def test_boundary_exactly_48h(self) -> None:
+        # > 48 is false at exactly 48, falls to next tier
+        assert _compute_wake_interval(48.0) == TIER_RESEARCH_HOURS
+
+    def test_research_window_24_to_48h(self) -> None:
+        assert _compute_wake_interval(36.0) == TIER_RESEARCH_HOURS
+
+    def test_boundary_exactly_24h(self) -> None:
+        assert _compute_wake_interval(24.0) == TIER_ACTIVE_HOURS
+
+    def test_active_research_6_to_24h(self) -> None:
+        assert _compute_wake_interval(12.0) == TIER_ACTIVE_HOURS
+
+    def test_boundary_exactly_6h(self) -> None:
+        assert _compute_wake_interval(6.0) == TIER_LINEUP_HOURS
+
+    def test_lineup_window_1_5_to_6h(self) -> None:
+        assert _compute_wake_interval(3.0) == TIER_LINEUP_HOURS
+
+    def test_too_close_returns_no_fixtures_tier(self) -> None:
+        assert _compute_wake_interval(1.0) == TIER_NO_FIXTURES_HOURS
+
+    def test_boundary_exactly_1_5h(self) -> None:
+        # <= 1.5 is the skip zone, returns no-fixtures tier
+        assert _compute_wake_interval(SKIP_THRESHOLD_HOURS) == TIER_NO_FIXTURES_HOURS
+
+
+class TestShouldSkipRun:
+    """Tests for skip-run logic."""
+
+    def test_no_fixtures_does_not_skip(self) -> None:
+        assert _should_skip_run(None) is False
+
+    def test_far_fixture_does_not_skip(self) -> None:
+        assert _should_skip_run(10.0) is False
+
+    def test_close_fixture_skips(self) -> None:
+        assert _should_skip_run(1.0) is True
+
+    def test_boundary_at_threshold_skips(self) -> None:
+        assert _should_skip_run(SKIP_THRESHOLD_HOURS) is True
+
+    def test_just_above_threshold_does_not_skip(self) -> None:
+        assert _should_skip_run(SKIP_THRESHOLD_HOURS + 0.01) is False
+
+
+class TestApplyOvernightSkip:
+    """Tests for overnight suppression."""
+
+    def test_daytime_unchanged(self) -> None:
+        dt = datetime(2026, 4, 15, 14, 0, tzinfo=UTC)
+        assert _apply_overnight_skip(dt) == dt
+
+    def test_late_night_pushed_to_next_morning(self) -> None:
+        dt = datetime(2026, 4, 15, 23, 30, tzinfo=UTC)
+        expected = datetime(2026, 4, 16, OVERNIGHT_RESUME_UTC, 0, tzinfo=UTC)
+        assert _apply_overnight_skip(dt) == expected
+
+    def test_early_morning_pushed_to_same_day_resume(self) -> None:
+        dt = datetime(2026, 4, 15, 3, 0, tzinfo=UTC)
+        expected = datetime(2026, 4, 15, OVERNIGHT_RESUME_UTC, 0, tzinfo=UTC)
+        assert _apply_overnight_skip(dt) == expected
+
+    def test_exactly_at_overnight_start_pushed(self) -> None:
+        dt = datetime(2026, 4, 15, OVERNIGHT_START_UTC, 0, tzinfo=UTC)
+        expected = datetime(2026, 4, 16, OVERNIGHT_RESUME_UTC, 0, tzinfo=UTC)
+        assert _apply_overnight_skip(dt) == expected
+
+    def test_exactly_at_resume_pushed(self) -> None:
+        # hour < OVERNIGHT_RESUME_UTC is overnight, but hour == OVERNIGHT_RESUME_UTC is not
+        dt = datetime(2026, 4, 15, OVERNIGHT_RESUME_UTC, 0, tzinfo=UTC)
+        assert _apply_overnight_skip(dt) == dt
+
+
+class TestMainNoSport:
+    """Test that main() exits early without a sport."""
+
+    @pytest.mark.asyncio
+    async def test_no_sport_returns_early(self) -> None:
+        ctx = JobContext(sport=None)
+        # Should not raise, just log error and return
+        with patch("odds_lambda.jobs.agent_run._get_next_kickoff") as mock_kickoff:
+            await main(ctx)
+            mock_kickoff.assert_not_called()
+
+
+class TestMainOrchestration:
+    """Test the main() orchestration logic."""
+
+    @pytest.mark.asyncio
+    async def test_preschedule_before_agent_run(self) -> None:
+        """Verify pre-scheduling happens before agent subprocess."""
+        call_order: list[str] = []
+
+        async def mock_schedule(**kwargs: object) -> None:
+            call_order.append("schedule")
+
+        async def mock_run(sport: str) -> int:
+            call_order.append("run")
+            return 0
+
+        with (
+            patch("odds_lambda.jobs.agent_run._get_next_kickoff", new_callable=AsyncMock) as mk,
+            patch("odds_lambda.jobs.agent_run._self_schedule", side_effect=mock_schedule),
+            patch("odds_lambda.jobs.agent_run._run_claude_agent", side_effect=mock_run),
+            patch(
+                "odds_lambda.jobs.agent_run._check_agent_requested_wakeup",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("odds_core.config.get_settings"),
+        ):
+            mk.return_value = datetime.now(UTC) + timedelta(hours=30)
+            await main(JobContext(sport="soccer_epl"))
+
+        assert call_order == ["schedule", "run"]
+
+    @pytest.mark.asyncio
+    async def test_skip_run_when_too_close(self) -> None:
+        """Agent subprocess should not run when too close to kickoff."""
+        with (
+            patch("odds_lambda.jobs.agent_run._get_next_kickoff", new_callable=AsyncMock) as mk,
+            patch("odds_lambda.jobs.agent_run._self_schedule", new_callable=AsyncMock),
+            patch("odds_lambda.jobs.agent_run._run_claude_agent", new_callable=AsyncMock) as run,
+            patch("odds_core.config.get_settings"),
+        ):
+            mk.return_value = datetime.now(UTC) + timedelta(hours=0.5)
+            await main(JobContext(sport="soccer_epl"))
+            run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_agent_override_reschedules(self) -> None:
+        """Agent-requested wakeup that is sooner than default triggers reschedule."""
+        schedule_calls: list[dict] = []
+
+        async def track_schedule(**kwargs: object) -> None:
+            schedule_calls.append(dict(kwargs))
+
+        override_time = datetime.now(UTC) + timedelta(hours=2)
+
+        with (
+            patch("odds_lambda.jobs.agent_run._get_next_kickoff", new_callable=AsyncMock) as mk,
+            patch("odds_lambda.jobs.agent_run._self_schedule", side_effect=track_schedule),
+            patch(
+                "odds_lambda.jobs.agent_run._run_claude_agent",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch(
+                "odds_lambda.jobs.agent_run._check_agent_requested_wakeup",
+                new_callable=AsyncMock,
+                return_value=override_time,
+            ),
+            patch("odds_core.config.get_settings"),
+        ):
+            mk.return_value = datetime.now(UTC) + timedelta(hours=30)
+            await main(JobContext(sport="soccer_epl"))
+
+        # Two schedule calls: pre-schedule + override
+        assert len(schedule_calls) == 2
+        assert schedule_calls[1]["reason"] == "agent-requested override"

--- a/tests/unit/test_agent_run.py
+++ b/tests/unit/test_agent_run.py
@@ -16,11 +16,11 @@ from odds_lambda.jobs.agent_run import (
     TIER_NO_FIXTURES_HOURS,
     TIER_RESEARCH_HOURS,
     TIER_TOO_CLOSE_HOURS,
-    _apply_overnight_skip,
     _compute_wake_interval,
     _should_skip_run,
     main,
 )
+from odds_lambda.scheduling.helpers import apply_overnight_skip
 from odds_lambda.scheduling.jobs import JobContext
 
 
@@ -84,27 +84,27 @@ class TestApplyOvernightSkip:
 
     def test_daytime_unchanged(self) -> None:
         dt = datetime(2026, 4, 15, 14, 0, tzinfo=UTC)
-        assert _apply_overnight_skip(dt) == dt
+        assert apply_overnight_skip(dt) == dt
 
     def test_late_night_pushed_to_next_morning(self) -> None:
         dt = datetime(2026, 4, 15, 23, 30, tzinfo=UTC)
         expected = datetime(2026, 4, 16, OVERNIGHT_RESUME_UTC, 0, tzinfo=UTC)
-        assert _apply_overnight_skip(dt) == expected
+        assert apply_overnight_skip(dt) == expected
 
     def test_early_morning_pushed_to_same_day_resume(self) -> None:
         dt = datetime(2026, 4, 15, 3, 0, tzinfo=UTC)
         expected = datetime(2026, 4, 15, OVERNIGHT_RESUME_UTC, 0, tzinfo=UTC)
-        assert _apply_overnight_skip(dt) == expected
+        assert apply_overnight_skip(dt) == expected
 
     def test_exactly_at_overnight_start_pushed(self) -> None:
         dt = datetime(2026, 4, 15, OVERNIGHT_START_UTC, 0, tzinfo=UTC)
         expected = datetime(2026, 4, 16, OVERNIGHT_RESUME_UTC, 0, tzinfo=UTC)
-        assert _apply_overnight_skip(dt) == expected
+        assert apply_overnight_skip(dt) == expected
 
     def test_exactly_at_resume_pushed(self) -> None:
         # hour < OVERNIGHT_RESUME_UTC is overnight, but hour == OVERNIGHT_RESUME_UTC is not
         dt = datetime(2026, 4, 15, OVERNIGHT_RESUME_UTC, 0, tzinfo=UTC)
-        assert _apply_overnight_skip(dt) == dt
+        assert apply_overnight_skip(dt) == dt
 
 
 class TestMainNoSport:
@@ -114,7 +114,7 @@ class TestMainNoSport:
     async def test_no_sport_returns_early(self) -> None:
         ctx = JobContext(sport=None)
         # Should not raise, just log error and return
-        with patch("odds_lambda.jobs.agent_run._get_next_kickoff") as mock_kickoff:
+        with patch("odds_lambda.jobs.agent_run.get_next_kickoff") as mock_kickoff:
             await main(ctx)
             mock_kickoff.assert_not_called()
 
@@ -135,8 +135,8 @@ class TestMainOrchestration:
             return 0
 
         with (
-            patch("odds_lambda.jobs.agent_run._get_next_kickoff", new_callable=AsyncMock) as mk,
-            patch("odds_lambda.jobs.agent_run._self_schedule", side_effect=mock_schedule),
+            patch("odds_lambda.jobs.agent_run.get_next_kickoff", new_callable=AsyncMock) as mk,
+            patch("odds_lambda.jobs.agent_run.self_schedule", side_effect=mock_schedule),
             patch("odds_lambda.jobs.agent_run._run_claude_agent", side_effect=mock_run),
             patch(
                 "odds_lambda.jobs.agent_run._check_agent_requested_wakeup",
@@ -154,8 +154,8 @@ class TestMainOrchestration:
     async def test_skip_run_when_too_close(self) -> None:
         """Agent subprocess should not run when too close to kickoff."""
         with (
-            patch("odds_lambda.jobs.agent_run._get_next_kickoff", new_callable=AsyncMock) as mk,
-            patch("odds_lambda.jobs.agent_run._self_schedule", new_callable=AsyncMock),
+            patch("odds_lambda.jobs.agent_run.get_next_kickoff", new_callable=AsyncMock) as mk,
+            patch("odds_lambda.jobs.agent_run.self_schedule", new_callable=AsyncMock),
             patch("odds_lambda.jobs.agent_run._run_claude_agent", new_callable=AsyncMock) as run,
             patch("odds_core.config.get_settings"),
         ):
@@ -174,8 +174,8 @@ class TestMainOrchestration:
         override_time = datetime.now(UTC) + timedelta(hours=2)
 
         with (
-            patch("odds_lambda.jobs.agent_run._get_next_kickoff", new_callable=AsyncMock) as mk,
-            patch("odds_lambda.jobs.agent_run._self_schedule", side_effect=track_schedule),
+            patch("odds_lambda.jobs.agent_run.get_next_kickoff", new_callable=AsyncMock) as mk,
+            patch("odds_lambda.jobs.agent_run.self_schedule", side_effect=track_schedule),
             patch(
                 "odds_lambda.jobs.agent_run._run_claude_agent",
                 new_callable=AsyncMock,
@@ -206,8 +206,8 @@ class TestMainOrchestration:
         past_time = datetime.now(UTC) - timedelta(hours=1)
 
         with (
-            patch("odds_lambda.jobs.agent_run._get_next_kickoff", new_callable=AsyncMock) as mk,
-            patch("odds_lambda.jobs.agent_run._self_schedule", side_effect=track_schedule),
+            patch("odds_lambda.jobs.agent_run.get_next_kickoff", new_callable=AsyncMock) as mk,
+            patch("odds_lambda.jobs.agent_run.self_schedule", side_effect=track_schedule),
             patch(
                 "odds_lambda.jobs.agent_run._run_claude_agent",
                 new_callable=AsyncMock,
@@ -239,8 +239,8 @@ class TestMainOrchestration:
         override_time = datetime.now(UTC) + timedelta(hours=20)
 
         with (
-            patch("odds_lambda.jobs.agent_run._get_next_kickoff", new_callable=AsyncMock) as mk,
-            patch("odds_lambda.jobs.agent_run._self_schedule", side_effect=track_schedule),
+            patch("odds_lambda.jobs.agent_run.get_next_kickoff", new_callable=AsyncMock) as mk,
+            patch("odds_lambda.jobs.agent_run.self_schedule", side_effect=track_schedule),
             patch(
                 "odds_lambda.jobs.agent_run._run_claude_agent",
                 new_callable=AsyncMock,

--- a/tests/unit/test_agent_run.py
+++ b/tests/unit/test_agent_run.py
@@ -7,8 +7,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from odds_lambda.jobs.agent_run import (
-    OVERNIGHT_RESUME_UTC,
-    OVERNIGHT_START_UTC,
     SKIP_THRESHOLD_HOURS,
     TIER_ACTIVE_HOURS,
     TIER_FAR_HOURS,
@@ -20,7 +18,6 @@ from odds_lambda.jobs.agent_run import (
     _should_skip_run,
     main,
 )
-from odds_lambda.scheduling.helpers import apply_overnight_skip
 from odds_lambda.scheduling.jobs import JobContext
 
 
@@ -77,34 +74,6 @@ class TestShouldSkipRun:
 
     def test_just_above_threshold_does_not_skip(self) -> None:
         assert _should_skip_run(SKIP_THRESHOLD_HOURS + 0.01) is False
-
-
-class TestApplyOvernightSkip:
-    """Tests for overnight suppression."""
-
-    def test_daytime_unchanged(self) -> None:
-        dt = datetime(2026, 4, 15, 14, 0, tzinfo=UTC)
-        assert apply_overnight_skip(dt) == dt
-
-    def test_late_night_pushed_to_next_morning(self) -> None:
-        dt = datetime(2026, 4, 15, 23, 30, tzinfo=UTC)
-        expected = datetime(2026, 4, 16, OVERNIGHT_RESUME_UTC, 0, tzinfo=UTC)
-        assert apply_overnight_skip(dt) == expected
-
-    def test_early_morning_pushed_to_same_day_resume(self) -> None:
-        dt = datetime(2026, 4, 15, 3, 0, tzinfo=UTC)
-        expected = datetime(2026, 4, 15, OVERNIGHT_RESUME_UTC, 0, tzinfo=UTC)
-        assert apply_overnight_skip(dt) == expected
-
-    def test_exactly_at_overnight_start_pushed(self) -> None:
-        dt = datetime(2026, 4, 15, OVERNIGHT_START_UTC, 0, tzinfo=UTC)
-        expected = datetime(2026, 4, 16, OVERNIGHT_RESUME_UTC, 0, tzinfo=UTC)
-        assert apply_overnight_skip(dt) == expected
-
-    def test_exactly_at_resume_pushed(self) -> None:
-        # hour < OVERNIGHT_RESUME_UTC is overnight, but hour == OVERNIGHT_RESUME_UTC is not
-        dt = datetime(2026, 4, 15, OVERNIGHT_RESUME_UTC, 0, tzinfo=UTC)
-        assert apply_overnight_skip(dt) == dt
 
 
 class TestMainNoSport:

--- a/tests/unit/test_agent_run.py
+++ b/tests/unit/test_agent_run.py
@@ -15,6 +15,7 @@ from odds_lambda.jobs.agent_run import (
     TIER_LINEUP_HOURS,
     TIER_NO_FIXTURES_HOURS,
     TIER_RESEARCH_HOURS,
+    TIER_TOO_CLOSE_HOURS,
     _apply_overnight_skip,
     _compute_wake_interval,
     _should_skip_run,
@@ -51,12 +52,12 @@ class TestComputeWakeInterval:
     def test_lineup_window_1_5_to_6h(self) -> None:
         assert _compute_wake_interval(3.0) == TIER_LINEUP_HOURS
 
-    def test_too_close_returns_no_fixtures_tier(self) -> None:
-        assert _compute_wake_interval(1.0) == TIER_NO_FIXTURES_HOURS
+    def test_too_close_returns_post_match_tier(self) -> None:
+        assert _compute_wake_interval(1.0) == TIER_TOO_CLOSE_HOURS
 
     def test_boundary_exactly_1_5h(self) -> None:
-        # <= 1.5 is the skip zone, returns no-fixtures tier
-        assert _compute_wake_interval(SKIP_THRESHOLD_HOURS) == TIER_NO_FIXTURES_HOURS
+        # <= 1.5 is the skip zone, returns post-match check-in tier
+        assert _compute_wake_interval(SKIP_THRESHOLD_HOURS) == TIER_TOO_CLOSE_HOURS
 
 
 class TestShouldSkipRun:
@@ -193,3 +194,67 @@ class TestMainOrchestration:
         # Two schedule calls: pre-schedule + override
         assert len(schedule_calls) == 2
         assert schedule_calls[1]["reason"] == "agent-requested override"
+
+    @pytest.mark.asyncio
+    async def test_agent_override_in_past_ignored(self) -> None:
+        """Agent-requested wakeup in the past should be ignored."""
+        schedule_calls: list[dict] = []
+
+        async def track_schedule(**kwargs: object) -> None:
+            schedule_calls.append(dict(kwargs))
+
+        past_time = datetime.now(UTC) - timedelta(hours=1)
+
+        with (
+            patch("odds_lambda.jobs.agent_run._get_next_kickoff", new_callable=AsyncMock) as mk,
+            patch("odds_lambda.jobs.agent_run._self_schedule", side_effect=track_schedule),
+            patch(
+                "odds_lambda.jobs.agent_run._run_claude_agent",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch(
+                "odds_lambda.jobs.agent_run._check_agent_requested_wakeup",
+                new_callable=AsyncMock,
+                return_value=past_time,
+            ),
+            patch("odds_core.config.get_settings"),
+        ):
+            mk.return_value = datetime.now(UTC) + timedelta(hours=30)
+            await main(JobContext(sport="soccer_epl"))
+
+        # Only the pre-schedule call, no override
+        assert len(schedule_calls) == 1
+        assert schedule_calls[0]["reason"] == "pre-schedule (default tier)"
+
+    @pytest.mark.asyncio
+    async def test_agent_override_later_than_default_ignored(self) -> None:
+        """Agent-requested wakeup later than default should not trigger reschedule."""
+        schedule_calls: list[dict] = []
+
+        async def track_schedule(**kwargs: object) -> None:
+            schedule_calls.append(dict(kwargs))
+
+        # Default for 30h away is TIER_RESEARCH_HOURS (12h), so override at +20h is later
+        override_time = datetime.now(UTC) + timedelta(hours=20)
+
+        with (
+            patch("odds_lambda.jobs.agent_run._get_next_kickoff", new_callable=AsyncMock) as mk,
+            patch("odds_lambda.jobs.agent_run._self_schedule", side_effect=track_schedule),
+            patch(
+                "odds_lambda.jobs.agent_run._run_claude_agent",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch(
+                "odds_lambda.jobs.agent_run._check_agent_requested_wakeup",
+                new_callable=AsyncMock,
+                return_value=override_time,
+            ),
+            patch("odds_core.config.get_settings"),
+        ):
+            mk.return_value = datetime.now(UTC) + timedelta(hours=30)
+            await main(JobContext(sport="soccer_epl"))
+
+        # Only the pre-schedule call, no override
+        assert len(schedule_calls) == 1

--- a/tests/unit/test_agent_run.py
+++ b/tests/unit/test_agent_run.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from odds_lambda.jobs.agent_run import (
+    OVERNIGHT_WINDOWS,
     SKIP_THRESHOLD_HOURS,
     TIER_ACTIVE_HOURS,
     TIER_FAR_HOURS,
@@ -227,3 +228,99 @@ class TestMainOrchestration:
 
         # Only the pre-schedule call, no override
         assert len(schedule_calls) == 1
+
+
+class TestOvernightWindowPerSport:
+    """Tests for sport-aware overnight suppression windows."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_sport_raises_valueerror(self) -> None:
+        ctx = JobContext(sport="basketball_nba")
+        with (
+            patch("odds_core.config.get_settings"),
+            pytest.raises(ValueError, match="No overnight window configured for basketball_nba"),
+        ):
+            await main(ctx)
+
+    @pytest.mark.asyncio
+    async def test_mlb_uses_mlb_overnight_window(self) -> None:
+        """MLB at 08:00 UTC (inside 06:00-14:00 window) should be pushed to 14:00."""
+        schedule_calls: list[dict] = []
+
+        async def track_schedule(**kwargs: object) -> None:
+            schedule_calls.append(dict(kwargs))
+
+        # Set now to a time where default interval lands at 08:00 UTC
+        fake_now = datetime(2026, 7, 15, 4, 0, tzinfo=UTC)
+        # 4h active tier -> wake at 08:00 UTC, inside MLB window (06-14)
+        next_ko = fake_now + timedelta(hours=10)
+
+        with (
+            patch("odds_lambda.jobs.agent_run.get_next_kickoff", new_callable=AsyncMock) as mk,
+            patch("odds_lambda.jobs.agent_run.self_schedule", side_effect=track_schedule),
+            patch(
+                "odds_lambda.jobs.agent_run._run_claude_agent",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch(
+                "odds_lambda.jobs.agent_run._check_agent_requested_wakeup",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("odds_core.config.get_settings"),
+            patch("odds_lambda.jobs.agent_run.datetime") as mock_dt,
+        ):
+            mock_dt.now.return_value = fake_now
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            mk.return_value = next_ko
+            await main(JobContext(sport="baseball_mlb"))
+
+        assert len(schedule_calls) == 1
+        scheduled_time = schedule_calls[0]["next_time"]
+        # Should be pushed to 14:00 UTC
+        assert scheduled_time.hour == 14
+
+    @pytest.mark.asyncio
+    async def test_epl_uses_epl_overnight_window(self) -> None:
+        """EPL at 23:00 UTC (inside 22:00-06:00 window) should be pushed to 06:00."""
+        schedule_calls: list[dict] = []
+
+        async def track_schedule(**kwargs: object) -> None:
+            schedule_calls.append(dict(kwargs))
+
+        # Set now to 19:00 UTC; 4h active tier -> wake at 23:00 UTC, inside EPL window (22-06)
+        fake_now = datetime(2026, 4, 18, 19, 0, tzinfo=UTC)
+        next_ko = fake_now + timedelta(hours=10)
+
+        with (
+            patch("odds_lambda.jobs.agent_run.get_next_kickoff", new_callable=AsyncMock) as mk,
+            patch("odds_lambda.jobs.agent_run.self_schedule", side_effect=track_schedule),
+            patch(
+                "odds_lambda.jobs.agent_run._run_claude_agent",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch(
+                "odds_lambda.jobs.agent_run._check_agent_requested_wakeup",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("odds_core.config.get_settings"),
+            patch("odds_lambda.jobs.agent_run.datetime") as mock_dt,
+        ):
+            mock_dt.now.return_value = fake_now
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            mk.return_value = next_ko
+            await main(JobContext(sport="soccer_epl"))
+
+        assert len(schedule_calls) == 1
+        scheduled_time = schedule_calls[0]["next_time"]
+        # Should be pushed to 06:00 UTC next day
+        assert scheduled_time.hour == 6
+
+    def test_overnight_windows_has_no_default(self) -> None:
+        """OVERNIGHT_WINDOWS should be an explicit dict with no fallback."""
+        assert isinstance(OVERNIGHT_WINDOWS, dict)
+        assert "soccer_epl" in OVERNIGHT_WINDOWS
+        assert "baseball_mlb" in OVERNIGHT_WINDOWS

--- a/tests/unit/test_fetch_oddsportal.py
+++ b/tests/unit/test_fetch_oddsportal.py
@@ -4,54 +4,54 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from odds_lambda.jobs.fetch_oddsportal import _apply_overnight_skip
+from odds_lambda.scheduling.helpers import apply_overnight_skip
 
 
 class TestApplyOvernightSkip:
     def test_epl_defaults_during_day(self) -> None:
         dt = datetime(2026, 4, 13, 14, 0, tzinfo=UTC)
-        assert _apply_overnight_skip(dt) == dt
+        assert apply_overnight_skip(dt) == dt
 
     def test_epl_defaults_late_night(self) -> None:
         dt = datetime(2026, 4, 13, 23, 0, tzinfo=UTC)
-        result = _apply_overnight_skip(dt)
+        result = apply_overnight_skip(dt)
         assert result == datetime(2026, 4, 14, 6, 0, tzinfo=UTC)
 
     def test_epl_defaults_early_morning(self) -> None:
         dt = datetime(2026, 4, 13, 3, 0, tzinfo=UTC)
-        result = _apply_overnight_skip(dt)
+        result = apply_overnight_skip(dt)
         assert result == datetime(2026, 4, 13, 6, 0, tzinfo=UTC)
 
     def test_epl_defaults_boundary_start(self) -> None:
         dt = datetime(2026, 4, 13, 22, 0, tzinfo=UTC)
-        result = _apply_overnight_skip(dt)
+        result = apply_overnight_skip(dt)
         assert result == datetime(2026, 4, 14, 6, 0, tzinfo=UTC)
 
     def test_epl_defaults_boundary_resume(self) -> None:
         dt = datetime(2026, 4, 13, 6, 0, tzinfo=UTC)
-        assert _apply_overnight_skip(dt) == dt
+        assert apply_overnight_skip(dt) == dt
 
     def test_mlb_hours_during_games(self) -> None:
         dt = datetime(2026, 6, 15, 23, 0, tzinfo=UTC)
-        result = _apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
+        result = apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
         assert result == dt
 
     def test_mlb_hours_overnight(self) -> None:
         dt = datetime(2026, 6, 16, 7, 0, tzinfo=UTC)
-        result = _apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
+        result = apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
         assert result == datetime(2026, 6, 16, 14, 0, tzinfo=UTC)
 
     def test_mlb_hours_boundary_start(self) -> None:
         dt = datetime(2026, 6, 16, 5, 0, tzinfo=UTC)
-        result = _apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
+        result = apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
         assert result == datetime(2026, 6, 16, 14, 0, tzinfo=UTC)
 
     def test_mlb_hours_boundary_resume(self) -> None:
         dt = datetime(2026, 6, 16, 14, 0, tzinfo=UTC)
-        result = _apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
+        result = apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
         assert result == dt
 
     def test_mlb_hours_before_overnight(self) -> None:
         dt = datetime(2026, 6, 16, 4, 30, tzinfo=UTC)
-        result = _apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
+        result = apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
         assert result == dt

--- a/tests/unit/test_fetch_oddsportal_scheduling.py
+++ b/tests/unit/test_fetch_oddsportal_scheduling.py
@@ -93,13 +93,13 @@ class TestProximityScheduling:
         with (
             patch("odds_lambda.jobs.fetch_oddsportal.ingest_league", side_effect=fake_ingest),
             patch(
-                "odds_lambda.jobs.fetch_oddsportal.get_scheduler_backend",
+                "odds_lambda.scheduling.helpers.get_scheduler_backend",
                 return_value=mock_backend,
             ),
             patch("odds_core.config.get_settings") as mock_settings,
             patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
             patch(
-                "odds_lambda.jobs.fetch_oddsportal._get_next_kickoff",
+                "odds_lambda.jobs.fetch_oddsportal.get_next_kickoff",
                 new_callable=AsyncMock,
                 return_value=None,
             ),
@@ -123,13 +123,13 @@ class TestProximityScheduling:
                 "odds_lambda.jobs.fetch_oddsportal.ingest_league", new_callable=AsyncMock
             ) as mock_ingest,
             patch(
-                "odds_lambda.jobs.fetch_oddsportal.get_scheduler_backend",
+                "odds_lambda.scheduling.helpers.get_scheduler_backend",
                 return_value=mock_backend,
             ),
             patch("odds_core.config.get_settings") as mock_settings,
             patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
             patch(
-                "odds_lambda.jobs.fetch_oddsportal._get_next_kickoff",
+                "odds_lambda.jobs.fetch_oddsportal.get_next_kickoff",
                 new_callable=AsyncMock,
                 return_value=None,
             ),
@@ -162,14 +162,14 @@ class TestProximityScheduling:
                 "odds_lambda.jobs.fetch_oddsportal.ingest_league", new_callable=AsyncMock
             ) as mock_ingest,
             patch(
-                "odds_lambda.jobs.fetch_oddsportal.get_scheduler_backend",
+                "odds_lambda.scheduling.helpers.get_scheduler_backend",
                 return_value=mock_backend,
             ),
             patch("odds_core.config.get_settings") as mock_settings,
             patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
             patch("odds_core.alerts.send_job_warning", new_callable=AsyncMock),
             patch(
-                "odds_lambda.jobs.fetch_oddsportal._get_next_kickoff",
+                "odds_lambda.jobs.fetch_oddsportal.get_next_kickoff",
                 new_callable=AsyncMock,
                 return_value=None,
             ),
@@ -197,14 +197,14 @@ class TestProximityScheduling:
                 side_effect=Exception("simulated timeout"),
             ),
             patch(
-                "odds_lambda.jobs.fetch_oddsportal.get_scheduler_backend",
+                "odds_lambda.scheduling.helpers.get_scheduler_backend",
                 return_value=mock_backend,
             ),
             patch("odds_core.config.get_settings") as mock_settings,
             patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
             patch("odds_core.alerts.send_job_warning", new_callable=AsyncMock),
             patch(
-                "odds_lambda.jobs.fetch_oddsportal._get_next_kickoff",
+                "odds_lambda.jobs.fetch_oddsportal.get_next_kickoff",
                 new_callable=AsyncMock,
                 return_value=None,
             ),
@@ -226,18 +226,18 @@ class TestProximityScheduling:
                 "odds_lambda.jobs.fetch_oddsportal.ingest_league", new_callable=AsyncMock
             ) as mock_ingest,
             patch(
-                "odds_lambda.jobs.fetch_oddsportal.get_scheduler_backend",
+                "odds_lambda.scheduling.helpers.get_scheduler_backend",
                 return_value=mock_backend,
             ),
             patch("odds_core.config.get_settings") as mock_settings,
             patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
             patch(
-                "odds_lambda.jobs.fetch_oddsportal._get_next_kickoff",
+                "odds_lambda.jobs.fetch_oddsportal.get_next_kickoff",
                 new_callable=AsyncMock,
                 side_effect=Exception("DB connection refused"),
             ),
             patch(
-                "odds_lambda.jobs.fetch_oddsportal._apply_overnight_skip",
+                "odds_lambda.jobs.fetch_oddsportal.apply_overnight_skip",
                 side_effect=lambda t, **kw: t,
             ),
         ):
@@ -270,18 +270,18 @@ class TestProximityScheduling:
                 "odds_lambda.jobs.fetch_oddsportal.ingest_league", new_callable=AsyncMock
             ) as mock_ingest,
             patch(
-                "odds_lambda.jobs.fetch_oddsportal.get_scheduler_backend",
+                "odds_lambda.scheduling.helpers.get_scheduler_backend",
                 return_value=mock_backend,
             ),
             patch("odds_core.config.get_settings") as mock_settings,
             patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
             patch(
-                "odds_lambda.jobs.fetch_oddsportal._get_next_kickoff",
+                "odds_lambda.jobs.fetch_oddsportal.get_next_kickoff",
                 new_callable=AsyncMock,
                 return_value=kickoff,
             ),
             patch(
-                "odds_lambda.jobs.fetch_oddsportal._apply_overnight_skip",
+                "odds_lambda.jobs.fetch_oddsportal.apply_overnight_skip",
                 side_effect=lambda t, **kw: t,
             ),
         ):
@@ -314,18 +314,18 @@ class TestProximityScheduling:
                 "odds_lambda.jobs.fetch_oddsportal.ingest_league", new_callable=AsyncMock
             ) as mock_ingest,
             patch(
-                "odds_lambda.jobs.fetch_oddsportal.get_scheduler_backend",
+                "odds_lambda.scheduling.helpers.get_scheduler_backend",
                 return_value=mock_backend,
             ),
             patch("odds_core.config.get_settings") as mock_settings,
             patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
             patch(
-                "odds_lambda.jobs.fetch_oddsportal._get_next_kickoff",
+                "odds_lambda.jobs.fetch_oddsportal.get_next_kickoff",
                 new_callable=AsyncMock,
                 return_value=kickoff,
             ),
             patch(
-                "odds_lambda.jobs.fetch_oddsportal._apply_overnight_skip",
+                "odds_lambda.jobs.fetch_oddsportal.apply_overnight_skip",
                 side_effect=lambda t, **kw: t,
             ),
         ):

--- a/tests/unit/test_scheduling_helpers.py
+++ b/tests/unit/test_scheduling_helpers.py
@@ -1,0 +1,137 @@
+"""Tests for shared scheduling helpers."""
+
+from __future__ import annotations
+
+import inspect
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from odds_lambda.scheduling.helpers import apply_overnight_skip, get_next_kickoff, self_schedule
+
+
+class TestApplyOvernightSkip:
+    """Tests for the overnight skip helper (wrap-midnight, same-day, no-op)."""
+
+    def test_daytime_unchanged(self) -> None:
+        dt = datetime(2026, 4, 15, 14, 0, tzinfo=UTC)
+        assert apply_overnight_skip(dt) == dt
+
+    def test_late_night_pushed_to_next_morning(self) -> None:
+        dt = datetime(2026, 4, 15, 23, 30, tzinfo=UTC)
+        expected = datetime(2026, 4, 16, 6, 0, tzinfo=UTC)
+        assert apply_overnight_skip(dt) == expected
+
+    def test_early_morning_pushed_to_same_day_resume(self) -> None:
+        dt = datetime(2026, 4, 15, 3, 0, tzinfo=UTC)
+        expected = datetime(2026, 4, 15, 6, 0, tzinfo=UTC)
+        assert apply_overnight_skip(dt) == expected
+
+    def test_exactly_at_overnight_start_pushed(self) -> None:
+        dt = datetime(2026, 4, 15, 22, 0, tzinfo=UTC)
+        expected = datetime(2026, 4, 16, 6, 0, tzinfo=UTC)
+        assert apply_overnight_skip(dt) == expected
+
+    def test_exactly_at_resume_not_pushed(self) -> None:
+        dt = datetime(2026, 4, 15, 6, 0, tzinfo=UTC)
+        assert apply_overnight_skip(dt) == dt
+
+    def test_wrap_midnight_window_defaults(self) -> None:
+        dt = datetime(2026, 4, 15, 0, 30, tzinfo=UTC)
+        expected = datetime(2026, 4, 15, 6, 0, tzinfo=UTC)
+        assert apply_overnight_skip(dt) == expected
+
+    def test_same_day_window_inside(self) -> None:
+        dt = datetime(2026, 6, 16, 7, 0, tzinfo=UTC)
+        result = apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
+        assert result == datetime(2026, 6, 16, 14, 0, tzinfo=UTC)
+
+    def test_same_day_window_outside_before(self) -> None:
+        dt = datetime(2026, 6, 16, 4, 30, tzinfo=UTC)
+        result = apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
+        assert result == dt
+
+    def test_same_day_window_outside_after(self) -> None:
+        dt = datetime(2026, 6, 16, 23, 0, tzinfo=UTC)
+        result = apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
+        assert result == dt
+
+    def test_same_day_window_boundary_start(self) -> None:
+        dt = datetime(2026, 6, 16, 5, 0, tzinfo=UTC)
+        result = apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
+        assert result == datetime(2026, 6, 16, 14, 0, tzinfo=UTC)
+
+    def test_same_day_window_boundary_resume(self) -> None:
+        dt = datetime(2026, 6, 16, 14, 0, tzinfo=UTC)
+        result = apply_overnight_skip(dt, overnight_start_utc=5, overnight_resume_utc=14)
+        assert result == dt
+
+
+class TestGetNextKickoff:
+    """Tests for the get_next_kickoff function signature and contract."""
+
+    def test_is_async(self) -> None:
+        assert inspect.iscoroutinefunction(get_next_kickoff)
+
+    def test_accepts_sport_key_param(self) -> None:
+        sig = inspect.signature(get_next_kickoff)
+        assert "sport_key" in sig.parameters
+
+
+class TestSelfSchedule:
+    """Tests for the self_schedule function."""
+
+    def test_is_async(self) -> None:
+        assert inspect.iscoroutinefunction(self_schedule)
+
+    def test_signature_has_required_params(self) -> None:
+        sig = inspect.signature(self_schedule)
+        params = sig.parameters
+        assert "job_name" in params
+        assert "next_time" in params
+        assert "dry_run" in params
+        assert "sport" in params
+        assert "interval_hours" in params
+        assert "reason" in params
+
+    @pytest.mark.asyncio
+    async def test_calls_scheduler_backend(self) -> None:
+        mock_backend = MagicMock()
+        mock_backend.schedule_next_execution = AsyncMock()
+        mock_backend.get_backend_name.return_value = "test"
+
+        with patch(
+            "odds_lambda.scheduling.helpers.get_scheduler_backend",
+            return_value=mock_backend,
+        ):
+            await self_schedule(
+                job_name="test-job",
+                next_time=datetime.now(UTC) + timedelta(hours=1),
+                dry_run=True,
+                sport="soccer_epl",
+                reason="test reason",
+            )
+
+        mock_backend.schedule_next_execution.assert_called_once()
+        call_kwargs = mock_backend.schedule_next_execution.call_args.kwargs
+        assert call_kwargs["job_name"] == "test-job"
+        assert call_kwargs["payload"] == {"sport": "soccer_epl"}
+
+    @pytest.mark.asyncio
+    async def test_no_sport_sends_none_payload(self) -> None:
+        mock_backend = MagicMock()
+        mock_backend.schedule_next_execution = AsyncMock()
+        mock_backend.get_backend_name.return_value = "test"
+
+        with patch(
+            "odds_lambda.scheduling.helpers.get_scheduler_backend",
+            return_value=mock_backend,
+        ):
+            await self_schedule(
+                job_name="test-job",
+                next_time=datetime.now(UTC) + timedelta(hours=1),
+                dry_run=False,
+            )
+
+        call_kwargs = mock_backend.schedule_next_execution.call_args.kwargs
+        assert call_kwargs["payload"] is None


### PR DESCRIPTION
## Summary
- New `agent_run.py` job module that self-schedules through the existing scheduler, waking the Claude Code agent at appropriate times relative to fixture kickoffs
- Fixture-proximity wake interval tiers: 24h (>48h out), 12h (24-48h), 4h (6-24h), 1h (1.5-6h), 3h post-match (<1.5h), 12h (no fixtures)
- Pre-schedules before running agent subprocess (survives crashes/timeouts)
- Spawns `claude -p "/agent {sport}"` via `asyncio.create_subprocess_exec` with 15-minute timeout covering both stdout reading and process wait
- Checks `agent_wakeups` table for agent-requested wake-up overrides (consumed after use, guards against past times)
- Overnight skip pushes 22:00-06:00 UTC wake-ups to 06:00
- Extracts shared scheduling helpers (`get_next_kickoff`, `apply_overnight_skip`, `self_schedule`) from `fetch_oddsportal.py` into `odds_lambda/scheduling/helpers.py` — both jobs now use the shared versions
- Adds `project_root` config setting to `Settings` (replaces hardcoded path)
- 53 tests across agent_run, fetch_oddsportal, fetch_oddsportal_scheduling, and scheduling_helpers

## Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)