### PR TITLE
Surface completed scrape results in get_scrape_status

### DIFF
--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -303,19 +303,28 @@ async def refresh_scrape(
 async def get_scrape_status(
     job_id: str | None = None,
 ) -> dict[str, Any]:
-    """Check whether the scheduler is running and list pending scrape jobs.
+    """Check scheduler status, list pending scrape jobs, and surface results.
 
-    Queries the APScheduler data store for jobs whose task matches
-    ``ingest_league``. Useful after ``refresh_scrape`` to confirm the
-    scheduler picked up the job.
+    Without ``job_id``: returns the current list of pending/running scrape
+    jobs in the APScheduler data store.
+
+    With ``job_id`` (returned from ``refresh_scrape``): also looks up the
+    completed result and returns ``matches_scraped``, ``events_matched``,
+    ``snapshots_stored``, ``errors``, and job outcome. Results are retained
+    by APScheduler for a bounded window after completion.
 
     Args:
-        job_id: Optional UUID string to filter for a specific job.
-               If provided, only that job is returned (if still pending).
+        job_id: Optional UUID string. When provided, the tool reports the
+                job's lifecycle state (pending, running, completed, failed)
+                and, for completed jobs, the ingestion stats.
 
     Returns:
-        Dict with scheduler status and list of pending scrape jobs.
+        Dict with scheduler status, pending jobs, and (if job_id is given)
+        the specific job's outcome.
     """
+    import dataclasses
+    from uuid import UUID
+
     try:
         from apscheduler import SchedulerRole
         from odds_lambda.scheduling.backends.local import build_scheduler
@@ -323,18 +332,38 @@ async def get_scrape_status(
         async with build_scheduler(role=SchedulerRole.scheduler) as scheduler:
             jobs = await scheduler.get_jobs()
 
-        scrape_jobs = [
-            {
-                "job_id": str(j.id),
-                "task_id": j.task_id,
-                "created_at": j.created_at.isoformat() if j.created_at else None,
-            }
-            for j in jobs
-            if "ingest_league" in j.task_id
-        ]
+            pending = [j for j in jobs if "ingest_league" in j.task_id]
+            if job_id is not None:
+                pending = [j for j in pending if str(j.id) == job_id]
 
-        if job_id is not None:
-            scrape_jobs = [j for j in scrape_jobs if j["job_id"] == job_id]
+            pending_jobs = [
+                {
+                    "job_id": str(j.id),
+                    "task_id": j.task_id,
+                    "created_at": j.created_at.isoformat() if j.created_at else None,
+                    "state": "running" if j.acquired_by else "pending",
+                }
+                for j in pending
+            ]
+
+            job_result: dict[str, Any] | None = None
+            if job_id is not None and not pending_jobs:
+                result = await scheduler.get_job_result(UUID(job_id), wait=False)
+                if result is not None:
+                    stats = result.return_value
+                    job_result = {
+                        "job_id": job_id,
+                        "state": "completed",
+                        "outcome": result.outcome.name,
+                        "started_at": result.started_at.isoformat() if result.started_at else None,
+                        "finished_at": result.finished_at.isoformat(),
+                        "stats": dataclasses.asdict(stats)
+                        if dataclasses.is_dataclass(stats)
+                        else None,
+                        "exception": repr(result.exception) if result.exception else None,
+                    }
+                else:
+                    job_result = {"job_id": job_id, "state": "unknown"}
 
     except Exception as e:
         logger.warning("get_scrape_status_failed", error=str(e))
@@ -344,11 +373,14 @@ async def get_scrape_status(
             "jobs": [],
         }
 
-    return {
+    response: dict[str, Any] = {
         "status": "ok",
-        "pending_scrape_jobs": len(scrape_jobs),
-        "jobs": scrape_jobs,
+        "pending_scrape_jobs": len(pending_jobs),
+        "jobs": pending_jobs,
     }
+    if job_result is not None:
+        response["result"] = job_result
+    return response
 
 
 @mcp.tool()

--- a/packages/odds-mcp/tests/test_server.py
+++ b/packages/odds-mcp/tests/test_server.py
@@ -227,6 +227,103 @@ class TestRefreshScrapeUnknownLeague:
             assert spec.sport_key == "baseball_mlb"
 
 
+class TestGetScrapeStatus:
+    @pytest.mark.asyncio
+    async def test_surfaces_completed_job_result(self) -> None:
+        from dataclasses import dataclass, field
+        from uuid import uuid4
+
+        from odds_mcp.server import get_scrape_status
+
+        @dataclass
+        class FakeStats:
+            league: str = "england-premier-league"
+            matches_scraped: int = 12
+            matches_converted: int = 12
+            events_matched: int = 10
+            events_created: int = 2
+            snapshots_stored: int = 12
+            errors: list[str] = field(default_factory=list)
+
+        job_id = uuid4()
+        mock_outcome = MagicMock()
+        mock_outcome.name = "success"
+        mock_result = MagicMock()
+        mock_result.outcome = mock_outcome
+        mock_result.return_value = FakeStats()
+        mock_result.started_at = datetime(2026, 4, 17, 10, 0, tzinfo=UTC)
+        mock_result.finished_at = datetime(2026, 4, 17, 10, 5, tzinfo=UTC)
+        mock_result.exception = None
+
+        mock_scheduler = AsyncMock()
+        mock_scheduler.get_jobs = AsyncMock(return_value=[])
+        mock_scheduler.get_job_result = AsyncMock(return_value=mock_result)
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_scheduler)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("odds_lambda.scheduling.backends.local.build_scheduler", return_value=mock_cm):
+            response = await get_scrape_status(job_id=str(job_id))
+
+        assert response["status"] == "ok"
+        assert response["pending_scrape_jobs"] == 0
+        assert response["result"]["state"] == "completed"
+        assert response["result"]["outcome"] == "success"
+        assert response["result"]["stats"]["matches_scraped"] == 12
+        assert response["result"]["stats"]["events_matched"] == 10
+        assert response["result"]["exception"] is None
+
+    @pytest.mark.asyncio
+    async def test_pending_job_reports_state(self) -> None:
+        from uuid import uuid4
+
+        from odds_mcp.server import get_scrape_status
+
+        job_id = uuid4()
+        mock_job = MagicMock()
+        mock_job.id = job_id
+        mock_job.task_id = "odds_lambda.jobs.fetch_oddsportal.ingest_league"
+        mock_job.created_at = datetime(2026, 4, 17, 10, 0, tzinfo=UTC)
+        mock_job.acquired_by = None
+
+        mock_scheduler = AsyncMock()
+        mock_scheduler.get_jobs = AsyncMock(return_value=[mock_job])
+        mock_scheduler.get_job_result = AsyncMock()
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_scheduler)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("odds_lambda.scheduling.backends.local.build_scheduler", return_value=mock_cm):
+            response = await get_scrape_status(job_id=str(job_id))
+
+        assert response["pending_scrape_jobs"] == 1
+        assert response["jobs"][0]["state"] == "pending"
+        assert "result" not in response
+        mock_scheduler.get_job_result.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unknown_job_id_reports_unknown(self) -> None:
+        from uuid import uuid4
+
+        from odds_mcp.server import get_scrape_status
+
+        job_id = uuid4()
+        mock_scheduler = AsyncMock()
+        mock_scheduler.get_jobs = AsyncMock(return_value=[])
+        mock_scheduler.get_job_result = AsyncMock(return_value=None)
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_scheduler)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("odds_lambda.scheduling.backends.local.build_scheduler", return_value=mock_cm):
+            response = await get_scrape_status(job_id=str(job_id))
+
+        assert response["result"]["state"] == "unknown"
+
+
 class TestGetUpcomingFixtures:
     @pytest.mark.asyncio
     async def test_returns_fixtures(self) -> None:


### PR DESCRIPTION
## Summary
- Extends `get_scrape_status` to call `scheduler.get_job_result(job_id, wait=False)` when a `job_id` is supplied, surfacing `matches_scraped`, `events_matched`, `snapshots_stored`, errors, and outcome after a scrape completes.
- Pending jobs now also report a `state` field (`pending` / `running`) derived from APScheduler's `acquired_by`.
- Adds three unit tests covering completed, pending, and unknown-job paths.

## Context
Post-#328, the MCP tool only listed pending APScheduler jobs. Once `ingest_league` finished, the job vanished from `get_jobs()`, so the agent lost visibility into scrape results after calling `refresh_scrape`. APScheduler 4 already persists job results — this change just reads them.

No schema changes, no new deps.

## Test plan
- [x] `uv run pytest packages/odds-mcp/tests/test_server.py::TestGetScrapeStatus` — 3/3 pass
- [ ] Manual: run `refresh_scrape` from MCP, wait for completion, confirm `get_scrape_status(job_id=...)` returns `result.stats`

## Notes
Two pre-existing test failures were observed locally in the same file (`test_known_league_uses_correct_sport`, `test_missing_event`) — both stale since #304/#328 and not caught by CI because CI only runs `tests/unit/`, not `packages/*/tests/`. Out of scope here; worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)