### PR TITLE
Fix 920aee156d9c migration: cast raw_data to jsonb

### DIFF
--- a/migrations/versions/920aee156d9c_relabel_1x2_market_key_from_h2h_to_1x2.py
+++ b/migrations/versions/920aee156d9c_relabel_1x2_market_key_from_h2h_to_1x2.py
@@ -37,11 +37,14 @@ def upgrade() -> None:
     # Step 2: Update raw_data JSON in odds_snapshots — replace "h2h" with
     # "1x2" in any bookmaker market entry that contains a Draw outcome.
     # Uses jsonb_set on each matching market object.
+    # raw_data is stored as json (not jsonb); cast to jsonb at entry so
+    # jsonb_array_elements / jsonb_set work. Assignment back to the json
+    # column is implicit (Postgres converts via text).
     op.execute("""
         UPDATE odds_snapshots
         SET raw_data = (
             SELECT jsonb_set(
-                raw_data,
+                raw_data::jsonb,
                 '{bookmakers}',
                 (
                     SELECT jsonb_agg(
@@ -72,14 +75,14 @@ def upgrade() -> None:
                             ELSE bk
                         END
                     )
-                    FROM jsonb_array_elements(raw_data->'bookmakers') AS bk
+                    FROM jsonb_array_elements(raw_data::jsonb->'bookmakers') AS bk
                 )
             )
         )
         WHERE id IN (
             SELECT s.id
             FROM odds_snapshots s,
-                 jsonb_array_elements(s.raw_data->'bookmakers') AS bk,
+                 jsonb_array_elements(s.raw_data::jsonb->'bookmakers') AS bk,
                  jsonb_array_elements(bk->'markets') AS m,
                  jsonb_array_elements(m->'outcomes') AS outcome
             WHERE m->>'key' = 'h2h'
@@ -97,11 +100,14 @@ def downgrade() -> None:
     """)
 
     # Reverse: patch raw_data JSON back
+    # raw_data is stored as json (not jsonb); cast to jsonb at entry so
+    # jsonb_array_elements / jsonb_set work. Assignment back to the json
+    # column is implicit (Postgres converts via text).
     op.execute("""
         UPDATE odds_snapshots
         SET raw_data = (
             SELECT jsonb_set(
-                raw_data,
+                raw_data::jsonb,
                 '{bookmakers}',
                 (
                     SELECT jsonb_agg(
@@ -120,14 +126,14 @@ def downgrade() -> None:
                             )
                         )
                     )
-                    FROM jsonb_array_elements(raw_data->'bookmakers') AS bk
+                    FROM jsonb_array_elements(raw_data::jsonb->'bookmakers') AS bk
                 )
             )
         )
         WHERE id IN (
             SELECT s.id
             FROM odds_snapshots s,
-                 jsonb_array_elements(s.raw_data->'bookmakers') AS bk,
+                 jsonb_array_elements(s.raw_data::jsonb->'bookmakers') AS bk,
                  jsonb_array_elements(bk->'markets') AS m
             WHERE m->>'key' = '1x2'
         )


### PR DESCRIPTION
## Summary
- Dev deploy has been failing on every push for days with `function jsonb_array_elements(json) does not exist`.
- Root cause: `odds_snapshots.raw_data` is `json`, not `jsonb` (see `packages/odds-core/odds_core/models.py` — `Column(JSON)`). The `->` operator on `json` returns `json`, which `jsonb_array_elements` rejects.
- Fix: cast `raw_data::jsonb` at the entry of each `jsonb_array_elements(raw_data->'bookmakers')`. Every inner `jsonb_array_elements(bk->'markets')` / `m->'outcomes')` is already safe because `bk` and `m` originate from `jsonb_array_elements` (jsonb-typed). Assignment of the `jsonb_set` result back to the `json` column happens implicitly (Postgres converts via text).
- Editing in place is safe — the migration has never completed anywhere it's been attempted, so no environment has partial state. The fixed version is still idempotent via the alembic version table if some environment does have it stamped.

## Verification
- Reproduced the bug locally against the `json` column:
  `SELECT jsonb_array_elements(raw_data->'bookmakers') FROM odds_snapshots LIMIT 1;`
  → `ERROR:  function jsonb_array_elements(json) does not exist`.
- Confirmed fix parses and executes: same query with `raw_data::jsonb` returns rows.
- Full chain downgrade is blocked because `cc937c8cd362.downgrade()` raises `NotImplementedError`, so fell back to running both the fixed `upgrade()` and `downgrade()` SQL bodies manually inside `BEGIN; … ROLLBACK;` transactions on the local DB.
  - `downgrade` path: ran against real rows where `m->>'key' = '1x2'`. `UPDATE` succeeded; post-update the sampled row's market keys are `h2h` (0× `1x2`, 19× `h2h`).
  - `upgrade` path: inserted a synthetic snapshot with `{key: h2h, outcomes: [..., Draw, ...]}` against an existing event id, ran the fixed SQL, confirmed `raw_data` was rewritten to `{key: 1x2, ...}` while preserving the `Draw` outcome, then rolled back.
- `uv run ruff check --fix` and `uv run ruff format` pass (unchanged — no new lint issues).

## Concerns
- Not able to do a full `alembic downgrade` → `alembic upgrade head` chain test because `cc937c8cd362` has no reversible `downgrade()`. The manual transactional check covers both SQL statements and is sufficient given the fix is a narrow cast.
- Dev/prod stamping: I have no visibility into whether prod successfully applied this migration against a `jsonb` column variant. The model is authoritative (`Column(JSON)`), and the task notes that every dev deploy has failed for days, so it's safe to assume no environment has partial state. If prod is somehow stamped at `920aee156d9c` already, the fixed migration won't re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)