### PR TITLE
Configurable scheduler bootstrap, remove Odds API default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ SCHEDULER_BACKEND=local
 # How many days ahead to check for games (default: 7)
 SCHEDULER_LOOKAHEAD_DAYS=7
 
-# Jobs to bootstrap on scheduler start (comma-separated, default: all registered jobs)
+# Jobs to bootstrap on scheduler start (JSON list, default: ["agent-run"])
 # SCHEDULER_BOOTSTRAP_JOBS=fetch-odds,fetch-oddsportal,agent-run
 
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ SCHEDULER_BACKEND=local
 # How many days ahead to check for games (default: 7)
 SCHEDULER_LOOKAHEAD_DAYS=7
 
+# Jobs to bootstrap on scheduler start (comma-separated, default: all registered jobs)
+# SCHEDULER_BOOTSTRAP_JOBS=fetch-odds,fetch-oddsportal,agent-run
+
 # =============================================================================
 # AWS CONFIGURATION (only needed if SCHEDULER_BACKEND=aws)
 # =============================================================================

--- a/packages/odds-cli/odds_cli/commands/scheduler.py
+++ b/packages/odds-cli/odds_cli/commands/scheduler.py
@@ -56,10 +56,9 @@ def start_local():
     async def run_scheduler():
         """Run scheduler using async context manager."""
         from odds_lambda.scheduling.jobs import (
-            _JOB_BOOTSTRAP_MAP,
-            _PER_SPORT_JOBS,
             JobContext,
             get_bootstrap_function,
+            is_per_sport_job,
             make_compound_job_name,
         )
 
@@ -67,26 +66,18 @@ def start_local():
 
         for job_name in app_settings.scheduler.bootstrap_jobs:
             bootstrap_fn = get_bootstrap_function(job_name)
-            has_custom_bootstrap = job_name in _JOB_BOOTSTRAP_MAP
-            is_per_sport = job_name in _PER_SPORT_JOBS
 
-            if is_per_sport:
+            if is_per_sport_job(job_name):
                 for sport_key in app_settings.data_collection.sports:
                     compound = make_compound_job_name(job_name, sport_key)
                     try:
-                        if has_custom_bootstrap:
-                            await bootstrap_fn(sport_key)
-                        else:
-                            await bootstrap_fn(JobContext(sport=sport_key))
+                        await bootstrap_fn(JobContext(sport=sport_key))
                         console.print(f"[green]  {compound} bootstrapped[/green]")
                     except Exception as e:
                         console.print(f"[yellow]  {compound} bootstrap failed: {e}[/yellow]")
             else:
                 try:
-                    if has_custom_bootstrap:
-                        await bootstrap_fn()
-                    else:
-                        await bootstrap_fn(JobContext())
+                    await bootstrap_fn(JobContext())
                     console.print(f"[green]  {job_name} bootstrapped[/green]")
                 except Exception as e:
                     console.print(f"[yellow]  {job_name} bootstrap failed: {e}[/yellow]")

--- a/packages/odds-cli/odds_cli/commands/scheduler.py
+++ b/packages/odds-cli/odds_cli/commands/scheduler.py
@@ -55,32 +55,41 @@ def start_local():
 
     async def run_scheduler():
         """Run scheduler using async context manager."""
-        # Bootstrap by running initial fetch to start self-scheduling
-        console.print("[green]Running initial fetch to bootstrap scheduler...[/green]")
+        from odds_lambda.scheduling.jobs import (
+            _JOB_BOOTSTRAP_MAP,
+            _PER_SPORT_JOBS,
+            JobContext,
+            get_bootstrap_function,
+            make_compound_job_name,
+        )
 
-        from odds_lambda.scheduling.jobs import JobContext
+        console.print("[green]Bootstrapping jobs...[/green]")
 
-        try:
-            from odds_lambda.jobs import fetch_odds
+        for job_name in app_settings.scheduler.bootstrap_jobs:
+            bootstrap_fn = get_bootstrap_function(job_name)
+            has_custom_bootstrap = job_name in _JOB_BOOTSTRAP_MAP
+            is_per_sport = job_name in _PER_SPORT_JOBS
 
-            await fetch_odds.main(JobContext())
-            console.print("[green]  fetch-odds bootstrapped[/green]")
-        except Exception as e:
-            console.print(f"[bold red]  fetch-odds bootstrap failed:[/bold red] {e}")
-            console.print(
-                "[yellow]Scheduler will still run, but jobs may not be scheduled[/yellow]"
-            )
-
-        # Bootstrap agent jobs for each configured sport
-        from odds_lambda.jobs import agent_run
-
-        for sport_key in app_settings.data_collection.sports:
-            suffix = sport_key.split("_")[-1]
-            try:
-                await agent_run.schedule_next(sport_key)
-                console.print(f"[green]  agent-run-{suffix} bootstrapped[/green]")
-            except Exception as e:
-                console.print(f"[yellow]  agent-run-{suffix} bootstrap failed: {e}[/yellow]")
+            if is_per_sport:
+                for sport_key in app_settings.data_collection.sports:
+                    compound = make_compound_job_name(job_name, sport_key)
+                    try:
+                        if has_custom_bootstrap:
+                            await bootstrap_fn(sport_key)
+                        else:
+                            await bootstrap_fn(JobContext(sport=sport_key))
+                        console.print(f"[green]  {compound} bootstrapped[/green]")
+                    except Exception as e:
+                        console.print(f"[yellow]  {compound} bootstrap failed: {e}[/yellow]")
+            else:
+                try:
+                    if has_custom_bootstrap:
+                        await bootstrap_fn()
+                    else:
+                        await bootstrap_fn(JobContext())
+                    console.print(f"[green]  {job_name} bootstrapped[/green]")
+                except Exception as e:
+                    console.print(f"[yellow]  {job_name} bootstrap failed: {e}[/yellow]")
 
         console.print()
 

--- a/packages/odds-core/odds_core/config.py
+++ b/packages/odds-core/odds_core/config.py
@@ -42,7 +42,7 @@ class DataCollectionConfig(BaseSettings):
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
-    sports: list[str] = Field(default=["basketball_nba"], description="Sports to track")
+    sports: list[str] = Field(default=["soccer_epl", "baseball_mlb"], description="Sports to track")
     bookmakers: list[str] = Field(
         default=[
             "pinnacle",
@@ -80,6 +80,10 @@ class SchedulerConfig(BaseSettings):
     lookahead_days: int = Field(
         default=7,
         description="How many days ahead to check for games when scheduling",
+    )
+    bootstrap_jobs: list[str] = Field(
+        default=["agent-run"],
+        description="Jobs to bootstrap when starting the local scheduler",
     )
 
 

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -180,12 +180,23 @@ def get_job_function(job_name: str) -> Callable[[JobContext], Awaitable[None]]:
     return fn
 
 
-def get_bootstrap_function(job_name: str) -> Callable[..., Awaitable[None]]:
+def is_per_sport_job(job_name: str) -> bool:
+    """Check whether a job accepts a sport parameter."""
+    return job_name in _PER_SPORT_JOBS
+
+
+def has_custom_bootstrap(job_name: str) -> bool:
+    """Check whether a job has a custom bootstrap entry point."""
+    return job_name in _JOB_BOOTSTRAP_MAP
+
+
+def get_bootstrap_function(job_name: str) -> Callable[[JobContext], Awaitable[None]]:
     """Get the bootstrap entry point for a job.
 
-    Jobs with an entry in ``_JOB_BOOTSTRAP_MAP`` use that function for
-    bootstrap (e.g. ``agent-run`` uses ``schedule_next`` instead of ``main``).
-    All other jobs fall back to their regular ``main(JobContext)`` function.
+    Returns a callable with the same ``(JobContext) -> Awaitable[None]``
+    signature as regular job functions. Jobs with a custom bootstrap
+    (e.g. ``agent-run`` uses ``schedule_next(sport)`` instead of ``main``)
+    are wrapped so the caller doesn't need to know about the difference.
 
     Raises:
         KeyError: If job name not found in registry
@@ -193,7 +204,24 @@ def get_bootstrap_function(job_name: str) -> Callable[..., Awaitable[None]]:
     if job_name in _JOB_BOOTSTRAP_MAP:
         module_path, func_name = _JOB_BOOTSTRAP_MAP[job_name]
         module = import_module(module_path)
-        return getattr(module, func_name)
+        raw_fn = getattr(module, func_name)
+
+        # Wrap custom bootstrap functions to accept JobContext uniformly.
+        # Per-sport custom bootstraps expect (sport: str); global ones expect ().
+        if job_name in _PER_SPORT_JOBS:
+
+            async def _per_sport_wrapper(ctx: JobContext) -> None:
+                assert ctx.sport, f"Job '{job_name}' requires a sport in JobContext"
+                await raw_fn(ctx.sport)
+
+            return _per_sport_wrapper
+        else:
+
+            async def _global_wrapper(ctx: JobContext) -> None:
+                await raw_fn()
+
+            return _global_wrapper
+
     return get_job_function(job_name)
 
 

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -67,6 +67,15 @@ _JOB_MODULE_MAP: dict[str, tuple[str, str]] = {
     "agent-run": ("odds_lambda.jobs.agent_run", "main"),
 }
 
+# Bootstrap entry-point overrides: jobs listed here use a different function
+# for bootstrap (scheduler start) than for normal execution. The function
+# receives a single ``sport: str`` argument for per-sport jobs, or no args
+# for global jobs.  Jobs not listed here use their regular ``main(JobContext)``
+# for bootstrap.
+_JOB_BOOTSTRAP_MAP: dict[str, tuple[str, str]] = {
+    "agent-run": ("odds_lambda.jobs.agent_run", "schedule_next"),
+}
+
 # Maps sport suffix to sport_key for per-sport job routing.
 # e.g. "fetch-odds-epl" resolves to ("fetch-odds", "soccer_epl")
 _SPORT_SUFFIX_MAP: dict[str, str] = {
@@ -169,6 +178,23 @@ def get_job_function(job_name: str) -> Callable[[JobContext], Awaitable[None]]:
     fn = getattr(module, func_name)
     _loaded_jobs[job_name] = fn
     return fn
+
+
+def get_bootstrap_function(job_name: str) -> Callable[..., Awaitable[None]]:
+    """Get the bootstrap entry point for a job.
+
+    Jobs with an entry in ``_JOB_BOOTSTRAP_MAP`` use that function for
+    bootstrap (e.g. ``agent-run`` uses ``schedule_next`` instead of ``main``).
+    All other jobs fall back to their regular ``main(JobContext)`` function.
+
+    Raises:
+        KeyError: If job name not found in registry
+    """
+    if job_name in _JOB_BOOTSTRAP_MAP:
+        module_path, func_name = _JOB_BOOTSTRAP_MAP[job_name]
+        module = import_module(module_path)
+        return getattr(module, func_name)
+    return get_job_function(job_name)
 
 
 def list_available_jobs() -> list[str]:

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -185,11 +185,6 @@ def is_per_sport_job(job_name: str) -> bool:
     return job_name in _PER_SPORT_JOBS
 
 
-def has_custom_bootstrap(job_name: str) -> bool:
-    """Check whether a job has a custom bootstrap entry point."""
-    return job_name in _JOB_BOOTSTRAP_MAP
-
-
 def get_bootstrap_function(job_name: str) -> Callable[[JobContext], Awaitable[None]]:
     """Get the bootstrap entry point for a job.
 

--- a/tests/integration/test_scheduler_e2e.py
+++ b/tests/integration/test_scheduler_e2e.py
@@ -173,8 +173,8 @@ async def test_scheduler_end_to_end(
             # Track execution
             execution_happened["fetch_odds"] = True
 
-            # Execute the real job
-            await original_main(JobContext())
+            # Execute the real job with explicit sport to avoid multi-sport default
+            await original_main(JobContext(sport="basketball_nba"))
 
     # Start the scheduler backend
     async with LocalSchedulerBackend(dry_run=False) as backend:
@@ -320,8 +320,8 @@ async def test_job_self_scheduling_chain(test_session, mock_session_factory):
             mock_backend.get_backend_name = lambda: "mock_backend"
             mock_backend_getter.return_value = mock_backend
 
-            # Execute job
-            await fetch_odds.main(JobContext())
+            # Execute job with explicit sport to avoid multi-sport default
+            await fetch_odds.main(JobContext(sport="basketball_nba"))
 
         # Verify self-scheduling
         assert len(scheduled_calls) == 1, f"Expected 1 schedule call for {tier_name}"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -29,13 +29,14 @@ class TestSettings:
             assert settings.api.quota == 500
             assert settings.api.keys is None
             assert settings.database.pool_size == 5
-            assert settings.data_collection.sports == ["basketball_nba"]
+            assert settings.data_collection.sports == ["soccer_epl", "baseball_mlb"]
             assert len(settings.data_collection.bookmakers) == 8
             assert settings.data_collection.markets == ["h2h", "spreads", "totals"]
             assert settings.data_collection.regions == ["us"]
             assert settings.scheduler.backend == "local"
             assert settings.scheduler.dry_run is False
             assert settings.scheduler.lookahead_days == 7
+            assert settings.scheduler.bootstrap_jobs == ["agent-run"]
             assert settings.data_quality.enable_validation is True
             assert settings.data_quality.reject_invalid_odds is False
             assert settings.alerts.alert_enabled is False

--- a/tests/unit/test_job_routing.py
+++ b/tests/unit/test_job_routing.py
@@ -1,6 +1,11 @@
-"""Tests for job name resolution and compound name construction."""
+"""Tests for job name resolution, compound name construction, and bootstrap functions."""
 
+from unittest.mock import AsyncMock, patch
+
+import pytest
 from odds_lambda.scheduling.jobs import (
+    JobContext,
+    get_bootstrap_function,
     make_compound_job_name,
     resolve_job_name,
     sport_key_to_suffix,
@@ -138,3 +143,48 @@ class TestMakeCompoundJobName:
         base, sport = resolve_job_name(compound)
         assert base == "agent-run"
         assert sport == "baseball_mlb"
+
+
+class TestGetBootstrapFunction:
+    """Tests for get_bootstrap_function()."""
+
+    def test_agent_run_returns_wrapper_calling_schedule_next(self) -> None:
+        mock_schedule_next = AsyncMock()
+        with patch("odds_lambda.scheduling.jobs.import_module") as mock_import:
+            mock_module = mock_import.return_value
+            mock_module.schedule_next = mock_schedule_next
+
+            # Clear cached jobs to force fresh import
+            from odds_lambda.scheduling.jobs import _loaded_jobs
+
+            _loaded_jobs.pop("agent-run", None)
+
+            fn = get_bootstrap_function("agent-run")
+
+        # Should accept JobContext and forward sport to schedule_next
+        import asyncio
+
+        asyncio.run(fn(JobContext(sport="soccer_epl")))
+        mock_schedule_next.assert_called_once_with("soccer_epl")
+
+    def test_regular_job_falls_back_to_main(self) -> None:
+        mock_main = AsyncMock()
+        with patch("odds_lambda.scheduling.jobs.import_module") as mock_import:
+            mock_module = mock_import.return_value
+            mock_module.main = mock_main
+
+            from odds_lambda.scheduling.jobs import _loaded_jobs
+
+            _loaded_jobs.pop("fetch-odds", None)
+
+            fn = get_bootstrap_function("fetch-odds")
+
+        import asyncio
+
+        ctx = JobContext(sport="soccer_epl")
+        asyncio.run(fn(ctx))
+        mock_main.assert_called_once_with(ctx)
+
+    def test_unknown_job_raises_key_error(self) -> None:
+        with pytest.raises(KeyError, match="Unknown job"):
+            get_bootstrap_function("nonexistent-job")


### PR DESCRIPTION
## Summary
- Add `SchedulerConfig.bootstrap_jobs` to control which jobs run on `odds scheduler start` (default: `["agent-run"]`)
- Change `DataCollectionConfig.sports` default from `["basketball_nba"]` to `["soccer_epl", "baseball_mlb"]`
- Remove hardcoded `fetch-odds` bootstrap — scheduler no longer calls The Odds API on startup
- Generic bootstrap loop iterates configured jobs, running per-sport where applicable; failures don't block the scheduler
- Add `_JOB_BOOTSTRAP_MAP` with public helpers (`get_bootstrap_function`, `is_per_sport_job`) so custom entry points (e.g. `schedule_next` for agent-run) are encapsulated in the job registry
- Fix e2e tests to pass explicit sport, making them independent of default sports config

## Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)