### PR TITLE
Refuse to mint stale op_live_* events at the writer layer

### DIFF
--- a/packages/odds-lambda/odds_lambda/storage/writers.py
+++ b/packages/odds-lambda/odds_lambda/storage/writers.py
@@ -21,6 +21,9 @@ logger = structlog.get_logger()
 class OddsWriter:
     """Handles all write operations to the database."""
 
+    LIVE_EVENT_ID_PREFIX = "op_live_"
+    LIVE_EVENT_STALE_THRESHOLD = timedelta(hours=1)
+
     def __init__(self, session: AsyncSession):
         """
         Initialize writer with database session.
@@ -72,9 +75,6 @@ class OddsWriter:
             self.session.add(event)
             logger.info("event_created", event_id=event.id)
             return event
-
-    LIVE_EVENT_ID_PREFIX = "op_live_"
-    LIVE_EVENT_STALE_THRESHOLD = timedelta(hours=1)
 
     @staticmethod
     def _build_event_id(home_team: str, away_team: str, match_date: datetime) -> str:

--- a/packages/odds-lambda/odds_lambda/storage/writers.py
+++ b/packages/odds-lambda/odds_lambda/storage/writers.py
@@ -73,6 +73,9 @@ class OddsWriter:
             logger.info("event_created", event_id=event.id)
             return event
 
+    LIVE_EVENT_ID_PREFIX = "op_live_"
+    LIVE_EVENT_STALE_THRESHOLD = timedelta(hours=1)
+
     @staticmethod
     def _build_event_id(home_team: str, away_team: str, match_date: datetime) -> str:
         """Generate deterministic event ID for OddsPortal-sourced events.
@@ -84,7 +87,7 @@ class OddsWriter:
         home_abbrev = team_abbrev(home_team)
         away_abbrev = team_abbrev(away_team)
         date_str = match_date.strftime("%Y-%m-%dT%H%M")
-        return f"op_live_{home_abbrev}_{away_abbrev}_{date_str}"
+        return f"{OddsWriter.LIVE_EVENT_ID_PREFIX}{home_abbrev}_{away_abbrev}_{date_str}"
 
     async def find_or_create_event(
         self,
@@ -137,6 +140,15 @@ class OddsWriter:
         existing = await self.session.get(Event, event_id)
         if existing:
             return event_id, False
+
+        if event_id.startswith(self.LIVE_EVENT_ID_PREFIX):
+            stale_cutoff = datetime.now(UTC) - self.LIVE_EVENT_STALE_THRESHOLD
+            if ensure_utc(match_date) < stale_cutoff:
+                raise ValueError(
+                    "Refusing to create stale live-scrape event: "
+                    f"home={home_team} away={away_team} "
+                    f"match_date={match_date.isoformat()}"
+                )
 
         event = Event(
             id=event_id,

--- a/tests/unit/test_team_normalization.py
+++ b/tests/unit/test_team_normalization.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from odds_core.models import Event, EventStatus
@@ -165,7 +165,7 @@ class TestFindOrCreateEventOnWriter:
         event_id, created = await writer.find_or_create_event(
             home_team="Arsenal",
             away_team="Chelsea",
-            match_date=datetime(2026, 4, 15, 15, 0, tzinfo=UTC),
+            match_date=datetime(2030, 4, 15, 15, 0, tzinfo=UTC),
             sport_key="soccer_epl",
             sport_title="EPL",
         )
@@ -210,7 +210,7 @@ class TestFindOrCreateEventOnWriter:
         from odds_lambda.storage.writers import OddsWriter
 
         writer = OddsWriter(test_session)
-        match_date = datetime(2026, 4, 15, 15, 0, tzinfo=UTC)
+        match_date = datetime(2030, 4, 15, 15, 0, tzinfo=UTC)
 
         event_id_1, created_1 = await writer.find_or_create_event(
             home_team="Arsenal",
@@ -334,3 +334,95 @@ class TestFindOrCreateEventMatchWindow:
         assert created_1 is True
         assert created_2 is False
         assert event_id_1 == event_id_2
+
+
+class TestFindOrCreateEventStaleLiveGuardrail:
+    """Defense-in-depth: refuse to mint op_live_* events with past commence times."""
+
+    @pytest.mark.asyncio
+    async def test_accepts_live_event_within_window(self, test_session) -> None:
+        from odds_lambda.storage.writers import OddsWriter
+
+        writer = OddsWriter(test_session)
+        match_date = datetime.now(UTC) + timedelta(minutes=30)
+
+        event_id, created = await writer.find_or_create_event(
+            home_team="Arsenal",
+            away_team="Chelsea",
+            match_date=match_date,
+            sport_key="soccer_epl",
+            sport_title="EPL",
+        )
+
+        assert created is True
+        assert event_id.startswith("op_live_")
+
+    @pytest.mark.asyncio
+    async def test_rejects_stale_live_event(self, test_session) -> None:
+        from odds_lambda.storage.writers import OddsWriter
+
+        writer = OddsWriter(test_session)
+        match_date = datetime.now(UTC) - timedelta(hours=2)
+
+        with pytest.raises(ValueError, match="stale live-scrape event"):
+            await writer.find_or_create_event(
+                home_team="Arsenal",
+                away_team="Chelsea",
+                match_date=match_date,
+                sport_key="soccer_epl",
+                sport_title="EPL",
+            )
+
+    @pytest.mark.asyncio
+    async def test_historical_ingestion_via_upsert_event_unaffected(self, test_session) -> None:
+        """Historical backfill callers go through upsert_event with non-live ids."""
+        from odds_lambda.storage.writers import OddsWriter
+
+        writer = OddsWriter(test_session)
+        match_date = datetime(2020, 1, 1, 15, 0, tzinfo=UTC)
+
+        event = Event(
+            id="fduk_2020_01_01_arsenal_chelsea",
+            sport_key="soccer_epl",
+            sport_title="EPL",
+            commence_time=match_date,
+            home_team="Arsenal",
+            away_team="Chelsea",
+            status=EventStatus.FINAL,
+        )
+
+        result = await writer.upsert_event(event)
+
+        assert result.id == "fduk_2020_01_01_arsenal_chelsea"
+        assert result.commence_time == match_date
+
+    @pytest.mark.asyncio
+    async def test_finds_existing_stale_live_event_without_creating(self, test_session) -> None:
+        """Guardrail only fires on create — looking up existing stale events still works."""
+        from odds_lambda.storage.writers import OddsWriter
+
+        match_date = datetime.now(UTC) - timedelta(hours=5)
+        event = Event(
+            id="op_live_ARS_CHE_2020-01-01T1500",
+            sport_key="soccer_epl",
+            sport_title="EPL",
+            commence_time=match_date,
+            home_team="Arsenal",
+            away_team="Chelsea",
+            status=EventStatus.SCHEDULED,
+        )
+        test_session.add(event)
+        await test_session.flush()
+
+        writer = OddsWriter(test_session)
+
+        event_id, created = await writer.find_or_create_event(
+            home_team="Arsenal",
+            away_team="Chelsea",
+            match_date=match_date,
+            sport_key="soccer_epl",
+            sport_title="EPL",
+        )
+
+        assert created is False
+        assert event_id == "op_live_ARS_CHE_2020-01-01T1500"


### PR DESCRIPTION
## Summary
- Adds a defense-in-depth guardrail in `OddsWriter.find_or_create_event`: rejects creating a new `Event` row when the event id starts with `op_live_` and `match_date` is more than 1 hour in the past.
- Scoped via id prefix (Option A from the issue) — historical backfill paths use different id schemes and remain unaffected.
- Raises `ValueError(home, away, match_date)` so the per-match `try/except` in `fetch_oddsportal.py` records it in `stats.errors` without aborting the run.
- Constants `LIVE_EVENT_ID_PREFIX` and `LIVE_EVENT_STALE_THRESHOLD` defined once on `OddsWriter` and reused.

## Tests
- Accept: live-prefix event within ±1h of now.
- Reject: live-prefix event with `match_date` 2h in the past raises `ValueError`.
- Idempotent: pre-existing stale `op_live_*` row is found, not re-created.
- Bypass: historical-prefix events created via `upsert_event` are unaffected.

## Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)