### PR TITLE
Bump Terraform 1.6.0 -> 1.9.8 to fix expired HashiCorp GPG key

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.6.0"
+          terraform_version: "1.9.8"
 
       - name: Build and push Lambda container image
         id: build-image

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.6.0"
+          terraform_version: "1.9.8"
 
       - name: Build and push Lambda container image
         id: build-image


### PR DESCRIPTION
## Summary

Dev deploy on main (run 24657989184, triggered by #338 merge) failed with:

\`\`\`
Error while installing hashicorp/aws v5.100.0: error checking signature:
openpgp: key expired
\`\`\`

The cascading \"Inconsistent dependency lock file\" error is misleading — the lock file at \`deployment/aws/terraform/.terraform.lock.hcl\` is fine (AWS provider pinned at 5.100.0, correct hashes). Installation aborts on signature check before the version selection is written back to the lock file, which then looks empty/inconsistent on the next check.

## Root cause

HashiCorp rotated the GPG key used to sign provider releases. Terraform 1.6.0 (Oct 2023) ships with the old trust store and rejects the new signature. 1.9.x carries the current keys.

## Fix

Bump \`terraform_version\` from \`\"1.6.0\"\` to \`\"1.9.8\"\` in both \`deploy-dev.yml\` and \`deploy-prod.yml\` for consistency.

## Test plan

- [ ] Dev deploy on this branch completes through Terraform Init + Apply
- [ ] Prod deploy (manual workflow_dispatch after merge) completes successfully