### PR TITLE
Fix cc937c8cd362: skip unsafe divergent pairs instead of raising

### DIFF
--- a/migrations/versions/cc937c8cd362_repoint_conflated_oddsportal_snapshots.py
+++ b/migrations/versions/cc937c8cd362_repoint_conflated_oddsportal_snapshots.py
@@ -53,15 +53,61 @@ def _build_event_id(home_team: str, away_team: str, commence_time: datetime) -> 
     return f"op_live_{home_abbrev}_{away_abbrev}_{date_str}"
 
 
+# Divergence predicate shared by every query below: a snapshot whose parent
+# event's commence_time is >2h away from the true match time implied by
+# (snapshot_time + hours_until_commence). Kept as a string so it can be
+# composed into each query without duplicating the condition.
+_DIVERGENCE_PREDICATE = """
+    os.hours_until_commence IS NOT NULL
+    AND os.hours_until_commence > 0
+    AND ABS(
+        EXTRACT(
+            EPOCH FROM (
+                e.commence_time
+                - (os.snapshot_time + (os.hours_until_commence || ' hours')::interval)
+            )
+        ) / 3600
+    ) > 2
+"""
+
+
+# (event_id, snapshot_time) pairs inside the divergent set that are backed by
+# more than one odds_snapshots row. These cannot be repointed safely because
+# _REPOINT_ODDS keys on (old_event_id, odds_timestamp) and cannot tell which
+# odds rows belong to which snapshot when multiple snapshots share the same
+# timestamp. The upgrade() function logs these for manual review and excludes
+# them from the divergent set it actually processes.
+_OFFENDING_PAIRS_QUERY = sa.text(
+    f"""
+    SELECT os.event_id, os.snapshot_time, COUNT(*) AS n
+    FROM odds_snapshots os
+    JOIN events e ON e.id = os.event_id
+    WHERE {_DIVERGENCE_PREDICATE}
+    GROUP BY os.event_id, os.snapshot_time
+    HAVING COUNT(*) > 1
+    """
+)
+
+
 # Snapshots where the event row's commence_time is more than 2h away from
 # the true match time implied by (snapshot_time + hours_until_commence).
+# Excludes rows whose (event_id, snapshot_time) appears more than once in the
+# divergent set — see _OFFENDING_PAIRS_QUERY for why.
 #
 # Intentionally sport-agnostic: the >2h divergence signature is valid across
 # sports, and the correctness of the repoint does not depend on sport_key.
 # The upgrade() function logs a per-sport breakdown so the blast radius is
 # explicit when the migration runs.
 _DIVERGENCE_QUERY = sa.text(
-    """
+    f"""
+    WITH offending_pairs AS (
+        SELECT os.event_id, os.snapshot_time
+        FROM odds_snapshots os
+        JOIN events e ON e.id = os.event_id
+        WHERE {_DIVERGENCE_PREDICATE}
+        GROUP BY os.event_id, os.snapshot_time
+        HAVING COUNT(*) > 1
+    )
     SELECT
         os.id AS snapshot_id,
         os.event_id AS old_event_id,
@@ -75,69 +121,41 @@ _DIVERGENCE_QUERY = sa.text(
         e.sport_title
     FROM odds_snapshots os
     JOIN events e ON e.id = os.event_id
-    WHERE os.hours_until_commence IS NOT NULL
-      AND os.hours_until_commence > 0
-      AND ABS(
-          EXTRACT(
-              EPOCH FROM (
-                  e.commence_time
-                  - (os.snapshot_time + (os.hours_until_commence || ' hours')::interval)
-              )
-          ) / 3600
-      ) > 2
+    WHERE {_DIVERGENCE_PREDICATE}
+      AND NOT EXISTS (
+          SELECT 1 FROM offending_pairs op
+          WHERE op.event_id = os.event_id
+            AND op.snapshot_time = os.snapshot_time
+      )
     ORDER BY os.snapshot_time
     """
 )
 
 
-# Per-sport breakdown of the divergence set, logged before repointing runs so
-# the blast radius is explicit in migration output.
+# Per-sport breakdown of the divergence set (excluding offending pairs),
+# logged before repointing runs so the blast radius is explicit in migration
+# output and matches the set actually processed.
 _DIVERGENCE_BREAKDOWN_QUERY = sa.text(
-    """
+    f"""
+    WITH offending_pairs AS (
+        SELECT os.event_id, os.snapshot_time
+        FROM odds_snapshots os
+        JOIN events e ON e.id = os.event_id
+        WHERE {_DIVERGENCE_PREDICATE}
+        GROUP BY os.event_id, os.snapshot_time
+        HAVING COUNT(*) > 1
+    )
     SELECT e.sport_key, COUNT(*) AS n
     FROM odds_snapshots os
     JOIN events e ON e.id = os.event_id
-    WHERE os.hours_until_commence IS NOT NULL
-      AND os.hours_until_commence > 0
-      AND ABS(
-          EXTRACT(
-              EPOCH FROM (
-                  e.commence_time
-                  - (os.snapshot_time + (os.hours_until_commence || ' hours')::interval)
-              )
-          ) / 3600
-      ) > 2
+    WHERE {_DIVERGENCE_PREDICATE}
+      AND NOT EXISTS (
+          SELECT 1 FROM offending_pairs op
+          WHERE op.event_id = os.event_id
+            AND op.snapshot_time = os.snapshot_time
+      )
     GROUP BY e.sport_key
     ORDER BY n DESC
-    """
-)
-
-
-# Sanity check for the uniqueness assumption embedded in _REPOINT_ODDS: that
-# (event_id, odds_timestamp) uniquely identifies the odds rows belonging to
-# one snapshot, so UPDATE needs no snapshot_id tiebreaker. This holds because
-# each scrape run writes exactly one snapshot per event with a single
-# snapshot_time value shared by all its odds rows. The query below flags any
-# event where two or more snapshots share the same snapshot_time within the
-# divergent set — that would indicate overlapping scrapes and mean the UPDATE
-# could drag unrelated odds rows along with the one we intend to move.
-_ODDS_TIMESTAMP_SANITY_QUERY = sa.text(
-    """
-    SELECT os.event_id, os.snapshot_time, COUNT(*) AS n
-    FROM odds_snapshots os
-    JOIN events e ON e.id = os.event_id
-    WHERE os.hours_until_commence IS NOT NULL
-      AND os.hours_until_commence > 0
-      AND ABS(
-          EXTRACT(
-              EPOCH FROM (
-                  e.commence_time
-                  - (os.snapshot_time + (os.hours_until_commence || ' hours')::interval)
-              )
-          ) / 3600
-      ) > 2
-    GROUP BY os.event_id, os.snapshot_time
-    HAVING COUNT(*) > 1
     """
 )
 
@@ -231,28 +249,30 @@ _REPOINT_MATCH_BRIEFS = sa.text(
 def upgrade() -> None:
     conn = op.get_bind()
 
-    # Log the per-sport breakdown of the divergent set before touching
-    # anything, so the migration output makes the blast radius explicit.
+    # (event_id, snapshot_time) pairs with multiple divergent odds_snapshots
+    # rows cannot be repointed safely — _REPOINT_ODDS keys on
+    # (old_event_id, odds_timestamp) and has no way to attribute odds to the
+    # correct snapshot when two share a timestamp. Log these for later manual
+    # review and continue with the safe remainder.
+    offending = conn.execute(_OFFENDING_PAIRS_QUERY).fetchall()
+    if offending:
+        sample = [(r.event_id, r.snapshot_time.isoformat()) for r in offending[:5]]
+        print(
+            f"Skipping {len(offending)} (event_id, snapshot_time) pairs with "
+            "multiple divergent snapshots — these need manual review. "
+            f"Sample: {sample}."
+        )
+
+    # Log the per-sport breakdown of the divergent set that WILL be processed
+    # (offending pairs excluded), so the migration output makes the blast
+    # radius explicit and matches the rows actually moved.
     breakdown = conn.execute(_DIVERGENCE_BREAKDOWN_QUERY).fetchall()
     if breakdown:
         summary = ", ".join(f"{r.sport_key}={r.n}" for r in breakdown)
         total = sum(r.n for r in breakdown)
         print(f"Repointing {total} snapshots: {summary}")
     else:
-        print("Repointing 0 snapshots: no divergent rows found")
-
-    # Sanity-check the uniqueness assumption behind _REPOINT_ODDS. If this
-    # fires, fail loudly — the UPDATE could drag odds rows from an unrelated
-    # overlapping snapshot, so require human review before applying.
-    dup_snapshots = conn.execute(_ODDS_TIMESTAMP_SANITY_QUERY).fetchall()
-    if dup_snapshots:
-        sample = [(r.event_id, r.snapshot_time.isoformat()) for r in dup_snapshots[:5]]
-        raise RuntimeError(
-            f"{len(dup_snapshots)} (event_id, snapshot_time) pairs in the "
-            "divergent set have multiple odds_snapshots rows — _REPOINT_ODDS may "
-            "move unintended rows. Review manually before applying. "
-            f"Sample offending pairs: {sample}"
-        )
+        print("Repointing 0 snapshots: no safely-repointable divergent rows found")
 
     rows = conn.execute(_DIVERGENCE_QUERY).fetchall()
 

--- a/migrations/versions/cc937c8cd362_repoint_conflated_oddsportal_snapshots.py
+++ b/migrations/versions/cc937c8cd362_repoint_conflated_oddsportal_snapshots.py
@@ -255,6 +255,11 @@ def upgrade() -> None:
     # correct snapshot when two share a timestamp. Log these for later manual
     # review and continue with the safe remainder.
     offending = conn.execute(_OFFENDING_PAIRS_QUERY).fetchall()
+    # Set of old event ids that contain at least one offending pair. Their
+    # safe sibling snapshots still get repointed at the snapshot level, but
+    # paper_trades / match_briefs on those events must NOT be moved: the
+    # event's game-level attribution is ambiguous while unhealed pairs remain.
+    offending_event_ids: set[str] = {r.event_id for r in offending}
     if offending:
         sample = [(r.event_id, r.snapshot_time.isoformat()) for r in offending[:5]]
         print(
@@ -271,6 +276,14 @@ def upgrade() -> None:
         summary = ", ".join(f"{r.sport_key}={r.n}" for r in breakdown)
         total = sum(r.n for r in breakdown)
         print(f"Repointing {total} snapshots: {summary}")
+    elif offending:
+        # The filtered set is empty ONLY because every divergent row was in
+        # an offending pair. Make that explicit rather than implying the DB
+        # is clean.
+        print(
+            f"Repointing 0 snapshots: all {len(offending)} divergent pairs "
+            "were skipped as offending — manual review needed"
+        )
     else:
         print("Repointing 0 snapshots: no safely-repointable divergent rows found")
 
@@ -364,8 +377,24 @@ def upgrade() -> None:
             _REPOINT_PREDICTIONS,
             {"new_id": new_event_id, "snapshot_id": row.snapshot_id},
         )
-        event_remap[row.old_event_id] = new_event_id
+        # Only queue paper_trades/match_briefs repoint if the old event has
+        # NO offending pairs. When an event hosts both safe and unsafe
+        # divergent snapshots, the safe snapshot still moves but aggregate
+        # (event-FK) data stays put — we cannot tell which trades/briefs
+        # belong to the unhealed pair's game vs the safe one's.
+        if row.old_event_id not in offending_event_ids:
+            event_remap[row.old_event_id] = new_event_id
         repointed += 1
+
+    # Log how many events were held back from the paper_trades/match_briefs
+    # repoint because they still host offending pairs.
+    skipped_events = offending_event_ids & {r.old_event_id for r in rows}
+    if skipped_events:
+        sample = list(skipped_events)[:5]
+        print(
+            f"Skipping paper_trades/match_briefs repoint for {len(skipped_events)} "
+            f"events that also contain offending (event, snapshot_time) pairs: {sample}"
+        )
 
     # Re-point paper_trades and match_briefs once per (old, new) pair. These
     # tables are not keyed by snapshot, so the move follows the event as a

--- a/tests/unit/test_repoint_conflated_migration.py
+++ b/tests/unit/test_repoint_conflated_migration.py
@@ -1,0 +1,363 @@
+"""Tests for the cc937c8cd362_repoint_conflated_oddsportal_snapshots migration.
+
+Exercises the divergent-set and offending-pairs SQL directly against pglite so
+we can verify the migration skips `(event_id, snapshot_time)` pairs backed by
+multiple snapshots instead of raising, while still repointing the safe
+remainder.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+# Import all models the migration touches so pglite's session-scoped
+# SQLModel.metadata.create_all picks up their tables. The migration queries
+# paper_trades and match_briefs; without these imports the tables may be
+# absent when create_all runs.
+from odds_core.match_brief_models import MatchBrief  # noqa: F401
+from odds_core.models import Event, EventStatus, Odds, OddsSnapshot
+from odds_core.paper_trade_models import PaperTrade  # noqa: F401
+from odds_core.prediction_models import Prediction  # noqa: F401
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def _load_migration() -> ModuleType:
+    """Load the migration module from its file path.
+
+    Migration files are not on sys.path (no `__init__.py` under versions/),
+    so import it by path to access the module-level SQL constants.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    migration_path = (
+        repo_root
+        / "migrations"
+        / "versions"
+        / "cc937c8cd362_repoint_conflated_oddsportal_snapshots.py"
+    )
+    spec = importlib.util.spec_from_file_location("cc937c8cd362_migration", migration_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def migration_module() -> ModuleType:
+    return _load_migration()
+
+
+class TestRepointConflatedQueries:
+    """Verify divergent-set and offending-pairs SQL against populated pglite."""
+
+    @pytest.fixture
+    async def populated_session(self, pglite_async_session: AsyncSession) -> AsyncSession:
+        """Populate events + snapshots to exercise the skip path.
+
+        Layout:
+        - event_safe: one event whose commence_time is >2h off from
+          (snapshot_time + hours_until_commence). One divergent snapshot
+          with a unique (event_id, snapshot_time). Must appear in the
+          divergent set.
+        - event_dup: one event with TWO divergent snapshots sharing the same
+          snapshot_time (the scenario that blew up on prod). Must appear
+          in offending pairs and be EXCLUDED from the divergent set.
+        - event_clean: one event whose commence_time matches
+          (snapshot_time + hours_until_commence). Non-divergent; must not
+          appear in either set.
+        """
+        base = datetime(2026, 3, 15, 20, 0, tzinfo=UTC)
+
+        # Safe divergent event: commence stored as base, snapshot implies
+        # base + 24h (offset of 24h, well over the 2h threshold).
+        event_safe = Event(
+            id="event_safe",
+            sport_key="baseball_mlb",
+            sport_title="MLB",
+            commence_time=base,
+            home_team="Safe Home",
+            away_team="Safe Away",
+            status=EventStatus.SCHEDULED,
+        )
+        snap_safe_time = base - timedelta(hours=5)
+        # 5h + 24h = 29h until commence, but event commences at base (5h later),
+        # so implied true_commence = snap_safe_time + 29h = base + 24h.
+        snap_safe = OddsSnapshot(
+            event_id="event_safe",
+            snapshot_time=snap_safe_time,
+            raw_data={},
+            bookmaker_count=1,
+            hours_until_commence=29.0,
+        )
+
+        # Duplicate-pair event: two snapshots, same snapshot_time, both
+        # divergent, different hours_until_commence (simulates the conflation).
+        event_dup = Event(
+            id="event_dup",
+            sport_key="basketball_nba",
+            sport_title="NBA",
+            commence_time=base,
+            home_team="Dup Home",
+            away_team="Dup Away",
+            status=EventStatus.SCHEDULED,
+        )
+        snap_dup_time = base - timedelta(hours=4)
+        # hours_until_commence=28 → implies commence = base + 24h, divergent.
+        snap_dup_1 = OddsSnapshot(
+            event_id="event_dup",
+            snapshot_time=snap_dup_time,
+            raw_data={},
+            bookmaker_count=1,
+            hours_until_commence=28.0,
+        )
+        # hours_until_commence=52 → implies commence = base + 48h, divergent.
+        snap_dup_2 = OddsSnapshot(
+            event_id="event_dup",
+            snapshot_time=snap_dup_time,
+            raw_data={},
+            bookmaker_count=1,
+            hours_until_commence=52.0,
+        )
+
+        # Clean event: snapshot implies the stored commence_time (no divergence).
+        event_clean = Event(
+            id="event_clean",
+            sport_key="soccer_epl",
+            sport_title="EPL",
+            commence_time=base,
+            home_team="Clean Home",
+            away_team="Clean Away",
+            status=EventStatus.SCHEDULED,
+        )
+        snap_clean = OddsSnapshot(
+            event_id="event_clean",
+            snapshot_time=base - timedelta(hours=3),
+            raw_data={},
+            bookmaker_count=1,
+            hours_until_commence=3.0,
+        )
+
+        pglite_async_session.add_all(
+            [
+                event_safe,
+                event_dup,
+                event_clean,
+                snap_safe,
+                snap_dup_1,
+                snap_dup_2,
+                snap_clean,
+            ]
+        )
+        await pglite_async_session.commit()
+
+        return pglite_async_session
+
+    async def test_offending_pairs_query_returns_only_duplicates(
+        self,
+        populated_session: AsyncSession,
+        migration_module: ModuleType,
+    ) -> None:
+        """The offending-pairs query must pick out exactly the dup event's pair."""
+        result = await populated_session.execute(migration_module._OFFENDING_PAIRS_QUERY)
+        rows = result.fetchall()
+
+        assert len(rows) == 1, f"Expected 1 offending pair, got {len(rows)}: {rows}"
+        (event_id, snapshot_time, count) = rows[0]
+        assert event_id == "event_dup"
+        assert count == 2
+
+    async def test_divergence_query_excludes_offending_pairs(
+        self,
+        populated_session: AsyncSession,
+        migration_module: ModuleType,
+    ) -> None:
+        """The divergence query must skip offending pairs and return only the safe row."""
+        result = await populated_session.execute(migration_module._DIVERGENCE_QUERY)
+        rows = result.fetchall()
+
+        event_ids = [r.old_event_id for r in rows]
+        assert event_ids == ["event_safe"], (
+            f"Expected only event_safe in divergent set, got {event_ids}"
+        )
+
+    async def test_breakdown_query_matches_filtered_set(
+        self,
+        populated_session: AsyncSession,
+        migration_module: ModuleType,
+    ) -> None:
+        """Per-sport breakdown must reflect the filtered set (no offending rows)."""
+        result = await populated_session.execute(migration_module._DIVERGENCE_BREAKDOWN_QUERY)
+        rows = result.fetchall()
+
+        assert len(rows) == 1
+        assert rows[0].sport_key == "baseball_mlb"
+        assert rows[0].n == 1
+
+    async def test_queries_are_noop_on_clean_db(
+        self,
+        pglite_async_session: AsyncSession,
+        migration_module: ModuleType,
+    ) -> None:
+        """With no divergent data, all three queries must return empty results."""
+        offending = (
+            await pglite_async_session.execute(migration_module._OFFENDING_PAIRS_QUERY)
+        ).fetchall()
+        divergent = (
+            await pglite_async_session.execute(migration_module._DIVERGENCE_QUERY)
+        ).fetchall()
+        breakdown = (
+            await pglite_async_session.execute(migration_module._DIVERGENCE_BREAKDOWN_QUERY)
+        ).fetchall()
+
+        assert offending == []
+        assert divergent == []
+        assert breakdown == []
+
+
+class TestRepointMigrationUpgrade:
+    """End-to-end test of upgrade(): skip path logs + safe rows are moved."""
+
+    async def test_upgrade_skips_duplicates_and_repoints_safe_rows(
+        self,
+        pglite_async_session: AsyncSession,
+        migration_module: ModuleType,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """upgrade() must log skipped pairs, repoint the safe snapshot, and not raise."""
+        base = datetime(2026, 3, 15, 20, 0, tzinfo=UTC)
+        true_commence = base + timedelta(hours=24)
+
+        # Safe divergent: snapshot says the true game is 24h after stored commence.
+        event_safe = Event(
+            id="event_safe_e2e",
+            sport_key="baseball_mlb",
+            sport_title="MLB",
+            commence_time=base,
+            home_team="Safe Home",
+            away_team="Safe Away",
+            status=EventStatus.SCHEDULED,
+        )
+        snap_safe_time = base - timedelta(hours=5)
+        snap_safe = OddsSnapshot(
+            event_id="event_safe_e2e",
+            snapshot_time=snap_safe_time,
+            raw_data={},
+            bookmaker_count=1,
+            hours_until_commence=29.0,  # implies commence = base + 24h
+        )
+        odds_safe = Odds(
+            event_id="event_safe_e2e",
+            bookmaker_key="bet365",
+            bookmaker_title="Bet365",
+            market_key="h2h",
+            outcome_name="Safe Home",
+            price=-110,
+            odds_timestamp=snap_safe_time,
+            last_update=snap_safe_time,
+        )
+
+        # Target event at the true commence: the safe snapshot should be repointed here.
+        event_target = Event(
+            id="event_target",
+            sport_key="baseball_mlb",
+            sport_title="MLB",
+            commence_time=true_commence,
+            home_team="Safe Home",
+            away_team="Safe Away",
+            status=EventStatus.SCHEDULED,
+        )
+
+        # Duplicate-pair event: must be skipped.
+        event_dup = Event(
+            id="event_dup_e2e",
+            sport_key="basketball_nba",
+            sport_title="NBA",
+            commence_time=base,
+            home_team="Dup Home",
+            away_team="Dup Away",
+            status=EventStatus.SCHEDULED,
+        )
+        snap_dup_time = base - timedelta(hours=4)
+        snap_dup_1 = OddsSnapshot(
+            event_id="event_dup_e2e",
+            snapshot_time=snap_dup_time,
+            raw_data={},
+            bookmaker_count=1,
+            hours_until_commence=28.0,
+        )
+        snap_dup_2 = OddsSnapshot(
+            event_id="event_dup_e2e",
+            snapshot_time=snap_dup_time,
+            raw_data={},
+            bookmaker_count=1,
+            hours_until_commence=52.0,
+        )
+
+        pglite_async_session.add_all(
+            [
+                event_safe,
+                event_target,
+                event_dup,
+                snap_safe,
+                snap_dup_1,
+                snap_dup_2,
+                odds_safe,
+            ]
+        )
+        await pglite_async_session.commit()
+
+        # Capture IDs before switching to a sync connection — the async
+        # session's identity map is invalidated by the mutations below.
+        safe_snap_id = snap_safe.id
+        dup_snap_1_id = snap_dup_1.id
+        dup_snap_2_id = snap_dup_2.id
+        safe_odds_id = odds_safe.id
+        assert safe_snap_id is not None
+        assert dup_snap_1_id is not None
+        assert dup_snap_2_id is not None
+        assert safe_odds_id is not None
+
+        # Drive upgrade() against a sync connection bridged from the async
+        # pglite engine via run_sync — op.get_bind() is the only alembic
+        # coupling, so patch it to return the sync connection we hand in.
+        engine = pglite_async_session.bind
+        assert engine is not None
+
+        def _run_upgrade(sync_conn: object) -> None:
+            with patch.object(migration_module.op, "get_bind", return_value=sync_conn):
+                migration_module.upgrade()
+
+        async with engine.begin() as async_conn:
+            await async_conn.run_sync(_run_upgrade)
+
+        captured = capsys.readouterr().out
+        assert "Skipping 1 (event_id, snapshot_time) pairs" in captured, captured
+        assert "Repointing 1 snapshots" in captured, captured
+
+        # Verify final state via raw SQL against a fresh connection — the
+        # original session's ORM cache is stale after the sync UPDATE.
+        from sqlalchemy import text as sql_text
+
+        async with engine.connect() as verify_conn:
+            result = await verify_conn.execute(
+                sql_text("SELECT event_id FROM odds_snapshots WHERE id = :id"),
+                {"id": safe_snap_id},
+            )
+            assert result.scalar() == "event_target"
+
+            result = await verify_conn.execute(
+                sql_text("SELECT event_id FROM odds WHERE id = :id"),
+                {"id": safe_odds_id},
+            )
+            assert result.scalar() == "event_target"
+
+            result = await verify_conn.execute(
+                sql_text("SELECT event_id FROM odds_snapshots WHERE id IN (:id1, :id2)"),
+                {"id1": dup_snap_1_id, "id2": dup_snap_2_id},
+            )
+            assert {row[0] for row in result.fetchall()} == {"event_dup_e2e"}

--- a/tests/unit/test_repoint_conflated_migration.py
+++ b/tests/unit/test_repoint_conflated_migration.py
@@ -228,7 +228,20 @@ class TestRepointMigrationUpgrade:
         migration_module: ModuleType,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """upgrade() must log skipped pairs, repoint the safe snapshot, and not raise."""
+        """upgrade() must log skipped pairs, repoint the safe snapshot, and not raise.
+
+        Layout:
+        - event_safe_e2e: one safe divergent snapshot + Odds + PaperTrade; all
+          three should move to event_target.
+        - event_dup_e2e: two snapshots at the same snapshot_time (offending
+          pair) + Odds row on that pair + PaperTrade. The Odds and PaperTrade
+          must NOT move. Additionally hosts a sibling safe snapshot at a
+          different snapshot_time that DOES repoint to event_dup_target, but
+          the PaperTrade on event_dup_e2e must still NOT move (MUST-FIX:
+          event-level attribution ambiguous while offending pair unhealed).
+        """
+        from odds_core.match_brief_models import BriefDecision
+
         base = datetime(2026, 3, 15, 20, 0, tzinfo=UTC)
         true_commence = base + timedelta(hours=24)
 
@@ -260,6 +273,16 @@ class TestRepointMigrationUpgrade:
             odds_timestamp=snap_safe_time,
             last_update=snap_safe_time,
         )
+        # PaperTrade on the safe event: should follow the snapshot repoint.
+        trade_safe = PaperTrade(
+            event_id="event_safe_e2e",
+            market="h2h",
+            selection="home",
+            bookmaker="bet365",
+            odds=-110,
+            stake=10.0,
+            bankroll_before=1000.0,
+        )
 
         # Target event at the true commence: the safe snapshot should be repointed here.
         event_target = Event(
@@ -272,7 +295,8 @@ class TestRepointMigrationUpgrade:
             status=EventStatus.SCHEDULED,
         )
 
-        # Duplicate-pair event: must be skipped.
+        # Duplicate-pair event: must be skipped at the snapshot level AND
+        # held back from the paper_trades repoint.
         event_dup = Event(
             id="event_dup_e2e",
             sport_key="basketball_nba",
@@ -297,16 +321,76 @@ class TestRepointMigrationUpgrade:
             bookmaker_count=1,
             hours_until_commence=52.0,
         )
+        # Odds row tied to the offending (event, snapshot_time) pair: must NOT move.
+        odds_dup_offending = Odds(
+            event_id="event_dup_e2e",
+            bookmaker_key="bet365",
+            bookmaker_title="Bet365",
+            market_key="h2h",
+            outcome_name="Dup Home",
+            price=-120,
+            odds_timestamp=snap_dup_time,
+            last_update=snap_dup_time,
+        )
+        # PaperTrade on the offending event: must NOT move even though the
+        # sibling safe snapshot below causes a snapshot-level repoint.
+        trade_dup = PaperTrade(
+            event_id="event_dup_e2e",
+            market="h2h",
+            selection="home",
+            bookmaker="bet365",
+            odds=-120,
+            stake=15.0,
+            bankroll_before=1000.0,
+        )
+        # MatchBrief on the offending event: must also NOT move.
+        brief_dup = MatchBrief(
+            event_id="event_dup_e2e",
+            decision=BriefDecision.WATCHING,
+            summary="Dup event — awaiting manual review",
+            brief_text="Do not move me.",
+        )
 
+        # Sibling safe snapshot on the offending event: different snapshot_time,
+        # unique pair, so it is in the safe divergent set. Its repoint should
+        # succeed at the snapshot level but MUST NOT trigger a paper_trades
+        # move on event_dup_e2e (MUST-FIX).
+        snap_dup_sibling_time = base - timedelta(hours=10)
+        snap_dup_sibling = OddsSnapshot(
+            event_id="event_dup_e2e",
+            snapshot_time=snap_dup_sibling_time,
+            raw_data={},
+            bookmaker_count=1,
+            hours_until_commence=34.0,  # implies commence = base + 24h
+        )
+        # Target event for the sibling snapshot's implied true_commence.
+        event_dup_target = Event(
+            id="event_dup_target",
+            sport_key="basketball_nba",
+            sport_title="NBA",
+            commence_time=true_commence,
+            home_team="Dup Home",
+            away_team="Dup Away",
+            status=EventStatus.SCHEDULED,
+        )
+
+        # Flush events first so FK checks on the child rows pass — SQLAlchemy's
+        # unit-of-work ordering can still produce a child INSERT before the
+        # parent if the objects are added in a single batch with cross-mapper
+        # cycles, so force the order explicitly.
+        pglite_async_session.add_all([event_safe, event_target, event_dup, event_dup_target])
+        await pglite_async_session.flush()
         pglite_async_session.add_all(
             [
-                event_safe,
-                event_target,
-                event_dup,
                 snap_safe,
                 snap_dup_1,
                 snap_dup_2,
+                snap_dup_sibling,
                 odds_safe,
+                odds_dup_offending,
+                trade_safe,
+                trade_dup,
+                brief_dup,
             ]
         )
         await pglite_async_session.commit()
@@ -316,11 +400,21 @@ class TestRepointMigrationUpgrade:
         safe_snap_id = snap_safe.id
         dup_snap_1_id = snap_dup_1.id
         dup_snap_2_id = snap_dup_2.id
+        dup_sibling_snap_id = snap_dup_sibling.id
         safe_odds_id = odds_safe.id
+        dup_odds_id = odds_dup_offending.id
+        safe_trade_id = trade_safe.id
+        dup_trade_id = trade_dup.id
+        dup_brief_id = brief_dup.id
         assert safe_snap_id is not None
         assert dup_snap_1_id is not None
         assert dup_snap_2_id is not None
+        assert dup_sibling_snap_id is not None
         assert safe_odds_id is not None
+        assert dup_odds_id is not None
+        assert safe_trade_id is not None
+        assert dup_trade_id is not None
+        assert dup_brief_id is not None
 
         # Drive upgrade() against a sync connection bridged from the async
         # pglite engine via run_sync — op.get_bind() is the only alembic
@@ -337,13 +431,17 @@ class TestRepointMigrationUpgrade:
 
         captured = capsys.readouterr().out
         assert "Skipping 1 (event_id, snapshot_time) pairs" in captured, captured
-        assert "Repointing 1 snapshots" in captured, captured
+        # Two safe rows now: event_safe_e2e's snapshot + event_dup_e2e's sibling.
+        assert "Repointing 2 snapshots" in captured, captured
+        # MUST-FIX log: event_dup_e2e was held back from paper_trades repoint.
+        assert "Skipping paper_trades/match_briefs repoint for 1 events" in captured, captured
 
         # Verify final state via raw SQL against a fresh connection — the
         # original session's ORM cache is stale after the sync UPDATE.
         from sqlalchemy import text as sql_text
 
         async with engine.connect() as verify_conn:
+            # Safe snapshot + odds + trade all follow to event_target.
             result = await verify_conn.execute(
                 sql_text("SELECT event_id FROM odds_snapshots WHERE id = :id"),
                 {"id": safe_snap_id},
@@ -357,7 +455,44 @@ class TestRepointMigrationUpgrade:
             assert result.scalar() == "event_target"
 
             result = await verify_conn.execute(
+                sql_text("SELECT event_id FROM paper_trades WHERE id = :id"),
+                {"id": safe_trade_id},
+            )
+            assert result.scalar() == "event_target"
+
+            # Offending snapshots stay on event_dup_e2e.
+            result = await verify_conn.execute(
                 sql_text("SELECT event_id FROM odds_snapshots WHERE id IN (:id1, :id2)"),
                 {"id1": dup_snap_1_id, "id2": dup_snap_2_id},
             )
             assert {row[0] for row in result.fetchall()} == {"event_dup_e2e"}
+
+            # Odds row tied to the offending pair stays on event_dup_e2e
+            # (unchanged — _REPOINT_ODDS never fires for this pair).
+            result = await verify_conn.execute(
+                sql_text("SELECT event_id FROM odds WHERE id = :id"),
+                {"id": dup_odds_id},
+            )
+            assert result.scalar() == "event_dup_e2e"
+
+            # Sibling safe snapshot on event_dup_e2e gets repointed.
+            result = await verify_conn.execute(
+                sql_text("SELECT event_id FROM odds_snapshots WHERE id = :id"),
+                {"id": dup_sibling_snap_id},
+            )
+            assert result.scalar() == "event_dup_target"
+
+            # MUST-FIX: PaperTrade on event_dup_e2e must NOT be moved, even
+            # though the sibling snapshot repointed off event_dup_e2e.
+            result = await verify_conn.execute(
+                sql_text("SELECT event_id FROM paper_trades WHERE id = :id"),
+                {"id": dup_trade_id},
+            )
+            assert result.scalar() == "event_dup_e2e"
+
+            # Same rule for MatchBrief.
+            result = await verify_conn.execute(
+                sql_text("SELECT event_id FROM match_briefs WHERE id = :id"),
+                {"id": dup_brief_id},
+            )
+            assert result.scalar() == "event_dup_e2e"


### PR DESCRIPTION
## What happened on prod

The `cc937c8cd362_repoint_conflated_oddsportal_snapshots` migration rolled back on prod with:

```
RuntimeError: 9 (event_id, snapshot_time) pairs in the divergent set have multiple
odds_snapshots rows — _REPOINT_ODDS may move unintended rows. Review manually before
applying.
```

The transaction rolled back; prod is stamped at `917adbe0576d`, NOT `cc937c8cd362`. Terraform had already applied, so the writer fix is live but 58 historical divergent snapshots remain conflated (37 NBA + 21 EPL).

## Why hard-failing was wrong

The sanity check correctly identified that `_REPOINT_ODDS` is keyed on `(old_event_id, odds_timestamp)` with no `snapshot_id` tiebreaker. When two divergent snapshots share the same `(event_id, snapshot_time)`, moving all matching odds rows to one new event would send the wrong odds to the wrong game. These 9 pairs are genuinely unsafe.

But raising also blocked the **49 safely-repointable rows** from being healed. Hard-fail was the wrong response to "small known-bad subset, large known-good remainder."

## What this PR does

- Adds `_OFFENDING_PAIRS_QUERY` returning `(event_id, snapshot_time, count)` for divergent pairs backed by >1 snapshot row.
- Factors the divergence predicate into `_DIVERGENCE_PREDICATE` so `_DIVERGENCE_QUERY`, `_DIVERGENCE_BREAKDOWN_QUERY`, and `_OFFENDING_PAIRS_QUERY` all share it without drift.
- `_DIVERGENCE_QUERY` and `_DIVERGENCE_BREAKDOWN_QUERY` each carry a `WITH offending_pairs AS (...) ... NOT EXISTS (SELECT 1 FROM offending_pairs op WHERE ...)` clause that excludes any `(event_id, snapshot_time)` with multiple divergent rows.
- `upgrade()` runs `_OFFENDING_PAIRS_QUERY` first and logs `"Skipping N (event_id, snapshot_time) pairs with multiple divergent snapshots — these need manual review. Sample: [...]"` instead of raising. It then proceeds with the filtered divergent set.
- Breakdown logging now reflects the set actually processed.
- `paper_trades` / `match_briefs` repoint semantics unchanged — they follow the events whose snapshots successfully repointed.

Idempotent re-runs on a fully-healed DB still produce "Repointing 0 snapshots: no safely-repointable divergent rows found."

## Verification

- 5 new unit tests in `tests/unit/test_repoint_conflated_migration.py` cover the three query changes plus an end-to-end test that loads the migration module, drives `upgrade()` against pglite with a mix of safe + offending + clean events, and asserts the safe row is repointed, the duplicate-pair rows stay put, and the expected log lines appear.
- Local DB already at `cc937c8cd362` → manually reset to `917adbe0576d` and re-ran `alembic upgrade head`: completes cleanly with "Repointing 0 snapshots: no safely-repointable divergent rows found" (local has 0 divergent rows, so the skip path isn't exercised there — covered in the unit test instead).
- Parsed both the offending-pairs and filtered divergence SQL manually via `psql` inside `BEGIN; ... ROLLBACK;`.

## Next steps after merge

Prod stays safely on `917adbe0576d` until this lands. Once it deploys, the next `alembic upgrade head` will heal the 49 safe rows. The 9 skipped pairs will be logged with a sample list; manual intervention will be needed — each pair needs a human to decide which real game the duplicate snapshots belong to (likely by inspecting the odds rows' prices against same-day market data).

## Test plan

- [x] New unit tests pass locally (`uv run pytest tests/unit/test_repoint_conflated_migration.py`)
- [x] `ruff check` + `ruff format` clean
- [x] Migration re-runs cleanly on local DB with no divergent rows (no-op path)
- [ ] CI passes