### PR TITLE
Per-run agent JSONL trace + dev-mode CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,9 @@ logs/
 plans/
 *.log
 
+# Local dev helpers
+scripts/snapshot_to_dev.sh
+
 # OS
 .DS_Store
 Thumbs.db

--- a/packages/odds-cli/odds_cli/commands/agent.py
+++ b/packages/odds-cli/odds_cli/commands/agent.py
@@ -1,0 +1,49 @@
+"""Run the sport agent subprocess outside the scheduler wrapper."""
+
+from __future__ import annotations
+
+import asyncio
+
+import typer
+from rich.console import Console
+
+from odds_cli.db_override import override_database_url
+
+app = typer.Typer()
+console = Console()
+
+
+@app.command("run")
+def run(
+    sport: str = typer.Option(
+        ..., "--sport", "-s", help="Sport key (e.g. 'soccer_epl', 'baseball_mlb')"
+    ),
+    db: str = typer.Option(
+        "odds_test",
+        "--db",
+        help="Database name to run against. Swapped into DATABASE_URL.",
+    ),
+) -> None:
+    """Run the sport agent subprocess directly, bypassing the scheduler wrapper.
+
+    No pre-schedule, no agent_wakeups consumption, no reschedule — so repeated
+    runs don't disturb the scheduler. By default the agent runs against the
+    ``odds_test`` database (same host/credentials as the configured
+    DATABASE_URL, just a different dbname); refresh it from the source-of-truth
+    DB with ``scripts/snapshot_to_dev.sh`` before use.
+    """
+    override_database_url(db)
+
+    from odds_lambda.jobs.agent_run import _run_claude_agent
+
+    console.print(f"[bold blue]Running agent for {sport} against db={db}...[/bold blue]")
+    exit_code = asyncio.run(_run_claude_agent(sport))
+
+    if exit_code < 0:
+        console.print("[bold red]Agent timed out[/bold red]")
+        raise typer.Exit(1)
+    if exit_code != 0:
+        console.print(f"[yellow]Agent exited with code {exit_code}[/yellow]")
+        raise typer.Exit(exit_code)
+
+    console.print("[green]Agent finished[/green]")

--- a/packages/odds-cli/odds_cli/commands/scheduler.py
+++ b/packages/odds-cli/odds_cli/commands/scheduler.py
@@ -30,7 +30,7 @@ def start_local(
             "driving manually)."
         ),
     ),
-):
+) -> None:
     """
     Start local scheduler for testing (APScheduler backend).
 

--- a/packages/odds-cli/odds_cli/commands/scheduler.py
+++ b/packages/odds-cli/odds_cli/commands/scheduler.py
@@ -14,7 +14,23 @@ logger = structlog.get_logger()
 
 
 @app.command("start")
-def start_local():
+def start_local(
+    db: str | None = typer.Option(
+        None,
+        "--db",
+        help="Override DATABASE_URL's dbname (e.g. 'odds_test' for a sandbox scheduler).",
+    ),
+    bootstrap: bool | None = typer.Option(
+        None,
+        "--bootstrap/--no-bootstrap",
+        help=(
+            "Bootstrap scheduled jobs on start. Defaults to on when --db is unset "
+            "(prod-like) and off when --db is set (sidecar mode — prevents a "
+            "concurrent agent-run from clashing with an `odds agent run` you're "
+            "driving manually)."
+        ),
+    ),
+):
     """
     Start local scheduler for testing (APScheduler backend).
 
@@ -26,12 +42,25 @@ def start_local():
     - Database running and accessible
 
     Usage:
-        odds scheduler start
+        odds scheduler start                          # prod-like (bootstrap on)
+        odds scheduler start --db odds_test           # dev sidecar (bootstrap off)
+        odds scheduler start --db odds_test --bootstrap   # dev full-loop smoke test
 
     Press Ctrl+C to stop the scheduler.
     """
+    if db is not None:
+        from odds_cli.db_override import override_database_url
+
+        override_database_url(db)
+
+    effective_bootstrap = (db is None) if bootstrap is None else bootstrap
+
     console.print("[bold blue]Starting local scheduler...[/bold blue]")
-    console.print("[dim]Backend: APScheduler (local testing mode)[/dim]\n")
+    console.print("[dim]Backend: APScheduler (local testing mode)[/dim]")
+    if db is not None:
+        console.print(f"[dim]Database override: {db}[/dim]")
+    console.print(f"[dim]Bootstrap: {'enabled' if effective_bootstrap else 'disabled'}[/dim]")
+    console.print()
 
     app_settings = get_settings()
 
@@ -62,11 +91,18 @@ def start_local():
             make_compound_job_name,
         )
 
+        bootstrap_jobs = app_settings.scheduler.bootstrap_jobs if effective_bootstrap else []
+
         # Start scheduler first so bootstrap jobs can schedule via the backend
         async with LocalSchedulerBackend() as _backend:
-            console.print("[green]Bootstrapping jobs...[/green]")
+            if bootstrap_jobs:
+                console.print("[green]Bootstrapping jobs...[/green]")
+            else:
+                console.print(
+                    "[dim]Skipping bootstrap — scheduler will idle until jobs arrive[/dim]"
+                )
 
-            for job_name in app_settings.scheduler.bootstrap_jobs:
+            for job_name in bootstrap_jobs:
                 bootstrap_fn = get_bootstrap_function(job_name)
 
                 if is_per_sport_job(job_name):

--- a/packages/odds-cli/odds_cli/db_override.py
+++ b/packages/odds-cli/odds_cli/db_override.py
@@ -7,7 +7,13 @@ from urllib.parse import urlsplit, urlunsplit
 
 
 def swap_dbname(url: str, new_db: str) -> str:
-    """Return ``url`` with its dbname component replaced by ``new_db``."""
+    """Return ``url`` with its dbname component replaced by ``new_db``.
+
+    Rejects dbnames containing ``/`` or ``?`` so an injected query string or
+    path separator can't smuggle extra URL components past the swap.
+    """
+    if "/" in new_db or "?" in new_db:
+        raise ValueError(f"invalid dbname: {new_db!r} (must not contain '/' or '?')")
     parts = urlsplit(url)
     return urlunsplit(parts._replace(path=f"/{new_db}"))
 

--- a/packages/odds-cli/odds_cli/db_override.py
+++ b/packages/odds-cli/odds_cli/db_override.py
@@ -1,0 +1,30 @@
+"""Shared helper for overriding the application's database from the CLI."""
+
+from __future__ import annotations
+
+import os
+from urllib.parse import urlsplit, urlunsplit
+
+
+def swap_dbname(url: str, new_db: str) -> str:
+    """Return ``url`` with its dbname component replaced by ``new_db``."""
+    parts = urlsplit(url)
+    return urlunsplit(parts._replace(path=f"/{new_db}"))
+
+
+def override_database_url(new_db: str) -> str:
+    """Swap the dbname in the current DATABASE_URL and reset the settings cache.
+
+    Reads the already-resolved DATABASE_URL via pydantic settings (honouring
+    ``.env``), replaces the dbname segment with ``new_db``, writes it back to
+    ``os.environ`` so subprocesses inherit it, and clears the cached Settings
+    so any later ``get_settings()`` call in this process re-reads the override.
+    Returns the new URL.
+    """
+    from odds_core.config import get_settings, reset_settings_cache
+
+    source = get_settings().database.url
+    new_url = swap_dbname(source, new_db)
+    os.environ["DATABASE_URL"] = new_url
+    reset_settings_cache()
+    return new_url

--- a/packages/odds-cli/odds_cli/main.py
+++ b/packages/odds-cli/odds_cli/main.py
@@ -6,6 +6,7 @@ from odds_core.logging_setup import configure_logging
 from rich.console import Console
 
 from odds_cli.commands import (
+    agent,
     backfill,
     backtest,
     copy_from_prod,
@@ -49,6 +50,7 @@ app.add_typer(pbpstats.app, name="pbpstats", help="PBPStats player season statis
 app.add_typer(scrape.app, name="scrape", help="Scrape odds from OddsPortal")
 app.add_typer(model.app, name="model", help="Model artifact management")
 app.add_typer(paper.app, name="paper", help="Paper trade management")
+app.add_typer(agent.app, name="agent", help="Run the sport agent subprocess directly")
 
 console = Console()
 

--- a/packages/odds-lambda/odds_lambda/jobs/agent_run.py
+++ b/packages/odds-lambda/odds_lambda/jobs/agent_run.py
@@ -16,8 +16,10 @@ Wake interval tiers:
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import UTC, datetime, timedelta
-from typing import NamedTuple
+from pathlib import Path
+from typing import Any, NamedTuple
 
 import structlog
 from odds_core.config import get_settings
@@ -44,6 +46,9 @@ OVERNIGHT_WINDOWS: dict[str, tuple[int, int]] = {
 
 # Agent subprocess limits
 AGENT_TIMEOUT_SECONDS = 15 * 60  # 15 minutes
+
+# Retain this many per-run JSONL logs per sport; older ones are pruned on write.
+AGENT_RUN_LOG_KEEP = 50
 
 # Horizon for "no fixtures" classification
 FIXTURE_HORIZON_DAYS = 7
@@ -72,16 +77,86 @@ def _compute_wake_interval(hours_until_ko: float | None) -> float:
     return TIER_LINEUP_HOURS
 
 
+def _preview_tool_input(d: dict[str, Any] | None, *, max_value_chars: int = 60) -> str | None:
+    """Return a compact ``key=value`` summary of tool input for live logging."""
+    if not d:
+        return None
+    parts: list[str] = []
+    for k, v in d.items():
+        s = str(v)
+        if len(s) > max_value_chars:
+            s = s[:max_value_chars] + "..."
+        parts.append(f"{k}={s}")
+    return " ".join(parts)
+
+
+def _prune_agent_run_logs(log_dir: Path, sport: str, keep: int) -> None:
+    """Delete all but the newest ``keep`` JSONL files for ``sport``."""
+    files = sorted(log_dir.glob(f"{sport}_*.jsonl"), reverse=True)
+    for stale in files[keep:]:
+        try:
+            stale.unlink()
+        except OSError as e:
+            logger.warning("agent_run_log_prune_failed", file=str(stale), error=str(e))
+
+
+def _log_stream_message(msg: dict[str, Any]) -> None:
+    """Emit a structlog event for notable stream-json message types.
+
+    Surfaces tool calls and the final result; other message types (assistant
+    text / thinking blocks, tool results, system init) are captured in the
+    per-run JSONL file but omitted from the main log to keep it readable.
+    """
+    msg_type = msg.get("type")
+    if msg_type == "assistant":
+        message = msg.get("message")
+        if not isinstance(message, dict):
+            return
+        for block in message.get("content") or []:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                logger.info(
+                    "agent_tool_use",
+                    tool=block.get("name"),
+                    input_preview=_preview_tool_input(block.get("input")),
+                )
+    elif msg_type == "result":
+        logger.info(
+            "agent_run_summary",
+            text=msg.get("result"),
+            num_turns=msg.get("num_turns"),
+            duration_ms=msg.get("duration_ms"),
+            cost_usd=msg.get("total_cost_usd"),
+        )
+
+
 async def _run_claude_agent(sport: str) -> int:
     """Spawn ``claude -p`` subprocess and return exit code.
 
-    Stdout is logged line-by-line at INFO level. Timeout after
-    ``AGENT_TIMEOUT_SECONDS``. Returns -1 on timeout.
+    Full stream-json trace is written to
+    ``logs/agent_runs/{sport}_<ts>.jsonl``; tool calls and the final result
+    are tee'd into the main structlog log for live visibility. Timeout after
+    ``AGENT_TIMEOUT_SECONDS``; returns -1 on timeout.
     """
-    cmd = ["claude", "-p", f"/agent {sport}", "--dangerously-skip-permissions"]
+    cmd = [
+        "claude",
+        "-p",
+        f"/agent {sport}",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--dangerously-skip-permissions",
+    ]
 
     settings = get_settings()
-    logger.info("agent_subprocess_starting", sport=sport, cmd=cmd)
+
+    log_dir = settings.project_root / "logs" / "agent_runs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    _prune_agent_run_logs(log_dir, sport, keep=AGENT_RUN_LOG_KEEP)
+
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    log_path = log_dir / f"{sport}_{timestamp}.jsonl"
+
+    logger.info("agent_subprocess_starting", sport=sport, cmd=cmd, log_file=str(log_path))
 
     proc = await asyncio.create_subprocess_exec(
         *cmd,
@@ -90,23 +165,36 @@ async def _run_claude_agent(sport: str) -> int:
         cwd=str(settings.project_root),
     )
 
-    try:
-        async with asyncio.timeout(AGENT_TIMEOUT_SECONDS):
-            assert proc.stdout is not None  # noqa: S101
-            async for line in proc.stdout:
-                text = line.decode("utf-8", errors="replace").rstrip()
-                if text:
-                    logger.info("agent_output", line=text)
-
+    with log_path.open("ab") as log_file:
+        try:
+            async with asyncio.timeout(AGENT_TIMEOUT_SECONDS):
+                assert proc.stdout is not None  # noqa: S101
+                async for line in proc.stdout:
+                    log_file.write(line)
+                    try:
+                        msg = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    _log_stream_message(msg)
+                await proc.wait()
+        except TimeoutError:
+            logger.warning(
+                "agent_subprocess_timeout",
+                sport=sport,
+                timeout=AGENT_TIMEOUT_SECONDS,
+                log_file=str(log_path),
+            )
+            proc.kill()
             await proc.wait()
-    except TimeoutError:
-        logger.warning("agent_subprocess_timeout", sport=sport, timeout=AGENT_TIMEOUT_SECONDS)
-        proc.kill()
-        await proc.wait()
-        return -1
+            return -1
 
     exit_code = proc.returncode or 0
-    logger.info("agent_subprocess_finished", sport=sport, exit_code=exit_code)
+    logger.info(
+        "agent_subprocess_finished",
+        sport=sport,
+        exit_code=exit_code,
+        log_file=str(log_path),
+    )
     return exit_code
 
 

--- a/packages/odds-lambda/odds_lambda/jobs/agent_run.py
+++ b/packages/odds-lambda/odds_lambda/jobs/agent_run.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, NamedTuple
@@ -49,6 +50,11 @@ AGENT_TIMEOUT_SECONDS = 15 * 60  # 15 minutes
 
 # Retain this many per-run JSONL logs per sport; older ones are pruned on write.
 AGENT_RUN_LOG_KEEP = 50
+
+# Upper bound on any single stream-json line. The asyncio default (64 KiB) is
+# too small — a single ``tool_result`` block (e.g. a large Read or WebFetch
+# payload) routinely exceeds it and would raise ``LimitOverrunError``.
+AGENT_STREAM_LINE_LIMIT = 8 * 1024 * 1024
 
 # Horizon for "no fixtures" classification
 FIXTURE_HORIZON_DAYS = 7
@@ -83,7 +89,7 @@ def _preview_tool_input(d: dict[str, Any] | None, *, max_value_chars: int = 60) 
         return None
     parts: list[str] = []
     for k, v in d.items():
-        s = str(v)
+        s = str(v).replace("\n", " ").replace("\r", " ")
         if len(s) > max_value_chars:
             s = s[:max_value_chars] + "..."
         parts.append(f"{k}={s}")
@@ -154,7 +160,8 @@ async def _run_claude_agent(sport: str) -> int:
     _prune_agent_run_logs(log_dir, sport, keep=AGENT_RUN_LOG_KEEP)
 
     timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-    log_path = log_dir / f"{sport}_{timestamp}.jsonl"
+    # PID suffix avoids collisions when two invocations start in the same second.
+    log_path = log_dir / f"{sport}_{timestamp}_{os.getpid()}.jsonl"
 
     logger.info("agent_subprocess_starting", sport=sport, cmd=cmd, log_file=str(log_path))
 
@@ -163,6 +170,7 @@ async def _run_claude_agent(sport: str) -> int:
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
         cwd=str(settings.project_root),
+        limit=AGENT_STREAM_LINE_LIMIT,
     )
 
     with log_path.open("ab") as log_file:

--- a/tests/unit/test_agent_run.py
+++ b/tests/unit/test_agent_run.py
@@ -15,6 +15,8 @@ from odds_lambda.jobs.agent_run import (
     TIER_RESEARCH_HOURS,
     ScheduleResult,
     _compute_wake_interval,
+    _log_stream_message,
+    _preview_tool_input,
     main,
     schedule_next,
 )
@@ -331,3 +333,98 @@ class TestScheduleNext:
     async def test_unknown_sport_raises_valueerror(self) -> None:
         with pytest.raises(ValueError, match="No overnight window configured for basketball_nba"):
             await schedule_next("basketball_nba")
+
+
+class TestPreviewToolInput:
+    """Tests for the tool-input formatter used in live main-log events."""
+
+    def test_none_input_returns_none(self) -> None:
+        assert _preview_tool_input(None) is None
+
+    def test_empty_dict_returns_none(self) -> None:
+        assert _preview_tool_input({}) is None
+
+    def test_single_key_renders_as_key_value(self) -> None:
+        assert _preview_tool_input({"file_path": "/tmp/x.md"}) == "file_path=/tmp/x.md"
+
+    def test_multiple_keys_all_rendered_space_separated(self) -> None:
+        preview = _preview_tool_input({"command": "ls", "description": "list files"})
+        assert preview == "command=ls description=list files"
+
+    def test_long_values_truncated_with_ellipsis(self) -> None:
+        long_value = "x" * 200
+        preview = _preview_tool_input({"payload": long_value}, max_value_chars=20)
+        assert preview is not None
+        assert preview.startswith("payload=" + "x" * 20)
+        assert preview.endswith("...")
+
+    def test_non_string_values_stringified(self) -> None:
+        assert _preview_tool_input({"count": 42, "flag": True}) == "count=42 flag=True"
+
+
+class TestLogStreamMessage:
+    """Tests for the stream-json message classifier that drives tee logging."""
+
+    def test_tool_use_emits_agent_tool_use(self) -> None:
+        msg = {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "Bash",
+                        "input": {"command": "ls"},
+                    }
+                ]
+            },
+        }
+        with patch("odds_lambda.jobs.agent_run.logger") as mock_logger:
+            _log_stream_message(msg)
+
+        mock_logger.info.assert_called_once_with(
+            "agent_tool_use",
+            tool="Bash",
+            input_preview="command=ls",
+        )
+
+    def test_result_emits_agent_run_summary_with_fields(self) -> None:
+        msg = {
+            "type": "result",
+            "result": "done",
+            "num_turns": 7,
+            "duration_ms": 12345,
+            "total_cost_usd": 0.5,
+        }
+        with patch("odds_lambda.jobs.agent_run.logger") as mock_logger:
+            _log_stream_message(msg)
+
+        mock_logger.info.assert_called_once_with(
+            "agent_run_summary",
+            text="done",
+            num_turns=7,
+            duration_ms=12345,
+            cost_usd=0.5,
+        )
+
+    def test_assistant_text_block_is_ignored(self) -> None:
+        msg = {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "hello"}]},
+        }
+        with patch("odds_lambda.jobs.agent_run.logger") as mock_logger:
+            _log_stream_message(msg)
+
+        mock_logger.info.assert_not_called()
+
+    def test_assistant_with_non_dict_message_is_silent(self) -> None:
+        msg = {"type": "assistant", "message": None}
+        with patch("odds_lambda.jobs.agent_run.logger") as mock_logger:
+            _log_stream_message(msg)
+
+        mock_logger.info.assert_not_called()
+
+    def test_unknown_type_is_silent(self) -> None:
+        with patch("odds_lambda.jobs.agent_run.logger") as mock_logger:
+            _log_stream_message({"type": "system", "subtype": "init"})
+
+        mock_logger.info.assert_not_called()

--- a/tests/unit/test_agent_run.py
+++ b/tests/unit/test_agent_run.py
@@ -361,6 +361,11 @@ class TestPreviewToolInput:
     def test_non_string_values_stringified(self) -> None:
         assert _preview_tool_input({"count": 42, "flag": True}) == "count=42 flag=True"
 
+    def test_newlines_collapsed_to_spaces(self) -> None:
+        # Multi-line command or file_text shouldn't break the single-line log format.
+        preview = _preview_tool_input({"command": "line1\nline2\r\nline3"})
+        assert preview == "command=line1 line2  line3"
+
 
 class TestLogStreamMessage:
     """Tests for the stream-json message classifier that drives tee logging."""

--- a/tests/unit/test_db_override.py
+++ b/tests/unit/test_db_override.py
@@ -1,0 +1,67 @@
+"""Tests for the CLI database-override helper."""
+
+from __future__ import annotations
+
+import pytest
+from odds_cli.db_override import swap_dbname
+
+
+class TestSwapDbname:
+    """Tests for the dbname-component swap used by --db flags."""
+
+    def test_swaps_local_url(self) -> None:
+        original = "postgresql+asyncpg://postgres:postgres@localhost:5433/odds"
+        assert (
+            swap_dbname(original, "odds_test")
+            == "postgresql+asyncpg://postgres:postgres@localhost:5433/odds_test"
+        )
+
+    def test_preserves_query_string(self) -> None:
+        original = "postgresql+asyncpg://u:p@ep-foo.neon.tech/neondb?sslmode=require"
+        assert (
+            swap_dbname(original, "odds_test")
+            == "postgresql+asyncpg://u:p@ep-foo.neon.tech/odds_test?sslmode=require"
+        )
+
+    def test_preserves_custom_port(self) -> None:
+        original = "postgresql://user:pw@db.internal:6543/production"
+        assert swap_dbname(original, "sandbox") == "postgresql://user:pw@db.internal:6543/sandbox"
+
+    def test_handles_url_without_port(self) -> None:
+        original = "postgresql+asyncpg://user:pw@host/olddb"
+        assert swap_dbname(original, "newdb") == "postgresql+asyncpg://user:pw@host/newdb"
+
+    def test_preserves_scheme_including_driver_suffix(self) -> None:
+        # The +asyncpg suffix must survive — pydantic settings / SQLAlchemy rely on it.
+        original = "postgresql+asyncpg://u:p@h/a"
+        assert swap_dbname(original, "b").startswith("postgresql+asyncpg://")
+
+    def test_overwrites_existing_path_segments(self) -> None:
+        # Defensive: URLs shouldn't carry extra path segments, but if one does,
+        # the swap collapses the path to just /newdb rather than appending.
+        original = "postgresql://u:p@h:5432/olddb/extra"
+        assert swap_dbname(original, "newdb") == "postgresql://u:p@h:5432/newdb"
+
+
+class TestOverrideDatabaseUrl:
+    """Tests that the env override reads current settings and clears the cache."""
+
+    def test_mutates_env_and_clears_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import os
+
+        from odds_cli.db_override import override_database_url
+        from odds_core.config import get_settings, reset_settings_cache
+
+        reset_settings_cache()
+        monkeypatch.setenv(
+            "DATABASE_URL", "postgresql+asyncpg://postgres:postgres@localhost:5433/odds"
+        )
+        # Prime the cache with the initial URL
+        assert get_settings().database.url.endswith("/odds")
+
+        new_url = override_database_url("odds_test")
+
+        assert new_url.endswith("/odds_test")
+        assert os.environ["DATABASE_URL"].endswith("/odds_test")
+        # Cache should have been cleared so the next get_settings() reflects the override.
+        assert get_settings().database.url.endswith("/odds_test")

--- a/tests/unit/test_db_override.py
+++ b/tests/unit/test_db_override.py
@@ -42,6 +42,14 @@ class TestSwapDbname:
         original = "postgresql://u:p@h:5432/olddb/extra"
         assert swap_dbname(original, "newdb") == "postgresql://u:p@h:5432/newdb"
 
+    def test_rejects_dbname_with_slash(self) -> None:
+        with pytest.raises(ValueError, match="invalid dbname"):
+            swap_dbname("postgresql://u:p@h/a", "bad/name")
+
+    def test_rejects_dbname_with_query_marker(self) -> None:
+        with pytest.raises(ValueError, match="invalid dbname"):
+            swap_dbname("postgresql://u:p@h/a", "bad?x=1")
+
 
 class TestOverrideDatabaseUrl:
     """Tests that the env override reads current settings and clears the cache."""


### PR DESCRIPTION
## Summary

Two related pieces of infrastructure for iterating on the EPL/MLB betting agent:

- **Per-run JSONL trace** (`49daeca`): `_run_claude_agent` now spawns `claude -p --output-format stream-json --verbose` and writes the full message stream to `logs/agent_runs/{sport}_<ts>.jsonl`. A Python tee parses each line and surfaces `tool_use` calls and the final `result` summary to the main structlog file as `agent_tool_use` / `agent_run_summary` events — the scheduler log stays readable while the full reasoning trace is preserved per run. Oldest files pruned on write (keep 50 per sport).

- **Dev-mode CLI** (`70c119c`): two entry points for running the agent against a sandbox DB without touching the source-of-truth scheduler:
  - `odds agent run --sport <sport> [--db <name>]` — invokes `_run_claude_agent` directly, bypassing the scheduler wrapper. Defaults to `--db odds_test`.
  - `odds scheduler start` gains `--db` and `--bootstrap/--no-bootstrap`. When `--db` is set, bootstrap defaults to off (sidecar mode — prevents a scheduler-launched `agent-run` from clashing with a manual `odds agent run`). Pass `--bootstrap` explicitly for full-loop smoke tests.
  - `odds_cli.db_override.swap_dbname` is the shared URL helper; `override_database_url` resets the lru-cached `Settings` so subsequent reads see the override.
  - `scripts/snapshot_to_dev.sh` (gitignored — local-only) refreshes the sandbox DB via `pg_dump | pg_restore` inside the postgres docker-compose container.

## Test plan

- [x] Unit tests: `_preview_tool_input`, `_log_stream_message`, `swap_dbname`, `override_database_url` (18 new cases, all green).
- [x] Live end-to-end run against `odds_test`: 9m13s / 64 turns / $3.43. JSONL captured 488 KB / 157 messages. Main log showed `agent_tool_use` for every MCP/tool call with readable multi-kwarg previews and final `agent_run_summary`. 3 briefs landed in `odds_test.match_briefs`; 0 in source `odds` (isolation confirmed).
- [x] CLI smoke tests: `odds scheduler start` with no args (bootstrap on), `--db odds_test` (bootstrap off), `--db odds_test --bootstrap` (bootstrap on).
- [ ] Known limitation — in sandbox mode with no sidecar scheduler, the agent's `refresh_scrape` → `get_scrape_status` poll loop has nothing to pick up the job. Workaround: run `odds scheduler start --db odds_test` in another terminal (bootstrap auto-off means it just listens for submitted jobs).
- [ ] Known limitation — agent filesystem edits (e.g. `packages/odds-mcp/agents/epl/observations.md`) are not sandboxed; only DB writes are isolated. Worth addressing later via git worktree per dev run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)