### PR TITLE
Fix fetch-oddsportal-results DB session scope and self-schedule reliability

### DIFF
--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py
@@ -254,9 +254,6 @@ async def process_results(
                     away_score=away_score,
                 )
 
-                # Remove from pending list so it can't match again
-                pending_events.remove(event)
-
                 snapshot_stored = False
                 market_data = record.get(market_key, [])
                 if market_data:
@@ -286,11 +283,13 @@ async def process_results(
 
                 await session.commit()
 
-                # Only advance stats after the commit succeeds so rolled-back
-                # records don't inflate success counters.
+                # Only advance batch state after the commit succeeds so rolled-back
+                # records don't inflate success counters or prematurely drop events
+                # from the in-flight dedupe list.
                 stats.events_updated += 1
                 if snapshot_stored:
                     stats.snapshots_stored += 1
+                pending_events.remove(event)
 
             except Exception as e:
                 msg = f"{record.get('home_team', '?')} vs {record.get('away_team', '?')}: {e}"

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py
@@ -253,11 +253,11 @@ async def process_results(
                     home_score=home_score,
                     away_score=away_score,
                 )
-                stats.events_updated += 1
 
                 # Remove from pending list so it can't match again
                 pending_events.remove(event)
 
+                snapshot_stored = False
                 market_data = record.get(market_key, [])
                 if market_data:
                     match_dt = parse_match_date(record["match_date"])
@@ -282,9 +282,15 @@ async def process_results(
                                 snapshot_time=snapshot_time,
                             )
                             snapshot.api_request_id = API_REQUEST_ID
-                            stats.snapshots_stored += 1
+                            snapshot_stored = True
 
                 await session.commit()
+
+                # Only advance stats after the commit succeeds so rolled-back
+                # records don't inflate success counters.
+                stats.events_updated += 1
+                if snapshot_stored:
+                    stats.snapshots_stored += 1
 
             except Exception as e:
                 msg = f"{record.get('home_team', '?')} vs {record.get('away_team', '?')}: {e}"
@@ -349,6 +355,18 @@ async def main(ctx: JobContext) -> None:
             )
         except Exception as e:
             logger.error("fetch_oddsportal_results_scheduling_failed", error=str(e), exc_info=True)
+            # Escalate to Discord so the failure is visible. Alert dispatch is
+            # best-effort — any error here must not mask an upstream exception
+            # propagating through this ``finally`` block.
+            try:
+                from odds_core.alerts import send_critical
+
+                await send_critical(
+                    f"🚨 fetch-oddsportal-results self-schedule failed "
+                    f"(job={schedule_job_name}): {type(e).__name__}: {e}"
+                )
+            except Exception:
+                logger.warning("fetch_oddsportal_results_scheduling_alert_failed", exc_info=True)
 
 
 if __name__ == "__main__":

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py
@@ -74,6 +74,20 @@ class ResultsStats:
     errors: list[str] = field(default_factory=list)
 
 
+@dataclass
+class PendingEvent:
+    """Plain-data snapshot of a pending event, decoupled from any DB session.
+
+    The results job reads pending events into these dataclasses so the DB
+    session can be closed before the long-running scrape begins.
+    """
+
+    id: str
+    home_team: str
+    away_team: str
+    commence_time: datetime | None
+
+
 async def run_harvester_historic(spec: LeagueSpec) -> list[dict[str, Any]]:
     """Scrape historical results for the given league via ``run_scraper_with_retry``."""
     from oddsharvester.utils.command_enum import CommandEnum
@@ -92,9 +106,13 @@ async def run_harvester_historic(spec: LeagueSpec) -> list[dict[str, Any]]:
 
 async def get_pending_events(
     session: AsyncSession, sport_key: str = DEFAULT_SPORT_KEY
-) -> list[Event]:
-    """Get SCHEDULED or LIVE events with commence_time in the past for the given sport."""
-    query = select(Event).where(
+) -> list[PendingEvent]:
+    """Get SCHEDULED or LIVE events with commence_time in the past for the given sport.
+
+    Returns plain ``PendingEvent`` dataclasses so callers can use the data after
+    the session is closed.
+    """
+    query = select(Event.id, Event.home_team, Event.away_team, Event.commence_time).where(
         and_(
             Event.sport_key == sport_key,
             Event.status.in_([EventStatus.SCHEDULED, EventStatus.LIVE]),
@@ -102,7 +120,15 @@ async def get_pending_events(
         )
     )
     result = await session.execute(query)
-    return list(result.scalars().all())
+    return [
+        PendingEvent(
+            id=row.id,
+            home_team=row.home_team,
+            away_team=row.away_team,
+            commence_time=row.commence_time,
+        )
+        for row in result.all()
+    ]
 
 
 def _parse_score(record: dict[str, Any]) -> tuple[int, int] | None:
@@ -116,8 +142,8 @@ def _parse_score(record: dict[str, Any]) -> tuple[int, int] | None:
 
 def _match_record_to_event(
     record: dict[str, Any],
-    pending_events: list[Event],
-) -> Event | None:
+    pending_events: list[PendingEvent],
+) -> PendingEvent | None:
     """Match a scraped record to a pending event by team name and date window."""
     home_team = record.get("home_team", "").strip()
     away_team = record.get("away_team", "").strip()
@@ -149,6 +175,14 @@ async def process_results(
 ) -> ResultsStats:
     """Process scraped results: update scores and store closing snapshots.
 
+    The job runs in three phases with distinct session scopes so no DB session
+    is held across the long-running OddsHarvester scrape (Neon closes idle
+    connections, which would crash the write phase):
+
+    1. Read phase — open a session, load pending events (detached), close session.
+    2. Scrape phase — run ``run_harvester_historic`` with no open session.
+    3. Write phase — open a fresh session, upsert scores and snapshots, commit.
+
     Args:
         raw_matches: Pre-scraped data (skips harvester call). For testing.
         sport: Sport key to filter (e.g. "soccer_epl"). Defaults to DEFAULT_SPORT_KEY.
@@ -168,26 +202,31 @@ async def process_results(
     market_key = _market_key_for_spec(spec)
     db_market = _db_market_for_spec(spec)
 
+    # Phase 1: read pending events, then release the session
     async with async_session_maker() as session:
         pending_events = await get_pending_events(session, sport_key=sport_key)
 
-        if not pending_events:
-            logger.info("no_pending_events", sport_key=sport_key)
-            return stats
+    if not pending_events:
+        logger.info("no_pending_events", sport_key=sport_key)
+        return stats
 
-        logger.info("pending_events_found", count=len(pending_events))
+    logger.info("pending_events_found", count=len(pending_events))
 
-        if raw_matches is None:
-            raw_matches = await run_harvester_historic(spec)
+    # Phase 2: scrape with no open session
+    if raw_matches is None:
+        raw_matches = await run_harvester_historic(spec)
 
-        stats.matches_scraped = len(raw_matches)
+    stats.matches_scraped = len(raw_matches)
 
-        if not raw_matches:
-            logger.warning("no_matches_scraped")
-            return stats
+    if not raw_matches:
+        logger.warning("no_matches_scraped")
+        return stats
 
-        logger.info("matches_scraped", count=len(raw_matches))
+    logger.info("matches_scraped", count=len(raw_matches))
 
+    # Phase 3: open a fresh session and write results, committing per-record so
+    # a single failure cannot invalidate earlier writes.
+    async with async_session_maker() as session:
         writer = OddsWriter(session)
 
         for record in raw_matches:
@@ -208,7 +247,6 @@ async def process_results(
 
                 home_score, away_score = scores
 
-                # Update event status
                 await writer.update_event_status(
                     event_id=event.id,
                     status=EventStatus.FINAL,
@@ -220,44 +258,42 @@ async def process_results(
                 # Remove from pending list so it can't match again
                 pending_events.remove(event)
 
-                # Store closing odds snapshot
                 market_data = record.get(market_key, [])
-                if not market_data:
-                    continue
+                if market_data:
+                    match_dt = parse_match_date(record["match_date"])
+                    raw_data = build_raw_data(
+                        market_data,
+                        event.home_team,
+                        event.away_team,
+                        use_opening=False,
+                        match_dt=match_dt,
+                        num_outcomes=spec.num_outcomes,
+                        db_market=db_market,
+                    )
+                    if raw_data is not None:
+                        snapshot_time_str = raw_data.pop("_snapshot_time", None)
+                        if snapshot_time_str:
+                            snapshot_time = datetime.fromisoformat(
+                                snapshot_time_str.replace("Z", "+00:00")
+                            )
+                            snapshot, _ = await writer.store_odds_snapshot(
+                                event_id=event.id,
+                                raw_data=raw_data,
+                                snapshot_time=snapshot_time,
+                            )
+                            snapshot.api_request_id = API_REQUEST_ID
+                            stats.snapshots_stored += 1
 
-                match_dt = parse_match_date(record["match_date"])
-                raw_data = build_raw_data(
-                    market_data,
-                    event.home_team,
-                    event.away_team,
-                    use_opening=False,
-                    match_dt=match_dt,
-                    num_outcomes=spec.num_outcomes,
-                    db_market=db_market,
-                )
-                if raw_data is None:
-                    continue
-
-                snapshot_time_str = raw_data.pop("_snapshot_time", None)
-                if not snapshot_time_str:
-                    continue
-
-                snapshot_time = datetime.fromisoformat(snapshot_time_str.replace("Z", "+00:00"))
-
-                snapshot, _ = await writer.store_odds_snapshot(
-                    event_id=event.id,
-                    raw_data=raw_data,
-                    snapshot_time=snapshot_time,
-                )
-                snapshot.api_request_id = API_REQUEST_ID
-                stats.snapshots_stored += 1
+                await session.commit()
 
             except Exception as e:
                 msg = f"{record.get('home_team', '?')} vs {record.get('away_team', '?')}: {e}"
                 stats.errors.append(msg)
                 logger.error("result_processing_failed", error=msg, exc_info=True)
-
-        await session.commit()
+                try:
+                    await session.rollback()
+                except Exception:
+                    logger.warning("session_rollback_failed", exc_info=True)
 
     logger.info(
         "results_collection_complete",
@@ -272,43 +308,47 @@ async def process_results(
 
 
 async def main(ctx: JobContext) -> None:
-    """Main job entry point — runs results collection, then self-schedules for tomorrow."""
+    """Main job entry point — runs results collection, then self-schedules for tomorrow.
+
+    Self-scheduling runs in a ``finally`` block so a failure inside
+    ``process_results`` cannot leave the EventBridge rule disabled.
+    """
     from odds_core.alerts import job_alert_context
     from odds_core.config import get_settings
 
     settings = get_settings()
     sport = ctx.sport
-
-    async with job_alert_context(make_compound_job_name("fetch-oddsportal-results", sport)):
-        logger.info("fetch_oddsportal_results_started", sport=sport)
-        await process_results(sport=sport)
-
-    # Self-schedule: run again tomorrow at 08:00 UTC
-    now = datetime.now(UTC)
-    tomorrow_8am = (now + timedelta(days=1)).replace(hour=8, minute=0, second=0, microsecond=0)
-
-    schedule_payload: dict[str, object] | None = None
-    if sport:
-        schedule_payload = {"sport": sport}
+    schedule_job_name = make_compound_job_name("fetch-oddsportal-results", sport)
 
     try:
-        from odds_lambda.scheduling.backends import get_scheduler_backend
+        async with job_alert_context(schedule_job_name):
+            logger.info("fetch_oddsportal_results_started", sport=sport)
+            await process_results(sport=sport)
+    finally:
+        # Self-schedule: run again tomorrow at 08:00 UTC, regardless of outcome.
+        now = datetime.now(UTC)
+        tomorrow_8am = (now + timedelta(days=1)).replace(hour=8, minute=0, second=0, microsecond=0)
 
-        backend = get_scheduler_backend(dry_run=settings.scheduler.dry_run)
-        schedule_job_name = make_compound_job_name("fetch-oddsportal-results", sport)
-        await backend.schedule_next_execution(
-            job_name=schedule_job_name,
-            next_time=tomorrow_8am,
-            payload=schedule_payload,
-        )
-        logger.info(
-            "fetch_oddsportal_results_next_scheduled",
-            next_time=tomorrow_8am.isoformat(),
-            backend=backend.get_backend_name(),
-        )
-    except Exception as e:
-        logger.error("fetch_oddsportal_results_scheduling_failed", error=str(e), exc_info=True)
-        raise
+        schedule_payload: dict[str, object] | None = None
+        if sport:
+            schedule_payload = {"sport": sport}
+
+        try:
+            from odds_lambda.scheduling.backends import get_scheduler_backend
+
+            backend = get_scheduler_backend(dry_run=settings.scheduler.dry_run)
+            await backend.schedule_next_execution(
+                job_name=schedule_job_name,
+                next_time=tomorrow_8am,
+                payload=schedule_payload,
+            )
+            logger.info(
+                "fetch_oddsportal_results_next_scheduled",
+                next_time=tomorrow_8am.isoformat(),
+                backend=backend.get_backend_name(),
+            )
+        except Exception as e:
+            logger.error("fetch_oddsportal_results_scheduling_failed", error=str(e), exc_info=True)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_fetch_oddsportal_results.py
+++ b/tests/unit/test_fetch_oddsportal_results.py
@@ -10,6 +10,7 @@ from odds_core.models import Event, EventStatus
 from odds_lambda.jobs.fetch_oddsportal import LeagueSpec
 from odds_lambda.jobs.fetch_oddsportal_results import (
     DEFAULT_SPORT_KEY,
+    PendingEvent,
     _db_market_for_spec,
     _market_key_for_spec,
     _match_record_to_event,
@@ -35,6 +36,21 @@ def _make_event(
         home_team=home_team,
         away_team=away_team,
         status=status,
+    )
+
+
+def _make_pending(
+    *,
+    event_id: str = "test_event_1",
+    home_team: str = "Arsenal",
+    away_team: str = "Chelsea",
+    commence_time: datetime | None = None,
+) -> PendingEvent:
+    return PendingEvent(
+        id=event_id,
+        home_team=home_team,
+        away_team=away_team,
+        commence_time=commence_time or datetime(2026, 3, 1, 15, 0, 0, tzinfo=UTC),
     )
 
 
@@ -99,24 +115,24 @@ class TestParseScore:
 
 class TestMatchRecordToEvent:
     def test_matches_by_team_and_date(self) -> None:
-        event = _make_event()
+        event = _make_pending()
         record = _make_record()
         assert _match_record_to_event(record, [event]) is event
 
     def test_no_match_different_teams(self) -> None:
-        event = _make_event(home_team="Liverpool", away_team="Everton")
+        event = _make_pending(home_team="Liverpool", away_team="Everton")
         record = _make_record()
         assert _match_record_to_event(record, [event]) is None
 
     def test_no_match_outside_24h_window(self) -> None:
-        event = _make_event(
+        event = _make_pending(
             commence_time=datetime(2026, 3, 5, 15, 0, 0, tzinfo=UTC),
         )
         record = _make_record(match_date="2026-03-01 15:00:00 UTC")
         assert _match_record_to_event(record, [event]) is None
 
     def test_matches_within_24h_window(self) -> None:
-        event = _make_event(
+        event = _make_pending(
             commence_time=datetime(2026, 3, 1, 20, 0, 0, tzinfo=UTC),
         )
         record = _make_record(match_date="2026-03-01 15:00:00 UTC")
@@ -127,12 +143,12 @@ class TestMatchRecordToEvent:
         assert _match_record_to_event(record, []) is None
 
     def test_missing_team_in_record(self) -> None:
-        event = _make_event()
+        event = _make_pending()
         record = {"home_team": "", "away_team": "Chelsea", "match_date": "2026-03-01 15:00:00 UTC"}
         assert _match_record_to_event(record, [event]) is None
 
     def test_missing_match_date(self) -> None:
-        event = _make_event()
+        event = _make_pending()
         record = {"home_team": "Arsenal", "away_team": "Chelsea", "match_date": ""}
         assert _match_record_to_event(record, [event]) is None
 
@@ -385,3 +401,103 @@ class TestSportResolution:
         stats = await process_results(raw_matches=[], sport="unknown_sport")
         assert stats.matches_scraped == 0
         assert stats.events_updated == 0
+
+
+class TestMainSelfSchedules:
+    """Self-schedule must run even when the results phase raises."""
+
+    @pytest.mark.asyncio
+    async def test_self_schedules_when_process_results_raises(self) -> None:
+        from odds_lambda.jobs import fetch_oddsportal_results
+        from odds_lambda.scheduling.jobs import JobContext
+
+        scheduled_calls: list[dict] = []
+
+        async def mock_schedule_next(
+            job_name: str,
+            next_time: datetime,
+            payload: dict[str, object] | None = None,
+        ) -> None:
+            scheduled_calls.append(
+                {"job_name": job_name, "next_time": next_time, "payload": payload}
+            )
+
+        mock_backend = AsyncMock()
+        mock_backend.schedule_next_execution = mock_schedule_next
+        mock_backend.get_backend_name = lambda: "mock_backend"
+
+        async def failing_process_results(**_kwargs) -> None:
+            raise RuntimeError("simulated per-record failure")
+
+        with (
+            patch.object(
+                fetch_oddsportal_results, "process_results", side_effect=failing_process_results
+            ),
+            patch(
+                "odds_lambda.scheduling.backends.get_scheduler_backend",
+                return_value=mock_backend,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="simulated per-record failure"):
+                await fetch_oddsportal_results.main(JobContext(sport="soccer_epl"))
+
+        assert len(scheduled_calls) == 1, "self-schedule must run even when process_results raises"
+        assert scheduled_calls[0]["job_name"] == "fetch-oddsportal-results-epl"
+        assert scheduled_calls[0]["payload"] == {"sport": "soccer_epl"}
+
+    @pytest.mark.asyncio
+    async def test_self_schedules_when_single_record_update_fails(self, test_session) -> None:
+        """A forced error in one record's update path should not block self-scheduling."""
+        from odds_lambda.jobs import fetch_oddsportal_results
+        from odds_lambda.scheduling.jobs import JobContext
+
+        event = _make_event()
+        test_session.add(event)
+        await test_session.commit()
+
+        record = _make_record()
+
+        mock_session_maker = AsyncMock()
+        mock_session_maker.__aenter__ = AsyncMock(return_value=test_session)
+        mock_session_maker.__aexit__ = AsyncMock(return_value=None)
+
+        scheduled_calls: list[dict] = []
+
+        async def mock_schedule_next(
+            job_name: str,
+            next_time: datetime,
+            payload: dict[str, object] | None = None,
+        ) -> None:
+            scheduled_calls.append(
+                {"job_name": job_name, "next_time": next_time, "payload": payload}
+            )
+
+        mock_backend = AsyncMock()
+        mock_backend.schedule_next_execution = mock_schedule_next
+        mock_backend.get_backend_name = lambda: "mock_backend"
+
+        async def failing_update_event_status(*_args, **_kwargs):
+            raise RuntimeError("simulated update failure")
+
+        with (
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal_results.async_session_maker",
+                return_value=mock_session_maker,
+            ),
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal_results.run_harvester_historic",
+                AsyncMock(return_value=[record]),
+            ),
+            patch(
+                "odds_lambda.storage.writers.OddsWriter.update_event_status",
+                side_effect=failing_update_event_status,
+            ),
+            patch(
+                "odds_lambda.scheduling.backends.get_scheduler_backend",
+                return_value=mock_backend,
+            ),
+        ):
+            await fetch_oddsportal_results.main(JobContext(sport="soccer_epl"))
+
+        assert len(scheduled_calls) == 1, "self-schedule must run after per-record failure"
+        assert scheduled_calls[0]["job_name"] == "fetch-oddsportal-results-epl"


### PR DESCRIPTION
## Summary

- Split `process_results()` in `packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal_results.py` into three phases with distinct DB session scopes: read pending events into a detached `PendingEvent` dataclass and close the session, run `run_harvester_historic()` with no open session, open a fresh session for per-record writes with per-record try/except + rollback.
- Moved `main()`'s `schedule_next_execution` call into a `try/finally` outside `job_alert_context` so self-scheduling always runs regardless of whether `process_results()` raised. Scheduling-only failures are now logged and dispatch a critical Discord alert (same `send_critical` pattern used by `fetch_scores` / `fetch_odds` / `fetch_polymarket`) so the EventBridge rule cannot go silently DISABLED.
- Stat counters (`stats.events_updated`, `stats.snapshots_stored`) advance only after `session.commit()` succeeds, so a rolled-back record cannot be counted as persisted.
- Added tests for both the `process_results`-raises-entirely path and the per-record write-failure path, asserting `main()` still reaches `schedule_next_execution`.

## Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)