### PR TITLE
Harden MCP agent tools: list-param workaround, retail coverage, SportKey

### DIFF
--- a/packages/odds-analytics/odds_analytics/utils.py
+++ b/packages/odds-analytics/odds_analytics/utils.py
@@ -7,7 +7,7 @@ devigging, h2h winner, profit-from-odds) lives in ``odds_core.odds_math``.
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
+from collections.abc import Collection, Iterable, Sequence
 from typing import TYPE_CHECKING
 
 from odds_core.odds_math import american_to_decimal, calculate_implied_probability
@@ -135,6 +135,27 @@ def calculate_market_hold(odds_list: list[int]) -> float:
     """Market hold (bookmaker's edge/vig) from a list of odds for all outcomes."""
     implied_probs = [calculate_implied_probability(odds) for odds in odds_list]
     return sum(implied_probs) - 1.0
+
+
+def per_book_market_holds(
+    prices: Iterable[tuple[str, str, int]],
+    required_outcomes: Collection[str],
+) -> dict[str, float]:
+    """Market hold per bookmaker from ``(bookmaker, outcome, price)`` tuples.
+
+    Books missing any of ``required_outcomes`` are dropped — a partial-market
+    sum would understate the hold (possibly negative) with no signal to the
+    caller. Duplicate ``(bookmaker, outcome)`` entries keep the last price.
+    """
+    required = set(required_outcomes)
+    by_book: dict[str, dict[str, int]] = {}
+    for bookmaker, outcome, price in prices:
+        by_book.setdefault(bookmaker, {})[outcome] = price
+    return {
+        bm: calculate_market_hold(list(outcome_prices.values()))
+        for bm, outcome_prices in by_book.items()
+        if set(outcome_prices) >= required
+    }
 
 
 def detect_arbitrage(odds_list: list[tuple[str, int]]) -> tuple[bool, float, dict]:

--- a/packages/odds-core/odds_core/config.py
+++ b/packages/odds-core/odds_core/config.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from odds_core.sports import SportKey
+
 
 class APIConfig(BaseSettings):
     """The Odds API configuration."""
@@ -42,7 +44,9 @@ class DataCollectionConfig(BaseSettings):
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
-    sports: list[str] = Field(default=["soccer_epl", "baseball_mlb"], description="Sports to track")
+    sports: list[SportKey] = Field(
+        default=["soccer_epl", "baseball_mlb"], description="Sports to track"
+    )
     bookmakers: list[str] = Field(
         default=[
             "pinnacle",

--- a/packages/odds-core/odds_core/sports.py
+++ b/packages/odds-core/odds_core/sports.py
@@ -7,6 +7,6 @@ scheduler jobs, MCP tools, and CLI commands.
 
 from typing import Literal, get_args
 
-SportKey = Literal["soccer_epl", "baseball_mlb"]
+SportKey = Literal["soccer_epl", "baseball_mlb", "basketball_nba"]
 
 SUPPORTED_SPORTS: tuple[SportKey, ...] = get_args(SportKey)

--- a/packages/odds-core/odds_core/sports.py
+++ b/packages/odds-core/odds_core/sports.py
@@ -1,0 +1,12 @@
+"""Supported sport keys for the odds pipeline.
+
+Values match The Odds API's sport key convention and are used as the
+``sport_key`` on ``Event`` rows and as the ``sport`` argument across
+scheduler jobs, MCP tools, and CLI commands.
+"""
+
+from typing import Literal, get_args
+
+SportKey = Literal["soccer_epl", "baseball_mlb"]
+
+SUPPORTED_SPORTS: tuple[SportKey, ...] = get_args(SportKey)

--- a/packages/odds-lambda/odds_lambda/jobs/agent_run.py
+++ b/packages/odds-lambda/odds_lambda/jobs/agent_run.py
@@ -24,6 +24,7 @@ from typing import Any, NamedTuple
 
 import structlog
 from odds_core.config import get_settings
+from odds_core.sports import SportKey
 
 from odds_lambda.scheduling.helpers import apply_overnight_skip, get_next_kickoff, self_schedule
 from odds_lambda.scheduling.jobs import JobContext, make_compound_job_name
@@ -40,7 +41,7 @@ TIER_NO_FIXTURES_HOURS = 12.0  # no fixtures within 7 days
 # Overnight suppression windows (start_utc, resume_utc) per sport
 # EPL: last KO ~20:00 UTC, suppress 22:00-06:00
 # MLB: last pitch ~04:00 UTC, suppress 06:00-14:00
-OVERNIGHT_WINDOWS: dict[str, tuple[int, int]] = {
+OVERNIGHT_WINDOWS: dict[SportKey, tuple[int, int]] = {
     "soccer_epl": (22, 6),
     "baseball_mlb": (6, 14),
 }
@@ -96,7 +97,7 @@ def _preview_tool_input(d: dict[str, Any] | None, *, max_value_chars: int = 60) 
     return " ".join(parts)
 
 
-def _prune_agent_run_logs(log_dir: Path, sport: str, keep: int) -> None:
+def _prune_agent_run_logs(log_dir: Path, sport: SportKey, keep: int) -> None:
     """Delete all but the newest ``keep`` JSONL files for ``sport``."""
     files = sorted(log_dir.glob(f"{sport}_*.jsonl"), reverse=True)
     for stale in files[keep:]:
@@ -135,7 +136,7 @@ def _log_stream_message(msg: dict[str, Any]) -> None:
         )
 
 
-async def _run_claude_agent(sport: str) -> int:
+async def _run_claude_agent(sport: SportKey) -> int:
     """Spawn ``claude -p`` subprocess and return exit code.
 
     Full stream-json trace is written to
@@ -206,7 +207,7 @@ async def _run_claude_agent(sport: str) -> int:
     return exit_code
 
 
-async def _check_agent_requested_wakeup(sport_key: str) -> datetime | None:
+async def _check_agent_requested_wakeup(sport_key: SportKey) -> datetime | None:
     """Read and consume any agent-requested wake-up from the agent_wakeups table.
 
     Returns the requested time if a row exists for this sport, then marks it
@@ -244,7 +245,7 @@ async def _check_agent_requested_wakeup(sport_key: str) -> datetime | None:
     return requested_time
 
 
-async def schedule_next(sport: str) -> ScheduleResult:
+async def schedule_next(sport: SportKey) -> ScheduleResult:
     """Compute and schedule the next agent wake-up for a sport.
 
     Queries the DB for the next kickoff, computes the wake interval from

--- a/packages/odds-lambda/odds_lambda/jobs/daily_digest.py
+++ b/packages/odds-lambda/odds_lambda/jobs/daily_digest.py
@@ -16,6 +16,7 @@ import structlog
 from odds_core.database import async_session_maker
 from odds_core.models import Event, EventStatus, OddsSnapshot
 from odds_core.prediction_models import Prediction
+from odds_core.sports import SportKey
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -23,7 +24,7 @@ from odds_lambda.scheduling.jobs import JobContext
 
 logger = structlog.get_logger()
 
-DEFAULT_SPORT_KEY = "soccer_epl"
+DEFAULT_SPORT_KEY: SportKey = "soccer_epl"
 EMBED_COLOR = 3066993  # Green
 MAX_FIELD_CHARS = 1024
 
@@ -32,7 +33,7 @@ async def _get_completed_events_with_predictions(
     session: AsyncSession,
     since: datetime,
     model_name: str,
-    sport_key: str = DEFAULT_SPORT_KEY,
+    sport_key: SportKey = DEFAULT_SPORT_KEY,
 ) -> list[dict[str, Any]]:
     """Get events completed since `since` that have predictions.
 
@@ -101,7 +102,7 @@ async def _get_upcoming_events_with_predictions(
     session: AsyncSession,
     until: datetime,
     model_name: str,
-    sport_key: str = DEFAULT_SPORT_KEY,
+    sport_key: SportKey = DEFAULT_SPORT_KEY,
 ) -> list[dict[str, Any]]:
     """Get SCHEDULED events before `until` that have at least one prediction.
 
@@ -252,7 +253,7 @@ def build_digest_embed(
     upcoming: list[dict[str, Any]],
     lookback_hours: float = 24,
     lookahead_hours: float = 48,
-    sport_key: str = DEFAULT_SPORT_KEY,
+    sport_key: SportKey = DEFAULT_SPORT_KEY,
 ) -> dict[str, Any]:
     """Build a Discord embed dict for the daily digest."""
     now = datetime.now(UTC)
@@ -290,7 +291,7 @@ async def send_digest(
     model_name: str | None = None,
     lookback_hours: float = 24,
     lookahead_hours: float = 48,
-    sport_key: str = DEFAULT_SPORT_KEY,
+    sport_key: SportKey = DEFAULT_SPORT_KEY,
 ) -> dict[str, int]:
     """Query predictions and results, send Discord digest.
 

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, fields
 from importlib import import_module
 
 import structlog
+from odds_core.sports import SportKey
 
 logger = structlog.get_logger()
 
@@ -21,7 +22,7 @@ class JobContext:
     fields have defaults.
     """
 
-    sport: str | None = None
+    sport: SportKey | None = None
 
     # backfill-polymarket manual invocation params
     include_spreads: bool = False

--- a/packages/odds-mcp/agents/common.md
+++ b/packages/odds-mcp/agents/common.md
@@ -8,7 +8,9 @@ Before triaging or researching any fixture, call `get_slate_briefs` to see the l
 
 ## Parallelism
 
-Maximise parallel tool calls and sub-agent research. Once games are selected for deep research, research them concurrently — do not work through games sequentially.
+Maximise parallel tool calls. Once games are selected for deep research, research them concurrently — do not work through games sequentially.
+
+For web research, dispatch the `web-research` subagent (via the `Agent` tool with `subagent_type: web-research`). That subagent has `WebSearch` and `WebFetch` available; the default `general-purpose` subagent does not, so dispatching it for web research will fail. Dispatch multiple `web-research` subagents in a single turn — one per fixture or topic — to parallelise. Keep MCP odds tool calls in the main context.
 
 ## Scrape Freshness
 

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -4,6 +4,7 @@ Thin wrappers over existing DB queries, jobs, and paper trading logic.
 All tools are stateless and use async_session_maker() for DB access.
 """
 
+import json
 import math
 from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
@@ -12,6 +13,7 @@ import structlog
 from fastmcp import FastMCP
 from odds_analytics.backtesting import BacktestEvent
 from odds_analytics.feature_extraction import TabularFeatureExtractor
+from odds_analytics.utils import calculate_market_hold
 from odds_core.agent_wakeup_models import AgentWakeup
 from odds_core.database import async_session_maker
 from odds_core.match_brief_models import BriefDecision, MatchBrief, SharpPriceMap
@@ -48,10 +50,31 @@ mcp = FastMCP(
 _LEAGUE_SPEC_BY_NAME = LEAGUE_SPEC_BY_NAME
 
 # Hybrid sharp reference matching production defaults.
-# Duplicated from feature_extraction.py DEFAULT_SHARP_BOOKMAKERS / DEFAULT_RETAIL_BOOKMAKERS
-# with EPL-specific overrides — keep in sync.
+# Duplicated from feature_extraction.py DEFAULT_SHARP_BOOKMAKERS with EPL-specific overrides — keep in sync.
 _DEFAULT_SHARP_BOOKMAKERS = ["pinnacle", "betfair_exchange"]
-_DEFAULT_RETAIL_BOOKMAKERS = ["bet365", "betway", "betfred"]
+# Used only by get_event_features for TabularFeatureExtractor. Must match whatever
+# retail set the deployed EPL model was trained on — today there is no deployed EPL
+# model, so this is a placeholder pending resolution of the "EPL predictions empty" TODO.
+_DEFAULT_RETAIL_BOOKMAKERS = ["bet365", "betway", "betfred", "betvictor", "bwin"]
+
+
+def _coerce_bookmaker_list(value: str | list[str] | None) -> list[str] | None:
+    # Claude Code's MCP client stringifies array params (anthropics/claude-code#22394).
+    # Accept JSON-array strings and comma-separated strings so tools stay callable.
+    # Remove once the upstream client is fixed.
+    if value is None or isinstance(value, list):
+        return value
+    stripped = value.strip()
+    if not stripped:
+        return None
+    if stripped.startswith("["):
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, list):
+            return [str(item) for item in parsed]
+    return [item.strip() for item in stripped.split(",") if item.strip()]
 
 
 def _event_to_dict(event: Event) -> dict[str, Any]:
@@ -447,8 +470,7 @@ async def get_event_features(
     event_id: str,
     market: MarketKey,
     outcome: Literal["home", "away"] = "home",
-    sharp_bookmakers: list[str] | None = None,
-    retail_bookmakers: list[str] | None = None,
+    sharp_bookmakers: str | list[str] | None = None,
 ) -> dict[str, Any]:
     """Get tabular features for an event's latest snapshot.
 
@@ -462,7 +484,6 @@ async def get_event_features(
         market: Market type — "h2h", "1x2", "totals", or "spreads".
         outcome: Which outcome to extract features for ("home" or "away").
         sharp_bookmakers: Sharp bookmaker keys (default: ["pinnacle", "betfair_exchange"]).
-        retail_bookmakers: Retail bookmaker keys (default: ["bet365", "betway", "betfred"]).
 
     Returns:
         Dict with event info and feature name/value pairs.
@@ -489,8 +510,8 @@ async def get_event_features(
             snapshot,
             market=market,
             outcome_name=outcome_name,
-            sharp_bookmakers=sharp_bookmakers or _DEFAULT_SHARP_BOOKMAKERS,
-            retail_bookmakers=retail_bookmakers or _DEFAULT_RETAIL_BOOKMAKERS,
+            sharp_bookmakers=_coerce_bookmaker_list(sharp_bookmakers) or _DEFAULT_SHARP_BOOKMAKERS,
+            retail_bookmakers=_DEFAULT_RETAIL_BOOKMAKERS,
         )
     except Exception as e:
         logger.error("feature_extraction_failed", event_id=event_id, error=str(e), exc_info=True)
@@ -865,30 +886,30 @@ async def get_slate_briefs(
 async def get_sharp_soft_spread(
     event_id: str,
     market: MarketKey,
-    sharp_bookmakers: list[str] | None = None,
-    retail_bookmakers: list[str] | None = None,
+    sharp_bookmakers: str | list[str] | None = None,
     sharp_lookback_hours: float = 2.0,
 ) -> dict[str, Any]:
     """Get sharp vs soft bookmaker price divergence for an event.
 
     Sharp prices are resolved via a time-windowed lookback across recent
     snapshots so that a missing sharp bookmaker in the latest scrape does not
-    discard a perfectly good price from a nearby snapshot.  Retail prices
-    always come from the single latest snapshot.
+    discard a perfectly good price from a nearby snapshot. Retail prices
+    always come from the single latest snapshot and cover every non-sharp
+    bookmaker in it. For h2h / 1x2 markets each retail entry also reports
+    that book's market hold, so callers can filter high-margin books.
 
     Args:
         event_id: Event identifier.
         market: Market type — "h2h", "1x2", "totals", or "spreads".
         sharp_bookmakers: Sharp bookmaker keys (default: ["pinnacle", "betfair_exchange"]).
-        retail_bookmakers: Retail bookmaker keys (default: ["bet365", "betway", "betfred"]).
         sharp_lookback_hours: How far back to search for sharp prices (default 2.0 h).
 
     Returns:
         Dict with per-outcome sharp price (with source snapshot time),
-        soft prices, and divergence values.
+        soft prices, and divergence values. Each soft entry includes
+        ``market_hold`` (h2h / 1x2 only; null for multi-line markets).
     """
-    sharp_bms = sharp_bookmakers or _DEFAULT_SHARP_BOOKMAKERS
-    retail_bms = retail_bookmakers or _DEFAULT_RETAIL_BOOKMAKERS
+    sharp_bms = _coerce_bookmaker_list(sharp_bookmakers) or _DEFAULT_SHARP_BOOKMAKERS
 
     async with async_session_maker() as session:
         reader = OddsReader(session)
@@ -934,6 +955,19 @@ async def get_sharp_soft_spread(
     for o in odds:
         outcomes.setdefault(o.outcome_name, []).append(o)
 
+    # Retail set is every non-sharp book in the snapshot.
+    sharp_set = set(sharp_bms)
+    retail_bms = sorted({o.bookmaker_key for o in odds if o.bookmaker_key not in sharp_set})
+
+    # Per-book market hold is only meaningful for single-line markets; totals / spreads
+    # span multiple lines, so computing it event-wide would conflate them.
+    book_hold: dict[str, float] | None = None
+    if market in ("h2h", "1x2"):
+        book_prices: dict[str, list[int]] = {}
+        for o in odds:
+            book_prices.setdefault(o.bookmaker_key, []).append(o.price)
+        book_hold = {bm: calculate_market_hold(prices) for bm, prices in book_prices.items()}
+
     spread: dict[str, dict[str, Any]] = {}
     for outcome_name, outcome_odds in outcomes.items():
         sharp_entry = sharp_by_outcome.get(outcome_name)
@@ -965,12 +999,18 @@ async def get_sharp_soft_spread(
             retail_price = bm_match[0].price
             retail_prob = round(calculate_implied_probability(retail_price), 6)
             divergence = round(retail_prob - sharp_prob, 6) if sharp_prob is not None else None
+            market_hold = (
+                round(book_hold[bm_key], 6)
+                if book_hold is not None and bm_key in book_hold
+                else None
+            )
             soft_prices.append(
                 {
                     "bookmaker": bm_key,
                     "price": retail_price,
                     "implied_prob": retail_prob,
                     "divergence": divergence,
+                    "market_hold": market_hold,
                 }
             )
 

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -53,9 +53,10 @@ _LEAGUE_SPEC_BY_NAME = LEAGUE_SPEC_BY_NAME
 # Hybrid sharp reference matching production defaults.
 # Duplicated from feature_extraction.py DEFAULT_SHARP_BOOKMAKERS with EPL-specific overrides — keep in sync.
 _DEFAULT_SHARP_BOOKMAKERS = ["pinnacle", "betfair_exchange"]
-# Used only by get_event_features for TabularFeatureExtractor. Must match whatever
-# retail set the deployed EPL model was trained on — today there is no deployed EPL
-# model, so this is a placeholder pending resolution of the "EPL predictions empty" TODO.
+# Used only by get_event_features for TabularFeatureExtractor. Distinct from
+# feature_extraction.DEFAULT_RETAIL_BOOKMAKERS (US books for the NBA model) — these are
+# UK books chosen to match the not-yet-deployed EPL model. When an EPL model ships, this
+# default must match whatever retail set it was trained on or features will silently drift.
 _DEFAULT_RETAIL_BOOKMAKERS = ["bet365", "betway", "betfred", "betvictor", "bwin"]
 
 

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -22,6 +22,7 @@ from odds_core.odds_math import calculate_implied_probability
 from odds_core.paper_trade_models import PaperTrade
 from odds_core.prediction_models import Prediction
 from odds_core.snapshot_utils import extract_odds_from_snapshot
+from odds_core.sports import SportKey
 from odds_lambda.jobs.fetch_oddsportal import LEAGUE_SPEC_BY_NAME
 from odds_lambda.paper_trading import (
     get_open_trades,
@@ -166,7 +167,7 @@ def _safe_float(val: Any) -> float | None:
 
 @mcp.tool()
 async def get_upcoming_fixtures(
-    league: str = "soccer_epl",
+    league: SportKey = "soccer_epl",
     days_ahead: int = 7,
 ) -> list[dict[str, Any]]:
     """Get upcoming scheduled fixtures for a league.
@@ -820,7 +821,7 @@ async def get_match_brief(
 
 @mcp.tool()
 async def get_slate_briefs(
-    league: str = "soccer_epl",
+    league: SportKey = "soccer_epl",
     days_ahead: int = 7,
 ) -> dict[str, Any]:
     """Get latest brief status for all upcoming fixtures in a league.
@@ -1028,7 +1029,7 @@ async def get_sharp_soft_spread(
 
 @mcp.tool()
 async def get_scheduled_jobs(
-    sport: str | None = None,
+    sport: SportKey | None = None,
 ) -> dict[str, Any]:
     """List all currently scheduled jobs from the scheduler backend.
 
@@ -1078,7 +1079,7 @@ async def get_scheduled_jobs(
 
 @mcp.tool()
 async def schedule_next_wakeup(
-    sport: str,
+    sport: SportKey,
     delay_hours: float,
     reason: str,
 ) -> dict[str, Any]:

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -13,7 +13,7 @@ import structlog
 from fastmcp import FastMCP
 from odds_analytics.backtesting import BacktestEvent
 from odds_analytics.feature_extraction import TabularFeatureExtractor
-from odds_analytics.utils import calculate_market_hold
+from odds_analytics.utils import per_book_market_holds
 from odds_core.agent_wakeup_models import AgentWakeup
 from odds_core.database import async_session_maker
 from odds_core.match_brief_models import BriefDecision, MatchBrief, SharpPriceMap
@@ -71,10 +71,13 @@ def _coerce_bookmaker_list(value: str | list[str] | None) -> list[str] | None:
     if stripped.startswith("["):
         try:
             parsed = json.loads(stripped)
-        except json.JSONDecodeError:
-            parsed = None
-        if isinstance(parsed, list):
-            return [str(item) for item in parsed]
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Malformed JSON array in bookmaker list: {stripped!r}") from e
+        if not isinstance(parsed, list):
+            raise ValueError(
+                f"Expected JSON array for bookmaker list, got {type(parsed).__name__}: {stripped!r}"
+            )
+        return [str(item) for item in parsed]
     return [item.strip() for item in stripped.split(",") if item.strip()]
 
 
@@ -964,10 +967,10 @@ async def get_sharp_soft_spread(
     # span multiple lines, so computing it event-wide would conflate them.
     book_hold: dict[str, float] | None = None
     if market in ("h2h", "1x2"):
-        book_prices: dict[str, list[int]] = {}
-        for o in odds:
-            book_prices.setdefault(o.bookmaker_key, []).append(o.price)
-        book_hold = {bm: calculate_market_hold(prices) for bm, prices in book_prices.items()}
+        book_hold = per_book_market_holds(
+            ((o.bookmaker_key, o.outcome_name, o.price) for o in odds),
+            required_outcomes=outcomes.keys(),
+        )
 
     spread: dict[str, dict[str, Any]] = {}
     for outcome_name, outcome_odds in outcomes.items():

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -616,3 +616,165 @@ class TestPaperBetValidation:
             )
             assert "error" in result
             assert "nonexistent" in result["error"]
+
+
+class TestGetSharpSoftSpreadMarketHold:
+    """Regression tests for per-book ``market_hold`` in ``get_sharp_soft_spread``."""
+
+    def _make_event(self) -> MagicMock:
+        event = MagicMock(spec=Event)
+        event.id = "evt-1"
+        event.sport_key = "soccer_epl"
+        event.sport_title = "EPL"
+        event.home_team = "Arsenal"
+        event.away_team = "Chelsea"
+        event.commence_time = datetime(2026, 4, 12, 15, 0, tzinfo=UTC)
+        event.status = EventStatus.SCHEDULED
+        event.home_score = None
+        event.away_score = None
+        event.completed_at = None
+        return event
+
+    def _make_odds(self, bookmaker: str, outcome: str, price: int) -> MagicMock:
+        o = MagicMock()
+        o.bookmaker_key = bookmaker
+        o.bookmaker_title = bookmaker
+        o.market_key = "h2h"
+        o.outcome_name = outcome
+        o.price = price
+        o.point = None
+        return o
+
+    def _make_snapshot(self) -> MagicMock:
+        snap = MagicMock()
+        snap.id = 1
+        snap.snapshot_time = datetime(2026, 4, 12, 10, 0, tzinfo=UTC)
+        return snap
+
+    def _make_sharp_result(self) -> MagicMock:
+        from odds_core.match_brief_models import SharpPriceMeta
+
+        result = MagicMock()
+        result.prices = {
+            "Arsenal": {"bookmaker": "pinnacle", "price": -110, "implied_prob": 0.524},
+            "Chelsea": {"bookmaker": "pinnacle", "price": -110, "implied_prob": 0.524},
+        }
+        result.meta = {
+            "Arsenal": SharpPriceMeta(
+                snapshot_id=1,
+                snapshot_time=datetime(2026, 4, 12, 10, 0, tzinfo=UTC),
+                age_seconds=0.0,
+            ),
+            "Chelsea": SharpPriceMeta(
+                snapshot_id=1,
+                snapshot_time=datetime(2026, 4, 12, 10, 0, tzinfo=UTC),
+                age_seconds=0.0,
+            ),
+        }
+        return result
+
+    def _mock_reader(self) -> AsyncMock:
+        reader = AsyncMock()
+        reader.get_event_by_id = AsyncMock(return_value=self._make_event())
+        reader.get_latest_snapshot = AsyncMock(return_value=self._make_snapshot())
+        reader.get_sharp_prices = AsyncMock(return_value=self._make_sharp_result())
+        return reader
+
+    @pytest.mark.asyncio
+    async def test_h2h_populates_market_hold(self) -> None:
+        from odds_mcp.server import get_sharp_soft_spread
+
+        odds = [
+            self._make_odds("pinnacle", "Arsenal", -110),
+            self._make_odds("pinnacle", "Chelsea", -110),
+            self._make_odds("bet365", "Arsenal", -105),
+            self._make_odds("bet365", "Chelsea", -115),
+        ]
+        reader = self._mock_reader()
+
+        with (
+            patch("odds_mcp.server.async_session_maker") as mock_session_maker,
+            patch("odds_mcp.server.OddsReader", return_value=reader),
+            patch("odds_mcp.server.extract_odds_from_snapshot", return_value=odds),
+        ):
+            mock_session_maker.return_value.__aenter__ = AsyncMock()
+            mock_session_maker.return_value.__aexit__ = AsyncMock()
+
+            result = await get_sharp_soft_spread(event_id="evt-1", market="h2h")
+
+        bet365_entries = [
+            soft
+            for outcome in result["spread"].values()
+            for soft in outcome["soft"]
+            if soft["bookmaker"] == "bet365"
+        ]
+        assert len(bet365_entries) == 2
+        for entry in bet365_entries:
+            assert entry["market_hold"] is not None
+            assert isinstance(entry["market_hold"], float)
+
+    @pytest.mark.asyncio
+    async def test_partial_outcome_book_gets_no_market_hold(self) -> None:
+        from odds_mcp.server import get_sharp_soft_spread
+
+        odds = [
+            self._make_odds("pinnacle", "Arsenal", -110),
+            self._make_odds("pinnacle", "Chelsea", -110),
+            self._make_odds("bet365", "Arsenal", -105),
+            self._make_odds("bet365", "Chelsea", -115),
+            # partial book missing "Chelsea" — must not report a misleading hold
+            self._make_odds("partial_book", "Arsenal", -110),
+        ]
+        reader = self._mock_reader()
+
+        with (
+            patch("odds_mcp.server.async_session_maker") as mock_session_maker,
+            patch("odds_mcp.server.OddsReader", return_value=reader),
+            patch("odds_mcp.server.extract_odds_from_snapshot", return_value=odds),
+        ):
+            mock_session_maker.return_value.__aenter__ = AsyncMock()
+            mock_session_maker.return_value.__aexit__ = AsyncMock()
+
+            result = await get_sharp_soft_spread(event_id="evt-1", market="h2h")
+
+        for outcome in result["spread"].values():
+            for soft in outcome["soft"]:
+                if soft["bookmaker"] == "partial_book":
+                    assert soft["market_hold"] is None
+
+    @pytest.mark.asyncio
+    async def test_totals_market_hold_none(self) -> None:
+        from odds_mcp.server import get_sharp_soft_spread
+
+        odds = [
+            self._make_odds("pinnacle", "Over", -110),
+            self._make_odds("pinnacle", "Under", -110),
+            self._make_odds("bet365", "Over", -105),
+            self._make_odds("bet365", "Under", -115),
+        ]
+        for o in odds:
+            o.market_key = "totals"
+            o.point = 2.5
+
+        reader = self._mock_reader()
+        sharp_result = MagicMock()
+        sharp_result.prices = {
+            "Over": {"bookmaker": "pinnacle", "price": -110, "implied_prob": 0.524},
+            "Under": {"bookmaker": "pinnacle", "price": -110, "implied_prob": 0.524},
+        }
+        sharp_result.meta = {}
+        reader.get_sharp_prices = AsyncMock(return_value=sharp_result)
+
+        with (
+            patch("odds_mcp.server.async_session_maker") as mock_session_maker,
+            patch("odds_mcp.server.OddsReader", return_value=reader),
+            patch("odds_mcp.server.extract_odds_from_snapshot", return_value=odds),
+        ):
+            mock_session_maker.return_value.__aenter__ = AsyncMock()
+            mock_session_maker.return_value.__aexit__ = AsyncMock()
+
+            result = await get_sharp_soft_spread(event_id="evt-1", market="totals")
+
+        for outcome in result["spread"].values():
+            for soft in outcome["soft"]:
+                assert soft["market_hold"] is None

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -8,6 +8,61 @@ from odds_core.models import Event, EventStatus, OddsSnapshot
 from odds_core.paper_trade_models import PaperTrade, TradeResult
 
 
+class TestCoerceBookmakerList:
+    def test_none_passthrough(self) -> None:
+        from odds_mcp.server import _coerce_bookmaker_list
+
+        assert _coerce_bookmaker_list(None) is None
+
+    def test_list_passthrough(self) -> None:
+        from odds_mcp.server import _coerce_bookmaker_list
+
+        assert _coerce_bookmaker_list(["bet365", "betway"]) == ["bet365", "betway"]
+
+    def test_empty_string_becomes_none(self) -> None:
+        from odds_mcp.server import _coerce_bookmaker_list
+
+        assert _coerce_bookmaker_list("") is None
+        assert _coerce_bookmaker_list("   ") is None
+
+    def test_json_array_string(self) -> None:
+        from odds_mcp.server import _coerce_bookmaker_list
+
+        assert _coerce_bookmaker_list('["bet365", "betway"]') == ["bet365", "betway"]
+
+    def test_json_array_with_whitespace(self) -> None:
+        from odds_mcp.server import _coerce_bookmaker_list
+
+        assert _coerce_bookmaker_list('  ["pinnacle", "betfair_exchange"]  ') == [
+            "pinnacle",
+            "betfair_exchange",
+        ]
+
+    def test_comma_separated_string(self) -> None:
+        from odds_mcp.server import _coerce_bookmaker_list
+
+        assert _coerce_bookmaker_list("bet365,betway,betfred") == ["bet365", "betway", "betfred"]
+
+    def test_comma_separated_with_whitespace(self) -> None:
+        from odds_mcp.server import _coerce_bookmaker_list
+
+        assert _coerce_bookmaker_list("bet365, betway , betfred") == [
+            "bet365",
+            "betway",
+            "betfred",
+        ]
+
+    def test_single_value_string(self) -> None:
+        from odds_mcp.server import _coerce_bookmaker_list
+
+        assert _coerce_bookmaker_list("pinnacle") == ["pinnacle"]
+
+    def test_malformed_json_falls_back_to_comma_split(self) -> None:
+        from odds_mcp.server import _coerce_bookmaker_list
+
+        assert _coerce_bookmaker_list("[bet365, betway") == ["[bet365", "betway"]
+
+
 class TestEventToDict:
     def _make_event(self, **overrides: object) -> Event:
         defaults = {

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -57,10 +57,11 @@ class TestCoerceBookmakerList:
 
         assert _coerce_bookmaker_list("pinnacle") == ["pinnacle"]
 
-    def test_malformed_json_falls_back_to_comma_split(self) -> None:
+    def test_malformed_json_raises(self) -> None:
         from odds_mcp.server import _coerce_bookmaker_list
 
-        assert _coerce_bookmaker_list("[bet365, betway") == ["[bet365", "betway"]
+        with pytest.raises(ValueError, match="Malformed JSON array"):
+            _coerce_bookmaker_list("[bet365, betway")
 
 
 class TestEventToDict:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -10,6 +10,7 @@ from odds_analytics.utils import (
     calculate_sharpe_ratio,
     calculate_sortino_ratio,
     detect_arbitrage,
+    per_book_market_holds,
 )
 from odds_core.odds_math import (
     american_to_decimal,
@@ -266,6 +267,34 @@ class TestMarketHold:
         hold = calculate_market_hold([+120, +200, +350])
         # Should have positive hold
         assert hold > 0
+
+
+class TestPerBookMarketHolds:
+    def test_complete_books_included(self):
+        prices = [
+            ("bet365", "home", -110),
+            ("bet365", "away", -110),
+            ("betfred", "home", -105),
+            ("betfred", "away", -115),
+        ]
+        holds = per_book_market_holds(prices, required_outcomes={"home", "away"})
+        assert set(holds) == {"bet365", "betfred"}
+        assert holds["bet365"] == pytest.approx(0.048, rel=0.01)
+
+    def test_book_missing_outcome_skipped(self):
+        prices = [
+            ("bet365", "home", -110),
+            ("bet365", "draw", +250),
+            ("bet365", "away", +280),
+            ("partial", "home", -110),
+            ("partial", "draw", +250),
+        ]
+        holds = per_book_market_holds(prices, required_outcomes={"home", "draw", "away"})
+        assert "partial" not in holds
+        assert "bet365" in holds
+
+    def test_empty_input(self):
+        assert per_book_market_holds([], required_outcomes={"home", "away"}) == {}
 
 
 class TestArbitrageDetection:


### PR DESCRIPTION
## Summary
- Coerce stringified array params in MCP tool inputs (workaround for anthropics/claude-code#22394 — Claude Code's MCP client serialises arrays as JSON strings). Helper accepts JSON-array strings and comma-separated strings; remove once upstream is fixed.
- `get_sharp_soft_spread` now returns every non-sharp book in the snapshot with per-book `market_hold` (computed via existing `calculate_market_hold`), dropping the arbitrary 5-book default. `retail_bookmakers` param removed from both `get_sharp_soft_spread` and `get_event_features`.
- New `odds_core.sports.SportKey` literal applied to four MCP tool signatures (`get_upcoming_fixtures`, `get_slate_briefs`, `get_scheduled_jobs`, `schedule_next_wakeup`) so typos like `sport='mlb'` fail validation instead of silently scheduling nothing.
- Agent parallelism guidance updated to dispatch the new user-level `web-research` subagent (which has `WebSearch`/`WebFetch`) instead of `general-purpose`.

## Test plan
- [x] `uv run pytest tests/unit/test_mcp_server.py` — 33 passed (includes new `TestCoerceBookmakerList`)
- [x] `uv run ruff check` / `uv run ruff format` clean
- [x] Reconnect `/mcp` in Claude Code and verify `get_sharp_soft_spread` / `get_event_features` accept list inputs end-to-end — both return full per-book `market_hold` output on Chelsea vs Man Utd 1x2
- [x] Verify an invalid sport key (e.g. `sport='mlb'`) is now rejected by the MCP validation layer — returns `literal_error: Input should be 'soccer_epl' or 'baseball_mlb'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)