### PR TITLE
Add ESPN fixture ingestion job and get_team_context MCP tool

### DIFF
--- a/deployment/aws/terraform/eventbridge.tf
+++ b/deployment/aws/terraform/eventbridge.tf
@@ -136,19 +136,31 @@ locals {
   # Schedule expressions for fixed-schedule jobs (map lookup prevents
   # a new job silently inheriting the wrong schedule via a ternary fallback).
   fixed_schedule_expressions = {
-    "daily-digest"      = "cron(0 8 * * ? *)"
-    "score-predictions" = "cron(30 * * * ? *)"
+    "daily-digest"        = "cron(0 8 * * ? *)"
+    "score-predictions"   = "cron(30 * * * ? *)"
+    "fetch-espn-fixtures" = "cron(0 6 * * ? *)"
   }
 
-  # Per-sport fixed-schedule jobs (daily-digest, score-predictions)
+  # Per-sport fixed-schedule jobs. fetch-espn-fixtures is EPL-only today —
+  # gated on sport_suffix to avoid scheduling it for sports without ESPN fixture
+  # coverage in this pipeline.
   sport_fixed_scheduler_rules = flatten([
-    for sport_suffix, cfg in local.sport_configs : [
-      for job in ["daily-digest", "score-predictions"] : {
-        key       = "${job}-${sport_suffix}"
-        job       = job
-        sport_key = cfg.sport_key
-      }
-    ]
+    for sport_suffix, cfg in local.sport_configs : concat(
+      [
+        for job in ["daily-digest", "score-predictions"] : {
+          key       = "${job}-${sport_suffix}"
+          job       = job
+          sport_key = cfg.sport_key
+        }
+      ],
+      sport_suffix == "epl" ? [
+        {
+          key       = "fetch-espn-fixtures-${sport_suffix}"
+          job       = "fetch-espn-fixtures"
+          sport_key = cfg.sport_key
+        }
+      ] : []
+    )
   ])
 
   fixed_scheduler_rules_map = { for r in local.sport_fixed_scheduler_rules : r.key => r }

--- a/packages/odds-lambda/odds_lambda/espn_fixture_fetcher.py
+++ b/packages/odds-lambda/odds_lambda/espn_fixture_fetcher.py
@@ -1,0 +1,278 @@
+"""Async fetcher for ESPN all-competition EPL fixture schedules.
+
+Wraps the ESPN Site API. Given a season start year, returns a list of
+``EspnFixtureRecord`` with deduplicated fixtures across Premier League,
+FA Cup, League Cup, and European competitions.
+
+The ESPN Site API is free and unauthenticated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+from odds_core.epl_data_models import EspnFixtureRecord
+from odds_core.team import normalize_team_name
+
+logger = structlog.get_logger()
+
+BASE_URL = "http://site.api.espn.com/apis/site/v2/sports/soccer"
+
+# ESPN league slugs for all competitions an EPL team might play in.
+LEAGUE_SLUGS: dict[str, str] = {
+    "eng.1": "Premier League",
+    "eng.fa": "FA Cup",
+    "eng.league_cup": "League Cup",
+    "uefa.champions": "Champions League",
+    "uefa.europa": "Europa League",
+    "uefa.europa.conf": "Conference League",
+}
+
+# Seasons: start year -> display label (matches FDUK convention).
+SEASONS: dict[int, str] = {
+    2015: "2015-16",
+    2016: "2016-17",
+    2017: "2017-18",
+    2018: "2018-19",
+    2019: "2019-20",
+    2020: "2020-21",
+    2021: "2021-22",
+    2022: "2022-23",
+    2023: "2023-24",
+    2024: "2024-25",
+    2025: "2025-26",
+    2026: "2026-27",
+}
+
+# Month at which the EPL season start year flips (August).
+_SEASON_FLIP_MONTH = 8
+
+# Default pacing between ESPN HTTP requests. ESPN is lenient but we stay polite.
+DEFAULT_REQUEST_DELAY_SECONDS = 0.5
+
+# HTTP retry policy for ESPN endpoints.
+_MAX_ATTEMPTS = 3
+_RETRY_BACKOFF_SECONDS = 1.0
+_REQUEST_TIMEOUT_SECONDS = 15.0
+
+
+def current_season(now: datetime | None = None) -> int:
+    """Return the EPL season start year for the given instant.
+
+    The season flips on August 1: dates in Aug-Dec resolve to that calendar
+    year, Jan-Jul resolve to the previous calendar year. ``now`` defaults to
+    the current UTC datetime.
+    """
+    if now is None:
+        now = datetime.now(UTC)
+    if now.month >= _SEASON_FLIP_MONTH:
+        return now.year
+    return now.year - 1
+
+
+def season_label(season: int) -> str:
+    """Return the display label (e.g. ``"2025-26"``) for a season start year."""
+    if season in SEASONS:
+        return SEASONS[season]
+    # Fall back to deriving the label for seasons beyond the static table.
+    return f"{season}-{(season + 1) % 100:02d}"
+
+
+def _extract_score(competitor: dict[str, Any]) -> str:
+    """Extract score from a competitor entry. Returns empty string if unavailable."""
+    score = competitor.get("score")
+    if score is None:
+        return ""
+    if isinstance(score, dict):
+        return score.get("displayValue", "")
+    return str(score)
+
+
+class EspnFixtureFetcher:
+    """Async fetcher for ESPN all-competition EPL fixture schedules.
+
+    Usage::
+
+        async with EspnFixtureFetcher() as fetcher:
+            records = await fetcher.fetch_season(2025)
+    """
+
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient | None = None,
+        request_delay_seconds: float = DEFAULT_REQUEST_DELAY_SECONDS,
+    ) -> None:
+        self._owns_client = client is None
+        self._client = client
+        self.request_delay_seconds = request_delay_seconds
+
+    async def __aenter__(self) -> EspnFixtureFetcher:
+        if self._client is None:
+            self._client = httpx.AsyncClient()
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        if self._owns_client and self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    def _require_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            raise RuntimeError(
+                "EspnFixtureFetcher used outside async context manager; "
+                "wrap calls in `async with EspnFixtureFetcher()`."
+            )
+        return self._client
+
+    async def _fetch_json(self, url: str) -> dict[str, Any]:
+        """Fetch JSON from ESPN API with retry."""
+        client = self._require_client()
+        last_exc: Exception | None = None
+        for attempt in range(_MAX_ATTEMPTS):
+            try:
+                resp = await client.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+                resp.raise_for_status()
+                return resp.json()
+            except (httpx.HTTPError, httpx.TimeoutException) as e:
+                last_exc = e
+                if attempt == _MAX_ATTEMPTS - 1:
+                    break
+                logger.warning("espn_fetch_retry", url=url, attempt=attempt + 1, error=str(e))
+                await asyncio.sleep(_RETRY_BACKOFF_SECONDS)
+        assert last_exc is not None
+        raise last_exc
+
+    async def fetch_teams(self, season: int) -> list[dict[str, str]]:
+        """Fetch EPL teams for a season. Returns list of {id, name}."""
+        url = f"{BASE_URL}/eng.1/teams?season={season}"
+        data = await self._fetch_json(url)
+        teams = data["sports"][0]["leagues"][0]["teams"]
+        return [{"id": t["team"]["id"], "name": t["team"]["displayName"]} for t in teams]
+
+    async def fetch_team_schedule(
+        self,
+        league_slug: str,
+        team_id: str,
+        season: int,
+    ) -> list[EspnFixtureRecord]:
+        """Fetch a team's schedule for one competition/season.
+
+        Returns a list of ``EspnFixtureRecord`` entries. ``season`` is stored as
+        the display label (e.g. ``"2025-26"``) on each record.
+        """
+        url = f"{BASE_URL}/{league_slug}/teams/{team_id}/schedule?season={season}"
+        data = await self._fetch_json(url)
+        events = data.get("events", [])
+        competition = LEAGUE_SLUGS[league_slug]
+        label = season_label(season)
+        records: list[EspnFixtureRecord] = []
+
+        for event in events:
+            date_str = event.get("date", "")
+            if not date_str:
+                continue
+
+            comps = event.get("competitions", [])
+            if not comps:
+                continue
+
+            comp = comps[0]
+            competitors = comp.get("competitors", [])
+            if len(competitors) != 2:
+                continue
+
+            team_entry = None
+            opponent_entry = None
+            for c in competitors:
+                if c["team"]["id"] == team_id:
+                    team_entry = c
+                else:
+                    opponent_entry = c
+
+            if team_entry is None or opponent_entry is None:
+                continue
+
+            team_name = normalize_team_name(team_entry["team"]["displayName"])
+            opponent_name = normalize_team_name(opponent_entry["team"]["displayName"])
+
+            status_type = comp.get("status", {}).get("type", {})
+            status = status_type.get("description", "")
+            round_name = event.get("seasonType", {}).get("name", "")
+
+            dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=UTC)
+
+            records.append(
+                EspnFixtureRecord(
+                    date=dt,
+                    team=team_name,
+                    opponent=opponent_name,
+                    competition=competition,
+                    match_round=round_name,
+                    home_away=team_entry["homeAway"],
+                    score_team=_extract_score(team_entry),
+                    score_opponent=_extract_score(opponent_entry),
+                    status=status,
+                    season=label,
+                )
+            )
+
+        return records
+
+    async def fetch_season(self, season: int) -> list[EspnFixtureRecord]:
+        """Fetch all fixtures for all EPL teams in a season across all competitions.
+
+        Each match is represented once per team; duplicates that would otherwise
+        appear (because a match shows up on both teams' schedules) are collapsed
+        using the ``(date, team, opponent)`` tuple so each row is unique per team.
+        """
+        teams = await self.fetch_teams(season)
+        logger.info("espn_teams_loaded", season=season, count=len(teams))
+
+        all_records: list[EspnFixtureRecord] = []
+        seen: set[tuple[str, str, str]] = set()
+
+        for idx, team in enumerate(teams):
+            team_id = team["id"]
+            team_name = normalize_team_name(team["name"])
+            team_records = 0
+
+            for league_slug in LEAGUE_SLUGS:
+                if self.request_delay_seconds > 0:
+                    await asyncio.sleep(self.request_delay_seconds)
+                try:
+                    fixtures = await self.fetch_team_schedule(league_slug, team_id, season)
+                except Exception as e:
+                    logger.warning(
+                        "espn_schedule_fetch_failed",
+                        team=team_name,
+                        league=league_slug,
+                        error=str(e),
+                    )
+                    continue
+
+                for record in fixtures:
+                    key = (record.date.isoformat(), record.team, record.opponent)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    all_records.append(record)
+                    team_records += 1
+
+            logger.info(
+                "espn_team_schedule_loaded",
+                season=season,
+                team=team_name,
+                new_fixtures=team_records,
+                index=idx + 1,
+                total=len(teams),
+            )
+
+        all_records.sort(key=lambda r: r.date)
+        return all_records

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_espn_fixtures.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_espn_fixtures.py
@@ -1,0 +1,98 @@
+"""Fetch ESPN fixtures job — refresh current-season all-competition schedules.
+
+Flow:
+1. Fetch current-season fixtures across EPL + FA Cup + League Cup + European
+   competitions from the ESPN Site API (free, unauthenticated).
+2. Upsert into ``espn_fixtures`` via ``EspnFixtureWriter`` (idempotent on
+   ``(date, team, competition)``).
+3. Self-schedule next execution for +24h.
+4. Alerts on failure via ``job_alert_context``.
+
+Scheduler cadence is daily at 06:00 UTC (pre-matchday), with ESPN being a free
+unauthenticated API there is no quota concern that would require smart gating.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from odds_core.config import get_settings
+from odds_core.database import async_session_maker
+
+from odds_lambda.espn_fixture_fetcher import EspnFixtureFetcher, current_season
+from odds_lambda.scheduling.helpers import self_schedule
+from odds_lambda.scheduling.jobs import JobContext, make_compound_job_name
+from odds_lambda.storage.espn_fixture_writer import EspnFixtureWriter
+
+logger = structlog.get_logger()
+
+# Sport this job serves. ESPN fixture coverage here is EPL-only.
+SPORT_KEY = "soccer_epl"
+
+# Default interval between runs. Fixture data moves slowly enough that daily is
+# plenty even in heavy cup weeks.
+DEFAULT_INTERVAL_HOURS = 24.0
+
+
+async def main(ctx: JobContext) -> None:
+    """Fetch ESPN fixtures for the current season and self-schedule."""
+    from odds_core.alerts import job_alert_context
+
+    app_settings = get_settings()
+    season = current_season()
+
+    logger.info(
+        "fetch_espn_fixtures_started",
+        backend=app_settings.scheduler.backend,
+        season=season,
+        sport=SPORT_KEY,
+    )
+
+    async with job_alert_context("fetch-espn-fixtures"):
+        count = await _fetch_and_upsert_current_season(season)
+        logger.info("fetch_espn_fixtures_completed", season=season, upserted=count)
+
+    # Self-schedule next execution (24h from now). Uses the sport-suffixed job
+    # name so the Lambda EventBridge rule matches Terraform.
+    try:
+        next_time = datetime.now(UTC) + timedelta(hours=DEFAULT_INTERVAL_HOURS)
+        compound_name = make_compound_job_name("fetch-espn-fixtures", SPORT_KEY)
+        await self_schedule(
+            job_name=compound_name,
+            next_time=next_time,
+            dry_run=app_settings.scheduler.dry_run,
+            sport=SPORT_KEY,
+            interval_hours=DEFAULT_INTERVAL_HOURS,
+            reason="fetch-espn-fixtures daily cadence",
+        )
+    except Exception as e:
+        logger.error("fetch_espn_fixtures_scheduling_failed", error=str(e), exc_info=True)
+        from odds_core.alerts import send_error
+
+        await send_error(f"fetch-espn-fixtures scheduling failed: {type(e).__name__}: {e}")
+
+
+async def _fetch_and_upsert_current_season(season: int) -> int:
+    """Fetch the given season from ESPN and upsert into the database.
+
+    Returns the number of records upserted.
+    """
+    async with EspnFixtureFetcher() as fetcher:
+        records = await fetcher.fetch_season(season)
+
+    if not records:
+        logger.warning("fetch_espn_fixtures_empty", season=season)
+        return 0
+
+    async with async_session_maker() as session:
+        writer = EspnFixtureWriter(session)
+        count = await writer.upsert_fixtures(records)
+        await session.commit()
+
+    return count
+
+
+if __name__ == "__main__":
+    asyncio.run(main(JobContext(sport=SPORT_KEY)))

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_espn_fixtures.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_espn_fixtures.py
@@ -5,25 +5,23 @@ Flow:
    competitions from the ESPN Site API (free, unauthenticated).
 2. Upsert into ``espn_fixtures`` via ``EspnFixtureWriter`` (idempotent on
    ``(date, team, competition)``).
-3. Self-schedule next execution for +24h.
-4. Alerts on failure via ``job_alert_context``.
+3. Alerts on failure via ``job_alert_context``.
 
-Scheduler cadence is daily at 06:00 UTC (pre-matchday), with ESPN being a free
-unauthenticated API there is no quota concern that would require smart gating.
+Scheduler cadence is a fixed daily cron (06:00 UTC, pre-matchday) managed in
+Terraform — the ESPN endpoint is free and unauthenticated so no proximity-based
+gating is needed.
 """
 
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime, timedelta
 
 import structlog
 from odds_core.config import get_settings
 from odds_core.database import async_session_maker
 
 from odds_lambda.espn_fixture_fetcher import EspnFixtureFetcher, current_season
-from odds_lambda.scheduling.helpers import self_schedule
-from odds_lambda.scheduling.jobs import JobContext, make_compound_job_name
+from odds_lambda.scheduling.jobs import JobContext
 from odds_lambda.storage.espn_fixture_writer import EspnFixtureWriter
 
 logger = structlog.get_logger()
@@ -31,14 +29,18 @@ logger = structlog.get_logger()
 # Sport this job serves. ESPN fixture coverage here is EPL-only.
 SPORT_KEY = "soccer_epl"
 
-# Default interval between runs. Fixture data moves slowly enough that daily is
-# plenty even in heavy cup weeks.
-DEFAULT_INTERVAL_HOURS = 24.0
-
 
 async def main(ctx: JobContext) -> None:
-    """Fetch ESPN fixtures for the current season and self-schedule."""
+    """Fetch ESPN fixtures for the current season.
+
+    Raises:
+        ValueError: If ``ctx.sport`` is provided and does not match the sport
+            this job serves.
+    """
     from odds_core.alerts import job_alert_context
+
+    if ctx.sport is not None and ctx.sport != SPORT_KEY:
+        raise ValueError(f"fetch-espn-fixtures only supports {SPORT_KEY}, got sport={ctx.sport!r}")
 
     app_settings = get_settings()
     season = current_season()
@@ -53,25 +55,6 @@ async def main(ctx: JobContext) -> None:
     async with job_alert_context("fetch-espn-fixtures"):
         count = await _fetch_and_upsert_current_season(season)
         logger.info("fetch_espn_fixtures_completed", season=season, upserted=count)
-
-    # Self-schedule next execution (24h from now). Uses the sport-suffixed job
-    # name so the Lambda EventBridge rule matches Terraform.
-    try:
-        next_time = datetime.now(UTC) + timedelta(hours=DEFAULT_INTERVAL_HOURS)
-        compound_name = make_compound_job_name("fetch-espn-fixtures", SPORT_KEY)
-        await self_schedule(
-            job_name=compound_name,
-            next_time=next_time,
-            dry_run=app_settings.scheduler.dry_run,
-            sport=SPORT_KEY,
-            interval_hours=DEFAULT_INTERVAL_HOURS,
-            reason="fetch-espn-fixtures daily cadence",
-        )
-    except Exception as e:
-        logger.error("fetch_espn_fixtures_scheduling_failed", error=str(e), exc_info=True)
-        from odds_core.alerts import send_error
-
-        await send_error(f"fetch-espn-fixtures scheduling failed: {type(e).__name__}: {e}")
 
 
 async def _fetch_and_upsert_current_season(season: int) -> int:

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -66,6 +66,7 @@ _JOB_MODULE_MAP: dict[str, tuple[str, str]] = {
     "score-predictions": ("odds_lambda.jobs.score_predictions", "main"),
     "daily-digest": ("odds_lambda.jobs.daily_digest", "main"),
     "agent-run": ("odds_lambda.jobs.agent_run", "main"),
+    "fetch-espn-fixtures": ("odds_lambda.jobs.fetch_espn_fixtures", "main"),
 }
 
 # Bootstrap entry-point overrides: jobs listed here use a different function
@@ -95,6 +96,7 @@ _PER_SPORT_JOBS: frozenset[str] = frozenset(
         "score-predictions",
         "daily-digest",
         "agent-run",
+        "fetch-espn-fixtures",
     }
 )
 

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -1234,6 +1234,8 @@ def _derive_standings(fixtures: list[EspnFixture]) -> dict[str, dict[str, Any]]:
     )
     for position, (team, row) in enumerate(ordered, start=1):
         row["position"] = position
+        # Duplicate the team name into the row so callers can flatten via
+        # ``sorted(table.values(), ...)`` without losing the dict key.
         row["team"] = team
 
     return table
@@ -1260,8 +1262,10 @@ async def get_team_context(
       all competitions (PL, FA Cup, League Cup, European) with
       ``days_until_ko``. This is the rotation-risk signal.
     - ``standings`` (when ``include_standings=True``): derived on the fly from
-      Premier League Final rows in the current season. Position assigned by the
-      standard EPL tiebreak chain: points, goal diff, goals for.
+      Premier League Final rows in the current season. Position assigned by a
+      simplified tiebreak chain: points, goal diff, goals for, team name. This
+      omits the official EPL head-to-head step, so ``position`` on a tight
+      3-way tie at the threshold is approximate — do not over-trust it.
 
     Mid-match ``In Progress`` rows are skipped from both last_results and
     upcoming_fixtures; they neither count as form nor as upcoming rotation.

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -15,6 +15,7 @@ from fastmcp import FastMCP
 from odds_analytics.utils import per_book_market_holds
 from odds_core.agent_wakeup_models import AgentWakeup
 from odds_core.database import async_session_maker
+from odds_core.epl_data_models import EspnFixture
 from odds_core.match_brief_models import BriefDecision, MatchBrief, SharpPriceMap
 from odds_core.models import Event, EventStatus, Odds, OddsSnapshot
 from odds_core.odds_math import calculate_implied_probability
@@ -22,6 +23,8 @@ from odds_core.paper_trade_models import PaperTrade
 from odds_core.prediction_models import Prediction
 from odds_core.snapshot_utils import extract_odds_from_snapshot
 from odds_core.sports import SportKey
+from odds_core.team import normalize_team_name
+from odds_lambda.espn_fixture_fetcher import current_season, season_label
 from odds_lambda.jobs.fetch_oddsportal import LEAGUE_SPEC_BY_NAME
 from odds_lambda.paper_trading import (
     get_open_trades,
@@ -1097,6 +1100,261 @@ async def schedule_next_wakeup(
         "delay_hours": delay_hours,
         "reason": reason,
     }
+
+
+# ---------------------------------------------------------------------------
+# ESPN fixture context helpers (used by ``get_team_context``)
+# ---------------------------------------------------------------------------
+
+
+# Matches ESPN's "status.type.description" for completed matches.
+_ESPN_STATUS_FINAL = "Final"
+# ESPN reports an "In Progress" description for currently-live matches. We
+# treat these as neither past nor future so the agent does not mistake a
+# partial score for a final result or schedule the match as "upcoming".
+_ESPN_STATUS_IN_PROGRESS = "In Progress"
+
+_PREMIER_LEAGUE = "Premier League"
+
+
+def _parse_score(value: str) -> int | None:
+    """Parse an ESPN score string (may be blank or non-numeric).
+
+    Returns ``None`` when the value cannot be interpreted as a non-negative int.
+    """
+    if not value:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed < 0:
+        return None
+    return parsed
+
+
+def _outcome_for_score(score_team: int, score_opponent: int) -> str:
+    if score_team > score_opponent:
+        return "W"
+    if score_team < score_opponent:
+        return "L"
+    return "D"
+
+
+def _fixture_to_dict(fixture: EspnFixture, *, as_of: datetime) -> dict[str, Any]:
+    """Serialise an EspnFixture for the upcoming-fixtures view."""
+    days_until = (fixture.date - as_of).total_seconds() / 86400.0
+    return {
+        "date": fixture.date.isoformat(),
+        "opponent": fixture.opponent,
+        "home_away": fixture.home_away,
+        "competition": fixture.competition,
+        "status": fixture.status,
+        "days_until_ko": round(days_until, 3),
+    }
+
+
+def _result_to_dict(fixture: EspnFixture) -> dict[str, Any] | None:
+    """Serialise an EspnFixture into a last-results entry.
+
+    Returns ``None`` when the row does not have parseable integer scores (e.g.
+    status is Final but scores are blank/malformed — an ESPN quirk).
+    """
+    score_team = _parse_score(fixture.score_team)
+    score_opponent = _parse_score(fixture.score_opponent)
+    if score_team is None or score_opponent is None:
+        return None
+    return {
+        "date": fixture.date.isoformat(),
+        "opponent": fixture.opponent,
+        "home_away": fixture.home_away,
+        "score_team": score_team,
+        "score_opponent": score_opponent,
+        "outcome": _outcome_for_score(score_team, score_opponent),
+        "competition": fixture.competition,
+    }
+
+
+def _derive_standings(fixtures: list[EspnFixture]) -> dict[str, dict[str, Any]]:
+    """Build a points table keyed by team from a season's Premier League rows.
+
+    The input is the set of EspnFixture rows for the target season. Only rows
+    where ``competition == "Premier League"`` and ``status == "Final"`` with
+    parseable scores count. Position is assigned by sorting the team-indexed
+    table by (points desc, goal_diff desc, goals_for desc) — the standard EPL
+    tiebreak chain. Each match contributes to both teams' rows (rows are per
+    team in ``espn_fixtures``).
+    """
+    table: dict[str, dict[str, Any]] = {}
+
+    for fixture in fixtures:
+        if fixture.competition != _PREMIER_LEAGUE:
+            continue
+        if fixture.status != _ESPN_STATUS_FINAL:
+            continue
+        score_team = _parse_score(fixture.score_team)
+        score_opponent = _parse_score(fixture.score_opponent)
+        if score_team is None or score_opponent is None:
+            continue
+
+        row = table.setdefault(
+            fixture.team,
+            {
+                "played": 0,
+                "wins": 0,
+                "draws": 0,
+                "losses": 0,
+                "goals_for": 0,
+                "goals_against": 0,
+            },
+        )
+        row["played"] += 1
+        row["goals_for"] += score_team
+        row["goals_against"] += score_opponent
+        if score_team > score_opponent:
+            row["wins"] += 1
+        elif score_team < score_opponent:
+            row["losses"] += 1
+        else:
+            row["draws"] += 1
+
+    # Finalise derived fields and assign positions.
+    for row in table.values():
+        row["goal_diff"] = row["goals_for"] - row["goals_against"]
+        row["points"] = row["wins"] * 3 + row["draws"]
+
+    ordered = sorted(
+        table.items(),
+        key=lambda item: (
+            -item[1]["points"],
+            -item[1]["goal_diff"],
+            -item[1]["goals_for"],
+            item[0],
+        ),
+    )
+    for position, (team, row) in enumerate(ordered, start=1):
+        row["position"] = position
+        row["team"] = team
+
+    return table
+
+
+@mcp.tool()
+async def get_team_context(
+    team: str,
+    as_of: str | None = None,
+    last_n: int = 5,
+    next_n: int = 5,
+    include_standings: bool = True,
+) -> dict[str, Any]:
+    """Fetch form, upcoming fixtures, and league table position for an EPL team.
+
+    Draws from the ``espn_fixtures`` table (refreshed daily by the
+    ``fetch-espn-fixtures`` job). Returns:
+
+    - ``last_results``: up to ``last_n`` most recent Premier-League-only Final
+      fixtures before ``as_of``, each with score, outcome (W/D/L), home/away.
+      PL-only to keep "form" meaningful — cup results sit in upcoming_fixtures
+      via rotation risk, not form.
+    - ``upcoming_fixtures``: next ``next_n`` fixtures after ``as_of`` across
+      all competitions (PL, FA Cup, League Cup, European) with
+      ``days_until_ko``. This is the rotation-risk signal.
+    - ``standings`` (when ``include_standings=True``): derived on the fly from
+      Premier League Final rows in the current season. Position assigned by the
+      standard EPL tiebreak chain: points, goal diff, goals for.
+
+    Mid-match ``In Progress`` rows are skipped from both last_results and
+    upcoming_fixtures; they neither count as form nor as upcoming rotation.
+
+    Args:
+        team: Canonical team name (matches the output of
+            ``odds_core.team.normalize_team_name`` — e.g. "Manchester Utd",
+            "Tottenham", "Wolves"). Common variants are also accepted.
+        as_of: ISO datetime cutoff. Defaults to now. Used to split fixtures
+            into past vs upcoming; also used to compute ``days_until_ko``.
+        last_n: Max last-results entries to return. Clamped to >= 1.
+        next_n: Max upcoming-fixtures entries to return. Clamped to >= 1.
+        include_standings: When True, include the derived table. The returned
+            ``standings.team_row`` is the target team's row; ``standings.table``
+            is the full 20-team ordering.
+
+    Returns:
+        Dict with ``team``, ``as_of``, ``season``, ``last_results``,
+        ``upcoming_fixtures``, and (optionally) ``standings``.
+    """
+    canonical_team = normalize_team_name(team)
+
+    if as_of is None:
+        resolved_as_of = datetime.now(UTC)
+    else:
+        parsed = datetime.fromisoformat(as_of.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        resolved_as_of = parsed
+
+    last_n = max(1, last_n)
+    next_n = max(1, next_n)
+
+    season = current_season(resolved_as_of)
+    season_lbl = season_label(season)
+
+    async with async_session_maker() as session:
+        # Team-scoped rows: drive last_results + upcoming_fixtures.
+        team_query = (
+            select(EspnFixture).where(EspnFixture.team == canonical_team).order_by(EspnFixture.date)
+        )
+        team_result = await session.execute(team_query)
+        team_rows = list(team_result.scalars().all())
+
+        # Season-scoped rows for all teams: drive standings derivation.
+        standings_rows: list[EspnFixture] = []
+        if include_standings:
+            standings_query = (
+                select(EspnFixture)
+                .where(EspnFixture.season == season_lbl)
+                .order_by(EspnFixture.date)
+            )
+            standings_result = await session.execute(standings_query)
+            standings_rows = list(standings_result.scalars().all())
+
+    # Split team_rows into past (Final, PL only) and upcoming (any competition,
+    # not started). "In Progress" is skipped on both sides.
+    last_results: list[dict[str, Any]] = []
+    upcoming: list[dict[str, Any]] = []
+    for row in team_rows:
+        if row.status == _ESPN_STATUS_IN_PROGRESS:
+            continue
+        if row.date < resolved_as_of:
+            if row.status != _ESPN_STATUS_FINAL or row.competition != _PREMIER_LEAGUE:
+                continue
+            entry = _result_to_dict(row)
+            if entry is not None:
+                last_results.append(entry)
+        elif row.date >= resolved_as_of:
+            upcoming.append(_fixture_to_dict(row, as_of=resolved_as_of))
+
+    # Newest-first on last_results; already date-asc on upcoming.
+    last_results.reverse()
+    last_results = last_results[:last_n]
+    upcoming_fixtures = upcoming[:next_n]
+
+    response: dict[str, Any] = {
+        "team": canonical_team,
+        "as_of": resolved_as_of.isoformat(),
+        "season": season_lbl,
+        "last_results": last_results,
+        "upcoming_fixtures": upcoming_fixtures,
+    }
+
+    if include_standings:
+        table = _derive_standings(standings_rows)
+        team_row = table.get(canonical_team)
+        response["standings"] = {
+            "team_row": team_row,
+            "table": sorted(table.values(), key=lambda r: r["position"]),
+        }
+
+    return response
 
 
 if __name__ == "__main__":

--- a/scripts/ingest_espn_fixtures.py
+++ b/scripts/ingest_espn_fixtures.py
@@ -3,31 +3,40 @@
 
 Downloads fixture schedules for every EPL team across all relevant competitions
 (Premier League, FA Cup, League Cup, Champions League, Europa League, Conference
-League) and writes one CSV per season to data/espn_fixtures/.
+League) and writes one CSV per season to data/espn_fixtures/ and/or upserts
+to the database.
 
 These CSVs are loaded as a pandas DataFrame by the training pipeline to provide
 accurate rest-day and congestion features that account for midweek European and
 cup matches.
 
 Usage:
-    # Fetch all seasons (2015-2025)
+    # Fetch all seasons (2015 onwards) — CSV + DB
     uv run python scripts/ingest_espn_fixtures.py
 
     # Fetch a single season
     uv run python scripts/ingest_espn_fixtures.py --season 2024
+
+    # CSV-only (no DB write)
+    uv run python scripts/ingest_espn_fixtures.py --skip-db
+
+Live daily refresh of the current season is handled by the
+``fetch-espn-fixtures`` scheduled job — this script is for backfill / manual
+multi-season ingest / CSV export.
 """
 
 from __future__ import annotations
 
 import argparse
+import asyncio
 import csv
 import logging
-import time
 from pathlib import Path
-from typing import Any
 
-import httpx
-from team_names import normalize_team as _normalize_team_central
+from odds_core.database import async_session_maker
+from odds_core.epl_data_models import EspnFixtureRecord
+from odds_lambda.espn_fixture_fetcher import SEASONS, EspnFixtureFetcher
+from odds_lambda.storage.espn_fixture_writer import EspnFixtureWriter
 
 logging.basicConfig(
     level=logging.INFO,
@@ -37,36 +46,6 @@ logging.basicConfig(
 log = logging.getLogger("ingest_espn_fixtures")
 
 DATA_DIR = Path(__file__).resolve().parent.parent / "data" / "espn_fixtures"
-
-BASE_URL = "http://site.api.espn.com/apis/site/v2/sports/soccer"
-
-# ESPN league slugs for all competitions an EPL team might play in.
-LEAGUE_SLUGS: dict[str, str] = {
-    "eng.1": "Premier League",
-    "eng.fa": "FA Cup",
-    "eng.league_cup": "League Cup",
-    "uefa.champions": "Champions League",
-    "uefa.europa": "Europa League",
-    "uefa.europa.conf": "Conference League",
-}
-
-# European competition names for tagging.
-EUROPEAN_COMPETITIONS = frozenset({"Champions League", "Europa League", "Conference League"})
-
-# Seasons: start year -> display label (matches FDUK convention).
-SEASONS: dict[int, str] = {
-    2015: "2015-16",
-    2016: "2016-17",
-    2017: "2017-18",
-    2018: "2018-19",
-    2019: "2019-20",
-    2020: "2020-21",
-    2021: "2021-22",
-    2022: "2022-23",
-    2023: "2023-24",
-    2024: "2024-25",
-    2025: "2025-26",
-}
 
 CSV_COLUMNS = [
     "date",
@@ -80,153 +59,22 @@ CSV_COLUMNS = [
     "status",
 ]
 
-REQUEST_DELAY = 0.5  # seconds between HTTP requests
+
+def _record_to_csv_row(record: EspnFixtureRecord) -> dict[str, str]:
+    return {
+        "date": record.date.isoformat().replace("+00:00", "Z"),
+        "team": record.team,
+        "opponent": record.opponent,
+        "competition": record.competition,
+        "match_round": record.match_round,
+        "home_away": record.home_away,
+        "score_team": record.score_team,
+        "score_opponent": record.score_opponent,
+        "status": record.status,
+    }
 
 
-def _normalize_team(espn_name: str) -> str:
-    """Convert ESPN displayName to pipeline canonical name."""
-    return _normalize_team_central(espn_name)
-
-
-def _fetch_json(client: httpx.Client, url: str) -> dict[str, Any]:
-    """Fetch JSON from ESPN API with retry."""
-    for attempt in range(3):
-        try:
-            resp = client.get(url, timeout=15)
-            resp.raise_for_status()
-            return resp.json()
-        except (httpx.HTTPError, httpx.TimeoutException) as e:
-            if attempt == 2:
-                raise
-            log.warning(f"  Retry {attempt + 1} for {url}: {e}")
-            time.sleep(1)
-    raise RuntimeError("unreachable")
-
-
-def _extract_score(competitor: dict[str, Any]) -> str:
-    """Extract score from a competitor entry. Returns empty string if unavailable."""
-    score = competitor.get("score")
-    if score is None:
-        return ""
-    if isinstance(score, dict):
-        return score.get("displayValue", "")
-    return str(score)
-
-
-def fetch_teams(client: httpx.Client, season: int) -> list[dict[str, str]]:
-    """Fetch EPL teams for a season. Returns list of {id, name}."""
-    url = f"{BASE_URL}/eng.1/teams?season={season}"
-    data = _fetch_json(client, url)
-    teams = data["sports"][0]["leagues"][0]["teams"]
-    return [{"id": t["team"]["id"], "name": t["team"]["displayName"]} for t in teams]
-
-
-def fetch_team_schedule(
-    client: httpx.Client,
-    league_slug: str,
-    team_id: str,
-    season: int,
-) -> list[dict[str, str]]:
-    """Fetch a team's schedule for one competition/season.
-
-    Returns list of fixture dicts matching CSV_COLUMNS.
-    """
-    url = f"{BASE_URL}/{league_slug}/teams/{team_id}/schedule?season={season}"
-    data = _fetch_json(client, url)
-    events = data.get("events", [])
-    competition = LEAGUE_SLUGS[league_slug]
-    fixtures: list[dict[str, str]] = []
-
-    for event in events:
-        date_str = event.get("date", "")
-        if not date_str:
-            continue
-
-        comps = event.get("competitions", [])
-        if not comps:
-            continue
-
-        comp = comps[0]
-        competitors = comp.get("competitors", [])
-        if len(competitors) != 2:
-            continue
-
-        # Identify team and opponent from competitors
-        team_entry = None
-        opponent_entry = None
-        for c in competitors:
-            if c["team"]["id"] == team_id:
-                team_entry = c
-            else:
-                opponent_entry = c
-
-        if team_entry is None or opponent_entry is None:
-            continue
-
-        team_name = _normalize_team(team_entry["team"]["displayName"])
-        opponent_name = _normalize_team(opponent_entry["team"]["displayName"])
-
-        # Status
-        status_type = comp.get("status", {}).get("type", {})
-        status = status_type.get("description", "")
-
-        # Round/phase
-        round_name = event.get("seasonType", {}).get("name", "")
-
-        fixtures.append(
-            {
-                "date": date_str,
-                "team": team_name,
-                "opponent": opponent_name,
-                "competition": competition,
-                "match_round": round_name,
-                "home_away": team_entry["homeAway"],
-                "score_team": _extract_score(team_entry),
-                "score_opponent": _extract_score(opponent_entry),
-                "status": status,
-            }
-        )
-
-    return fixtures
-
-
-def fetch_season(client: httpx.Client, season: int) -> list[dict[str, str]]:
-    """Fetch all fixtures for all EPL teams in a season across all competitions."""
-    teams = fetch_teams(client, season)
-    log.info(f"  Found {len(teams)} teams")
-
-    all_fixtures: list[dict[str, str]] = []
-    seen: set[tuple[str, str, str]] = set()  # (date, team, opponent) for dedup
-
-    for i, team in enumerate(teams):
-        team_id = team["id"]
-        team_name = _normalize_team(team["name"])
-        team_fixtures = 0
-
-        for league_slug in LEAGUE_SLUGS:
-            time.sleep(REQUEST_DELAY)
-            try:
-                fixtures = fetch_team_schedule(client, league_slug, team_id, season)
-            except Exception as e:
-                log.warning(f"  Failed {team_name} {league_slug}: {e}")
-                continue
-
-            for f in fixtures:
-                # Dedup: each match appears twice (once per team)
-                key = (f["date"], f["team"], f["opponent"])
-                if key not in seen:
-                    seen.add(key)
-                    all_fixtures.append(f)
-                    team_fixtures += 1
-
-        log.info(f"  [{i + 1}/{len(teams)}] {team_name}: {team_fixtures} new fixtures")
-
-    # Sort by date
-    all_fixtures.sort(key=lambda f: f["date"])
-    return all_fixtures
-
-
-def write_csv(fixtures: list[dict[str, str]], season: int) -> Path:
+def write_csv(records: list[EspnFixtureRecord], season: int) -> Path:
     """Write fixtures to CSV file."""
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     label = SEASONS[season]
@@ -235,47 +83,40 @@ def write_csv(fixtures: list[dict[str, str]], season: int) -> Path:
     with open(path, "w", newline="") as fh:
         writer = csv.DictWriter(fh, fieldnames=CSV_COLUMNS)
         writer.writeheader()
-        writer.writerows(fixtures)
+        writer.writerows(_record_to_csv_row(r) for r in records)
 
     return path
 
 
-async def write_db(fixtures: list[dict[str, str]], season: int) -> int:
+async def write_db(records: list[EspnFixtureRecord]) -> int:
     """Write fixtures to database via EspnFixtureWriter."""
-    from datetime import UTC, datetime
-
-    from odds_core.database import async_session_maker
-    from odds_core.epl_data_models import EspnFixtureRecord
-    from odds_lambda.storage.espn_fixture_writer import EspnFixtureWriter
-
-    label = SEASONS[season]
-    records: list[EspnFixtureRecord] = []
-    for f in fixtures:
-        date_str = f["date"]
-        dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=UTC)
-        records.append(
-            EspnFixtureRecord(
-                date=dt,
-                team=f["team"],
-                opponent=f["opponent"],
-                competition=f["competition"],
-                match_round=f.get("match_round", ""),
-                home_away=f["home_away"],
-                score_team=f.get("score_team", ""),
-                score_opponent=f.get("score_opponent", ""),
-                status=f.get("status", ""),
-                season=label,
-            )
-        )
-
     async with async_session_maker() as session:
         writer = EspnFixtureWriter(session)
         count = await writer.upsert_fixtures(records)
         await session.commit()
-
     return count
+
+
+async def _run(seasons: list[int], skip_db: bool) -> None:
+    total_records = 0
+
+    async with EspnFixtureFetcher() as fetcher:
+        season_records: list[tuple[int, list[EspnFixtureRecord]]] = []
+        for season in seasons:
+            label = SEASONS[season]
+            log.info(f"[{label}] Fetching fixtures...")
+            records = await fetcher.fetch_season(season)
+            path = write_csv(records, season)
+            total_records += len(records)
+            log.info(f"[{label}] Wrote {len(records)} fixtures to {path}")
+            season_records.append((season, records))
+
+    if not skip_db:
+        for season, records in season_records:
+            count = await write_db(records)
+            log.info(f"[{SEASONS[season]}] Upserted {count} fixtures to database")
+
+    log.info(f"\nTotal: {total_records} fixtures across {len(seasons)} seasons")
 
 
 def main() -> None:
@@ -300,34 +141,7 @@ def main() -> None:
     else:
         seasons = sorted(SEASONS.keys())
 
-    client = httpx.Client()
-    total_fixtures = 0
-    # Collect per-season data for a single async DB write pass
-    season_data: list[tuple[list[dict[str, str]], int]] = []
-
-    try:
-        for season in seasons:
-            label = SEASONS[season]
-            log.info(f"[{label}] Fetching fixtures...")
-            fixtures = fetch_season(client, season)
-            path = write_csv(fixtures, season)
-            total_fixtures += len(fixtures)
-            log.info(f"[{label}] Wrote {len(fixtures)} fixtures to {path}")
-            season_data.append((fixtures, season))
-    finally:
-        client.close()
-
-    if not args.skip_db and season_data:
-        import asyncio
-
-        async def _write_all() -> None:
-            for fixtures, season in season_data:
-                count = await write_db(fixtures, season)
-                log.info(f"[{SEASONS[season]}] Upserted {count} fixtures to database")
-
-        asyncio.run(_write_all())
-
-    log.info(f"\nTotal: {total_fixtures} fixtures across {len(seasons)} seasons")
+    asyncio.run(_run(seasons, skip_db=args.skip_db))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_espn_fixture_fetcher.py
+++ b/tests/unit/test_espn_fixture_fetcher.py
@@ -1,0 +1,258 @@
+"""Unit tests for EspnFixtureFetcher and the current_season helper."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import pytest
+from odds_lambda.espn_fixture_fetcher import (
+    EspnFixtureFetcher,
+    current_season,
+    season_label,
+)
+
+
+class TestCurrentSeason:
+    def test_august_flips_to_new_season(self) -> None:
+        # 1 Aug 2025 → 2025-26 season.
+        assert current_season(datetime(2025, 8, 1, tzinfo=UTC)) == 2025
+
+    def test_july_still_previous_season(self) -> None:
+        # 31 Jul 2025 → 2024-25 season (still).
+        assert current_season(datetime(2025, 7, 31, tzinfo=UTC)) == 2024
+
+    def test_january_previous_year(self) -> None:
+        # 15 Jan 2026 → 2025-26 season (start year 2025).
+        assert current_season(datetime(2026, 1, 15, tzinfo=UTC)) == 2025
+
+    def test_december_current_year(self) -> None:
+        # 15 Dec 2025 → 2025-26 season (start year 2025).
+        assert current_season(datetime(2025, 12, 15, tzinfo=UTC)) == 2025
+
+    def test_default_uses_now(self) -> None:
+        # Just exercise the default path; value depends on clock.
+        assert isinstance(current_season(), int)
+
+
+class TestSeasonLabel:
+    def test_known_season(self) -> None:
+        assert season_label(2024) == "2024-25"
+        assert season_label(2025) == "2025-26"
+
+    def test_derived_future_season(self) -> None:
+        # Seasons past the static table still get a sensible label.
+        assert season_label(2099) == "2099-00"
+
+
+def _team_list_payload(teams: list[tuple[str, str]]) -> dict[str, Any]:
+    """Build a minimal ESPN `/teams` response with the given (id, name) pairs."""
+    return {
+        "sports": [
+            {
+                "leagues": [
+                    {
+                        "teams": [
+                            {"team": {"id": team_id, "displayName": name}}
+                            for team_id, name in teams
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+
+def _schedule_payload(
+    *,
+    team_id: str,
+    opponent_id: str,
+    team_name: str,
+    opponent_name: str,
+    date: str,
+    home_away: str = "home",
+    score_team: str | None = None,
+    score_opponent: str | None = None,
+    status: str = "Scheduled",
+    season_name: str = "Regular Season",
+) -> dict[str, Any]:
+    """Build a minimal ESPN `/teams/{id}/schedule` response containing one event."""
+    opponent_home_away = "away" if home_away == "home" else "home"
+    team_competitor: dict[str, Any] = {
+        "team": {"id": team_id, "displayName": team_name},
+        "homeAway": home_away,
+    }
+    opponent_competitor: dict[str, Any] = {
+        "team": {"id": opponent_id, "displayName": opponent_name},
+        "homeAway": opponent_home_away,
+    }
+    if score_team is not None:
+        team_competitor["score"] = {"displayValue": score_team}
+    if score_opponent is not None:
+        opponent_competitor["score"] = {"displayValue": score_opponent}
+
+    return {
+        "events": [
+            {
+                "date": date,
+                "seasonType": {"name": season_name},
+                "competitions": [
+                    {
+                        "competitors": [team_competitor, opponent_competitor],
+                        "status": {"type": {"description": status}},
+                    }
+                ],
+            }
+        ]
+    }
+
+
+class TestEspnFixtureFetcher:
+    """End-to-end tests for EspnFixtureFetcher with a mock httpx client."""
+
+    @pytest.fixture
+    def transport_responses(self) -> dict[str, dict[str, Any]]:
+        """URL prefix -> JSON response body. Matched by URL `startswith` on handler."""
+        return {}
+
+    @pytest.fixture
+    def mock_client(self, transport_responses: dict[str, dict[str, Any]]) -> httpx.AsyncClient:
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = str(request.url)
+            # Match by longest prefix first to avoid `/teams` shadowing
+            # `/teams/{id}/schedule`.
+            best_match: str | None = None
+            for prefix in transport_responses:
+                if url.startswith(prefix) and (best_match is None or len(prefix) > len(best_match)):
+                    best_match = prefix
+            if best_match is not None:
+                return httpx.Response(200, json=transport_responses[best_match])
+            # No match — return 404 so tests surface unexpected URLs loudly.
+            return httpx.Response(404, json={"error": "unexpected", "url": url})
+
+        transport = httpx.MockTransport(handler)
+        return httpx.AsyncClient(transport=transport)
+
+    @pytest.mark.asyncio
+    async def test_fetch_season_produces_normalised_records(
+        self,
+        mock_client: httpx.AsyncClient,
+        transport_responses: dict[str, dict[str, Any]],
+    ) -> None:
+        # Arrange: 2 EPL teams, each with one PL fixture; other competitions empty.
+        transport_responses["http://site.api.espn.com/apis/site/v2/sports/soccer/eng.1/teams"] = (
+            _team_list_payload([("1", "Arsenal"), ("2", "Wolverhampton Wanderers")])
+        )
+
+        # Premier League schedules: one match between Arsenal and Wolves.
+        # Each team's feed returns the same match mirrored (home_away swapped),
+        # which should be deduplicated by the fetcher.
+        transport_responses[
+            "http://site.api.espn.com/apis/site/v2/sports/soccer/eng.1/teams/1/schedule"
+        ] = _schedule_payload(
+            team_id="1",
+            opponent_id="2",
+            team_name="Arsenal",
+            opponent_name="Wolverhampton Wanderers",
+            date="2025-08-17T15:00:00Z",
+            home_away="home",
+            score_team="2",
+            score_opponent="1",
+            status="Final",
+        )
+        transport_responses[
+            "http://site.api.espn.com/apis/site/v2/sports/soccer/eng.1/teams/2/schedule"
+        ] = _schedule_payload(
+            team_id="2",
+            opponent_id="1",
+            team_name="Wolverhampton Wanderers",
+            opponent_name="Arsenal",
+            date="2025-08-17T15:00:00Z",
+            home_away="away",
+            score_team="1",
+            score_opponent="2",
+            status="Final",
+        )
+
+        # All other competition endpoints: empty events list.
+        for slug in (
+            "eng.fa",
+            "eng.league_cup",
+            "uefa.champions",
+            "uefa.europa",
+            "uefa.europa.conf",
+        ):
+            for team_id in ("1", "2"):
+                transport_responses[
+                    f"http://site.api.espn.com/apis/site/v2/sports/soccer/{slug}/teams/{team_id}/schedule"
+                ] = {"events": []}
+
+        # Act
+        async with EspnFixtureFetcher(client=mock_client, request_delay_seconds=0.0) as fetcher:
+            records = await fetcher.fetch_season(2025)
+
+        # Assert: two distinct rows (one per team) for the same match.
+        assert len(records) == 2
+
+        arsenal_row = next(r for r in records if r.team == "Arsenal")
+        wolves_row = next(r for r in records if r.team == "Wolves")
+
+        # Normalisation worked (Wolverhampton Wanderers → Wolves)
+        assert arsenal_row.opponent == "Wolves"
+        assert wolves_row.opponent == "Arsenal"
+
+        # Home/away is team-relative
+        assert arsenal_row.home_away == "home"
+        assert wolves_row.home_away == "away"
+
+        # Scores team-relative
+        assert arsenal_row.score_team == "2"
+        assert arsenal_row.score_opponent == "1"
+        assert wolves_row.score_team == "1"
+        assert wolves_row.score_opponent == "2"
+
+        # Status + competition propagated
+        assert arsenal_row.status == "Final"
+        assert arsenal_row.competition == "Premier League"
+
+        # Date parsed as UTC-aware datetime
+        assert arsenal_row.date == datetime(2025, 8, 17, 15, 0, tzinfo=UTC)
+
+        # Season label uses the display form
+        assert arsenal_row.season == "2025-26"
+
+    @pytest.mark.asyncio
+    async def test_fetch_season_swallows_single_competition_failure(
+        self,
+        mock_client: httpx.AsyncClient,
+        transport_responses: dict[str, dict[str, Any]],
+    ) -> None:
+        # Only one team; FA Cup endpoint returns 404 (unmatched). Other
+        # competitions should still fetch normally and the job must not abort.
+        transport_responses["http://site.api.espn.com/apis/site/v2/sports/soccer/eng.1/teams"] = (
+            _team_list_payload([("1", "Arsenal")])
+        )
+
+        # PL endpoint works
+        transport_responses[
+            "http://site.api.espn.com/apis/site/v2/sports/soccer/eng.1/teams/1/schedule"
+        ] = _schedule_payload(
+            team_id="1",
+            opponent_id="99",
+            team_name="Arsenal",
+            opponent_name="Chelsea",
+            date="2025-09-01T15:00:00Z",
+            status="Final",
+            score_team="3",
+            score_opponent="0",
+        )
+        # Remaining competitions have no schedule registered → handler returns 404.
+
+        async with EspnFixtureFetcher(client=mock_client, request_delay_seconds=0.0) as fetcher:
+            records = await fetcher.fetch_season(2025)
+
+        # PL fixture still ingested even though the other endpoints 404'd.
+        assert len(records) == 1
+        assert records[0].team == "Arsenal"
+        assert records[0].opponent == "Chelsea"

--- a/tests/unit/test_get_team_context.py
+++ b/tests/unit/test_get_team_context.py
@@ -1,0 +1,539 @@
+"""Unit tests for the ``get_team_context`` MCP tool and standings derivation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from odds_core.epl_data_models import EspnFixtureRecord
+from odds_lambda.storage.espn_fixture_writer import EspnFixtureWriter
+
+
+def _pl_record(
+    *,
+    team: str,
+    opponent: str,
+    date: datetime,
+    home_away: str,
+    score_team: str,
+    score_opponent: str,
+    status: str = "Final",
+    competition: str = "Premier League",
+    season: str = "2025-26",
+) -> EspnFixtureRecord:
+    return EspnFixtureRecord(
+        date=date,
+        team=team,
+        opponent=opponent,
+        competition=competition,
+        match_round="Regular Season",
+        home_away=home_away,
+        score_team=score_team,
+        score_opponent=score_opponent,
+        status=status,
+        season=season,
+    )
+
+
+def _match_records(
+    home: str,
+    away: str,
+    *,
+    date: datetime,
+    score_home: int,
+    score_away: int,
+    status: str = "Final",
+    competition: str = "Premier League",
+    season: str = "2025-26",
+) -> list[EspnFixtureRecord]:
+    """Both sides of a single match as paired fixture records."""
+    return [
+        _pl_record(
+            team=home,
+            opponent=away,
+            date=date,
+            home_away="home",
+            score_team=str(score_home),
+            score_opponent=str(score_away),
+            status=status,
+            competition=competition,
+            season=season,
+        ),
+        _pl_record(
+            team=away,
+            opponent=home,
+            date=date,
+            home_away="away",
+            score_team=str(score_away),
+            score_opponent=str(score_home),
+            status=status,
+            competition=competition,
+            season=season,
+        ),
+    ]
+
+
+class TestDeriveStandings:
+    """Hand-crafted fixture sets → known-good standings."""
+
+    def _build(self, records: list[EspnFixtureRecord]) -> list[Any]:
+        # Build fake EspnFixture objects with the fields the deriver reads.
+        rows: list[Any] = []
+        for r in records:
+            row = MagicMock()
+            row.team = r.team
+            row.opponent = r.opponent
+            row.competition = r.competition
+            row.status = r.status
+            row.score_team = r.score_team
+            row.score_opponent = r.score_opponent
+            row.date = r.date
+            rows.append(row)
+        return rows
+
+    def test_three_teams_round_robin(self) -> None:
+        from odds_mcp.server import _derive_standings
+
+        # A beats B 2-0, A draws C 1-1, B beats C 3-1
+        records: list[EspnFixtureRecord] = []
+        records.extend(
+            _match_records(
+                "A",
+                "B",
+                date=datetime(2025, 8, 10, 15, 0, tzinfo=UTC),
+                score_home=2,
+                score_away=0,
+            )
+        )
+        records.extend(
+            _match_records(
+                "A",
+                "C",
+                date=datetime(2025, 8, 17, 15, 0, tzinfo=UTC),
+                score_home=1,
+                score_away=1,
+            )
+        )
+        records.extend(
+            _match_records(
+                "B",
+                "C",
+                date=datetime(2025, 8, 24, 15, 0, tzinfo=UTC),
+                score_home=3,
+                score_away=1,
+            )
+        )
+
+        table = _derive_standings(self._build(records))
+
+        # A: played 2, W1 D1 L0 → 4 pts, GF 3, GA 1, GD +2
+        a = table["A"]
+        assert a["played"] == 2
+        assert a["wins"] == 1
+        assert a["draws"] == 1
+        assert a["losses"] == 0
+        assert a["goals_for"] == 3
+        assert a["goals_against"] == 1
+        assert a["goal_diff"] == 2
+        assert a["points"] == 4
+
+        # B: played 2, W1 D0 L1 → 3 pts, GF 3, GA 3, GD 0
+        b = table["B"]
+        assert b["played"] == 2
+        assert b["wins"] == 1
+        assert b["losses"] == 1
+        assert b["points"] == 3
+        assert b["goals_for"] == 3
+        assert b["goals_against"] == 3
+
+        # C: played 2, W0 D1 L1 → 1 pt, GF 2, GA 4, GD -2
+        c = table["C"]
+        assert c["points"] == 1
+        assert c["goal_diff"] == -2
+
+        # Position ordering: A (4 pts) → B (3 pts) → C (1 pt)
+        assert a["position"] == 1
+        assert b["position"] == 2
+        assert c["position"] == 3
+
+    def test_position_tiebreak_by_goal_diff_then_gf(self) -> None:
+        from odds_mcp.server import _derive_standings
+
+        # X, Y, Z all play 2 games, all end with 4 pts, differentiated by GD/GF.
+        # X: beats Y 3-0, draws Z 0-0 → 4 pts, GD +3, GF 3
+        # Y: loses to X 0-3, beats Z 2-0 → 3 pts
+        # Z: draws X 0-0, loses to Y 0-2 → 1 pt
+        # Add W that mirrors X's points with different GD to force tiebreak:
+        # Actually let's build a cleaner tie: two teams on same pts & GD, differ on GF.
+        records: list[EspnFixtureRecord] = []
+        records.extend(
+            _match_records(
+                "X",
+                "Z",
+                date=datetime(2025, 8, 10, 15, 0, tzinfo=UTC),
+                score_home=4,
+                score_away=2,
+            )
+        )
+        records.extend(
+            _match_records(
+                "Y",
+                "Z",
+                date=datetime(2025, 8, 17, 15, 0, tzinfo=UTC),
+                score_home=3,
+                score_away=1,
+            )
+        )
+        # Now X and Y both have 3 pts, GD +2; X has GF 4 vs Y's GF 3.
+        table = _derive_standings(self._build(records))
+        assert table["X"]["points"] == 3
+        assert table["Y"]["points"] == 3
+        assert table["X"]["goal_diff"] == 2
+        assert table["Y"]["goal_diff"] == 2
+        # X has more goals for → ranks above Y
+        assert table["X"]["position"] == 1
+        assert table["Y"]["position"] == 2
+
+    def test_only_counts_premier_league(self) -> None:
+        from odds_mcp.server import _derive_standings
+
+        # An FA Cup win does NOT count toward the league table.
+        records: list[EspnFixtureRecord] = []
+        records.extend(
+            _match_records(
+                "A",
+                "B",
+                date=datetime(2025, 8, 10, 15, 0, tzinfo=UTC),
+                score_home=3,
+                score_away=0,
+                competition="FA Cup",
+            )
+        )
+        table = _derive_standings(self._build(records))
+        assert table == {}
+
+    def test_only_counts_final_status(self) -> None:
+        from odds_mcp.server import _derive_standings
+
+        records: list[EspnFixtureRecord] = []
+        records.extend(
+            _match_records(
+                "A",
+                "B",
+                date=datetime(2025, 8, 10, 15, 0, tzinfo=UTC),
+                score_home=3,
+                score_away=0,
+                status="Scheduled",
+            )
+        )
+        table = _derive_standings(self._build(records))
+        assert table == {}
+
+    def test_skips_malformed_scores(self) -> None:
+        from odds_mcp.server import _derive_standings
+
+        # Final row with blank scores (ESPN quirk) is ignored.
+        records: list[EspnFixtureRecord] = []
+        records.extend(
+            _match_records(
+                "A",
+                "B",
+                date=datetime(2025, 8, 10, 15, 0, tzinfo=UTC),
+                score_home=2,
+                score_away=1,
+            )
+        )
+        # Corrupt the second match: Final, but blank scores.
+        bad_home = _pl_record(
+            team="A",
+            opponent="C",
+            date=datetime(2025, 8, 17, 15, 0, tzinfo=UTC),
+            home_away="home",
+            score_team="",
+            score_opponent="",
+        )
+        bad_away = _pl_record(
+            team="C",
+            opponent="A",
+            date=datetime(2025, 8, 17, 15, 0, tzinfo=UTC),
+            home_away="away",
+            score_team="",
+            score_opponent="",
+        )
+        records.extend([bad_home, bad_away])
+
+        table = _derive_standings(self._build(records))
+        # A has played 1, not 2, because the blank-score row was dropped.
+        assert table["A"]["played"] == 1
+        assert table["B"]["played"] == 1
+        assert "C" not in table
+
+
+class TestGetTeamContextAsOf:
+    """Integration-ish: seed ESPN fixtures, call the MCP tool, assert semantics."""
+
+    @pytest.mark.asyncio
+    async def test_last_results_respects_as_of_cutoff(
+        self, pglite_async_session, test_engine
+    ) -> None:
+        """as_of must exclude fixtures strictly in the future (no look-ahead)."""
+        from odds_mcp import server as mcp_server
+
+        writer = EspnFixtureWriter(pglite_async_session)
+
+        # Arsenal record: one completed PL match in the past (1 Sep), one
+        # upcoming (15 Sep). With as_of = 10 Sep, only the 1 Sep result counts.
+        records: list[EspnFixtureRecord] = []
+        records.extend(
+            _match_records(
+                "Arsenal",
+                "Chelsea",
+                date=datetime(2025, 9, 1, 15, 0, tzinfo=UTC),
+                score_home=2,
+                score_away=1,
+            )
+        )
+        records.extend(
+            _match_records(
+                "Arsenal",
+                "Liverpool",
+                date=datetime(2025, 9, 15, 15, 0, tzinfo=UTC),
+                score_home=0,
+                score_away=0,
+                status="Scheduled",
+            )
+        )
+        await writer.upsert_fixtures(records)
+        await pglite_async_session.commit()
+
+        from sqlalchemy.ext.asyncio import async_sessionmaker
+
+        test_session_maker = async_sessionmaker(test_engine, expire_on_commit=False)
+
+        with patch.object(mcp_server, "async_session_maker", test_session_maker):
+            result = await mcp_server.get_team_context(
+                team="Arsenal",
+                as_of="2025-09-10T00:00:00Z",
+                last_n=5,
+                next_n=5,
+                include_standings=False,
+            )
+
+        assert result["team"] == "Arsenal"
+        assert len(result["last_results"]) == 1
+        assert result["last_results"][0]["opponent"] == "Chelsea"
+        assert result["last_results"][0]["outcome"] == "W"
+        # Upcoming: Liverpool fixture still in the future.
+        assert len(result["upcoming_fixtures"]) == 1
+        assert result["upcoming_fixtures"][0]["opponent"] == "Liverpool"
+
+    @pytest.mark.asyncio
+    async def test_in_progress_rows_skipped_from_both_sides(
+        self, pglite_async_session, test_engine
+    ) -> None:
+        from odds_mcp import server as mcp_server
+        from sqlalchemy.ext.asyncio import async_sessionmaker
+
+        writer = EspnFixtureWriter(pglite_async_session)
+
+        # A match currently in progress should NOT appear in last_results (no
+        # final score yet) nor in upcoming_fixtures (already kicked off).
+        records: list[EspnFixtureRecord] = []
+        records.extend(
+            _match_records(
+                "Arsenal",
+                "Chelsea",
+                date=datetime(2025, 9, 10, 14, 0, tzinfo=UTC),
+                score_home=1,
+                score_away=0,
+                status="In Progress",
+            )
+        )
+        await writer.upsert_fixtures(records)
+        await pglite_async_session.commit()
+
+        test_session_maker = async_sessionmaker(test_engine, expire_on_commit=False)
+
+        with patch.object(mcp_server, "async_session_maker", test_session_maker):
+            # as_of slightly after kickoff (match is live)
+            result = await mcp_server.get_team_context(
+                team="Arsenal",
+                as_of="2025-09-10T15:00:00Z",
+                last_n=5,
+                next_n=5,
+                include_standings=False,
+            )
+
+        assert result["last_results"] == []
+        assert result["upcoming_fixtures"] == []
+
+    @pytest.mark.asyncio
+    async def test_normalises_team_alias(self, pglite_async_session, test_engine) -> None:
+        """Inputs like 'Wolverhampton Wanderers' resolve to canonical 'Wolves'."""
+        from odds_mcp import server as mcp_server
+        from sqlalchemy.ext.asyncio import async_sessionmaker
+
+        writer = EspnFixtureWriter(pglite_async_session)
+        records = _match_records(
+            "Wolves",
+            "Arsenal",
+            date=datetime(2025, 9, 1, 15, 0, tzinfo=UTC),
+            score_home=1,
+            score_away=0,
+        )
+        await writer.upsert_fixtures(records)
+        await pglite_async_session.commit()
+
+        test_session_maker = async_sessionmaker(test_engine, expire_on_commit=False)
+
+        with patch.object(mcp_server, "async_session_maker", test_session_maker):
+            result = await mcp_server.get_team_context(
+                team="Wolverhampton Wanderers",
+                as_of="2025-09-10T00:00:00Z",
+                include_standings=False,
+            )
+
+        assert result["team"] == "Wolves"
+        assert len(result["last_results"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_upcoming_includes_cup_competitions(
+        self, pglite_async_session, test_engine
+    ) -> None:
+        from odds_mcp import server as mcp_server
+        from sqlalchemy.ext.asyncio import async_sessionmaker
+
+        writer = EspnFixtureWriter(pglite_async_session)
+        records: list[EspnFixtureRecord] = []
+        records.extend(
+            _match_records(
+                "Arsenal",
+                "Chelsea",
+                date=datetime(2025, 9, 15, 15, 0, tzinfo=UTC),
+                score_home=0,
+                score_away=0,
+                status="Scheduled",
+            )
+        )
+        records.extend(
+            _match_records(
+                "Arsenal",
+                "Liverpool",
+                date=datetime(2025, 9, 22, 19, 0, tzinfo=UTC),
+                score_home=0,
+                score_away=0,
+                status="Scheduled",
+                competition="Champions League",
+            )
+        )
+        await writer.upsert_fixtures(records)
+        await pglite_async_session.commit()
+
+        test_session_maker = async_sessionmaker(test_engine, expire_on_commit=False)
+
+        with patch.object(mcp_server, "async_session_maker", test_session_maker):
+            result = await mcp_server.get_team_context(
+                team="Arsenal",
+                as_of="2025-09-10T00:00:00Z",
+                include_standings=False,
+            )
+
+        competitions = {f["competition"] for f in result["upcoming_fixtures"]}
+        assert competitions == {"Premier League", "Champions League"}
+
+    @pytest.mark.asyncio
+    async def test_standings_returned_from_db(self, pglite_async_session, test_engine) -> None:
+        from odds_mcp import server as mcp_server
+        from sqlalchemy.ext.asyncio import async_sessionmaker
+
+        writer = EspnFixtureWriter(pglite_async_session)
+        records: list[EspnFixtureRecord] = []
+        # Arsenal beats Chelsea, then draws Liverpool.
+        records.extend(
+            _match_records(
+                "Arsenal",
+                "Chelsea",
+                date=datetime(2025, 8, 15, 15, 0, tzinfo=UTC),
+                score_home=2,
+                score_away=0,
+            )
+        )
+        records.extend(
+            _match_records(
+                "Arsenal",
+                "Liverpool",
+                date=datetime(2025, 8, 22, 15, 0, tzinfo=UTC),
+                score_home=1,
+                score_away=1,
+            )
+        )
+        await writer.upsert_fixtures(records)
+        await pglite_async_session.commit()
+
+        test_session_maker = async_sessionmaker(test_engine, expire_on_commit=False)
+
+        with patch.object(mcp_server, "async_session_maker", test_session_maker):
+            result = await mcp_server.get_team_context(
+                team="Arsenal",
+                as_of="2025-09-01T00:00:00Z",
+                include_standings=True,
+            )
+
+        standings = result["standings"]
+        arsenal_row = standings["team_row"]
+        assert arsenal_row["points"] == 4  # 1W + 1D
+        assert arsenal_row["position"] == 1
+        # Full table returned in position order
+        assert [r["team"] for r in standings["table"]] == ["Arsenal", "Liverpool", "Chelsea"]
+
+
+class TestParseScore:
+    def test_valid_integer(self) -> None:
+        from odds_mcp.server import _parse_score
+
+        assert _parse_score("3") == 3
+
+    def test_blank(self) -> None:
+        from odds_mcp.server import _parse_score
+
+        assert _parse_score("") is None
+
+    def test_malformed(self) -> None:
+        from odds_mcp.server import _parse_score
+
+        assert _parse_score("abc") is None
+
+    def test_negative_rejected(self) -> None:
+        from odds_mcp.server import _parse_score
+
+        assert _parse_score("-1") is None
+
+
+class TestGetTeamContextMockedDB:
+    """Guardrail: `as_of=None` defaults to now; resolved datetime echoes back."""
+
+    @pytest.mark.asyncio
+    async def test_default_as_of_returns_now(self) -> None:
+        from odds_mcp import server as mcp_server
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("odds_mcp.server.async_session_maker") as mock_session_maker:
+            mock_session_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_maker.return_value.__aexit__ = AsyncMock()
+
+            result = await mcp_server.get_team_context(
+                team="Arsenal",
+                as_of=None,
+                include_standings=False,
+            )
+
+        # as_of echoed back as an ISO string
+        parsed = datetime.fromisoformat(result["as_of"])
+        # Should be within a second of now (test ran milliseconds ago)
+        assert abs((parsed - datetime.now(UTC)).total_seconds()) < 5

--- a/tests/unit/test_get_team_context.py
+++ b/tests/unit/test_get_team_context.py
@@ -161,12 +161,11 @@ class TestDeriveStandings:
     def test_position_tiebreak_by_goal_diff_then_gf(self) -> None:
         from odds_mcp.server import _derive_standings
 
-        # X, Y, Z all play 2 games, all end with 4 pts, differentiated by GD/GF.
-        # X: beats Y 3-0, draws Z 0-0 → 4 pts, GD +3, GF 3
-        # Y: loses to X 0-3, beats Z 2-0 → 3 pts
-        # Z: draws X 0-0, loses to Y 0-2 → 1 pt
-        # Add W that mirrors X's points with different GD to force tiebreak:
-        # Actually let's build a cleaner tie: two teams on same pts & GD, differ on GF.
+        # Two matches chosen to tie X and Y on points (3) AND goal diff (+2),
+        # with X ahead on goals-for — exercises the GF tiebreak branch.
+        # X beats Z 4-2 → X: 3 pts, GD +2, GF 4
+        # Y beats Z 3-1 → Y: 3 pts, GD +2, GF 3
+        # Z loses both  → Z: 0 pts, GD -4, GF 3
         records: list[EspnFixtureRecord] = []
         records.extend(
             _match_records(
@@ -186,7 +185,6 @@ class TestDeriveStandings:
                 score_away=1,
             )
         )
-        # Now X and Y both have 3 pts, GD +2; X has GF 4 vs Y's GF 3.
         table = _derive_standings(self._build(records))
         assert table["X"]["points"] == 3
         assert table["Y"]["points"] == 3


### PR DESCRIPTION
## Summary

- Extracted `EspnFixtureFetcher` from `scripts/ingest_espn_fixtures.py` into a reusable async class in `packages/odds-lambda/odds_lambda/espn_fixture_fetcher.py` (httpx-based, retry with backoff, dedup, `current_season` helper).
- Refactored the script to delegate to the fetcher while retaining multi-season backfill + CSV capability.
- New scheduled job `fetch-espn-fixtures-epl` at `packages/odds-lambda/odds_lambda/jobs/fetch_espn_fixtures.py`, registered in `scheduling/jobs.py` and in Terraform (`eventbridge.tf`) as a fixed daily cron at 06:00 UTC. EPL-only. Cadence owned by Terraform cron (no self-scheduling — matches `daily-digest` / `score-predictions`).
- New `get_team_context` MCP tool in `packages/odds-mcp/odds_mcp/server.py` returning `last_results` (PL-only, Final), `upcoming_fixtures` (all competitions, with `days_until_ko`), and derived PL `standings` (points → GD → GF tiebreak) for any normalised EPL team. `as_of` cutoff honoured; mid-match `In Progress` rows skipped from both sides.
- Tests: 9 fetcher tests (mocked httpx), 15 `get_team_context` tests covering standings derivation, tiebreaks, PL-only filter, `as_of` no-look-ahead, mid-match skip, and alias normalisation.

## Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)