### PR TITLE
Move scoring + fixed-schedule jobs local; add odds_agent role

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,13 @@ SCHEDULER_BACKEND=local
 # How many days ahead to check for games (default: 7)
 SCHEDULER_LOOKAHEAD_DAYS=7
 
-# Jobs to bootstrap on scheduler start (JSON list, default: ["agent-run"])
-# SCHEDULER_BOOTSTRAP_JOBS=fetch-odds,fetch-oddsportal,agent-run
+# Jobs to bootstrap on scheduler start (JSON list). Default includes the
+# event-driven scraper jobs (fetch-oddsportal, fetch-oddsportal-results) and
+# the fixed-schedule jobs (daily-digest, fetch-espn-fixtures) that now run
+# on the local scheduler instead of EventBridge.
+# Default: ["agent-run", "fetch-oddsportal", "fetch-oddsportal-results",
+#           "daily-digest", "fetch-espn-fixtures"]
+# SCHEDULER_BOOTSTRAP_JOBS=fetch-oddsportal,fetch-oddsportal-results,daily-digest,fetch-espn-fixtures,agent-run
 
 # =============================================================================
 # AWS CONFIGURATION (only needed if SCHEDULER_BACKEND=aws)
@@ -52,6 +57,16 @@ PROD_DATABASE_URL=postgresql+asyncpg://user:password@prod-host:5432/odds_prod?ss
 
 # Connection pool size (default: 5)
 DATABASE_POOL_SIZE=5
+
+# Agent subprocess DSN (optional, defense-in-depth).
+# When set, the ``agent-run`` job overrides DATABASE_URL in the agent
+# subprocess with this value so the agent connects as the read-mostly
+# ``odds_agent`` role (created by migration f1a2b3c4d5e6). The role has
+# SELECT on all tables and INSERT/UPDATE only on paper_trades,
+# match_briefs, and agent_wakeups. When unset, the agent inherits the
+# parent's DATABASE_URL (security control disabled) and a warning is
+# logged — functional, but the agent can write to any table.
+# AGENT_DATABASE_URL=postgresql+asyncpg://odds_agent:password@host:5432/odds?ssl=require
 
 # =============================================================================
 # THE ODDS API CONFIGURATION

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,15 @@ AWS_REGION=us-east-1
 AWS_LAMBDA_ARN=
 
 # =============================================================================
+# MODEL LOADING (required for local score-predictions)
+# =============================================================================
+# Even with SCHEDULER_BACKEND=local, model artifacts are pulled from S3 via
+# plain boto3 (packages/odds-lambda/odds_lambda/model_loader.py). Local AWS
+# credentials with S3 read permission on MODEL_BUCKET are required.
+MODEL_NAME=epl-clv-home
+MODEL_BUCKET=
+
+# =============================================================================
 # DATABASE CONFIGURATION
 # =============================================================================
 # Primary database URL (used by application)

--- a/deployment/aws/terraform/eventbridge.tf
+++ b/deployment/aws/terraform/eventbridge.tf
@@ -135,33 +135,15 @@ locals {
 
   # Schedule expressions for fixed-schedule jobs (map lookup prevents
   # a new job silently inheriting the wrong schedule via a ternary fallback).
-  fixed_schedule_expressions = {
-    "daily-digest"        = "cron(0 8 * * ? *)"
-    "score-predictions"   = "cron(30 * * * ? *)"
-    "fetch-espn-fixtures" = "cron(0 6 * * ? *)"
-  }
+  # score-predictions, daily-digest, and fetch-espn-fixtures now run in the
+  # local scheduler so the agent, scraper, and scorer share one DB. Only
+  # jobs that still fire from EventBridge belong here.
+  fixed_schedule_expressions = {}
 
-  # Per-sport fixed-schedule jobs. fetch-espn-fixtures is EPL-only today —
-  # gated on sport_suffix to avoid scheduling it for sports without ESPN fixture
-  # coverage in this pipeline.
-  sport_fixed_scheduler_rules = flatten([
-    for sport_suffix, cfg in local.sport_configs : concat(
-      [
-        for job in ["daily-digest", "score-predictions"] : {
-          key       = "${job}-${sport_suffix}"
-          job       = job
-          sport_key = cfg.sport_key
-        }
-      ],
-      sport_suffix == "epl" ? [
-        {
-          key       = "fetch-espn-fixtures-${sport_suffix}"
-          job       = "fetch-espn-fixtures"
-          sport_key = cfg.sport_key
-        }
-      ] : []
-    )
-  ])
+  # Per-sport fixed-schedule jobs. Empty until a Lambda-hosted fixed-schedule
+  # job is reintroduced; kept as a list comprehension so adding one back is
+  # a single-line change.
+  sport_fixed_scheduler_rules = []
 
   fixed_scheduler_rules_map = { for r in local.sport_fixed_scheduler_rules : r.key => r }
 }

--- a/deployment/aws/terraform/eventbridge.tf
+++ b/deployment/aws/terraform/eventbridge.tf
@@ -260,7 +260,7 @@ output "dynamic_rules" {
 
 output "scheduler_jobs" {
   description = "Job names routed to the scheduler Lambda (CSV for scripts)"
-  value       = join(",", concat(local.self_scheduling_scheduler_jobs, keys(local.fixed_scheduler_rules_map)))
+  value       = join(",", local.self_scheduling_scheduler_jobs)
 }
 
 output "scraper_jobs" {

--- a/deployment/aws/terraform/eventbridge.tf
+++ b/deployment/aws/terraform/eventbridge.tf
@@ -36,8 +36,11 @@ resource "aws_lambda_permission" "allow_eventbridge_backfill_polymarket" {
   ]
 }
 
-# Per-sport fixed-schedule rules (daily-digest and score-predictions).
-# Generated from sport_configs so each sport gets independent rules.
+# Per-sport fixed-schedule rules. Currently empty — score-predictions,
+# daily-digest, and fetch-espn-fixtures now run on the local scheduler
+# (see `fixed_schedule_expressions` below). The resources are retained so
+# adding a new Lambda-hosted fixed-schedule job is a single-line change
+# (add the job to `fixed_schedule_expressions` + `sport_fixed_scheduler_rules`).
 resource "aws_cloudwatch_event_rule" "fixed_scheduler" {
   for_each = local.fixed_scheduler_rules_map
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -142,10 +142,10 @@ Centralized mapping of job names to async entry points. Modules are lazy-importe
 | `check-health` | `odds_lambda.jobs.check_health` | Self-scheduling |
 | `fetch-polymarket` | `odds_lambda.jobs.fetch_polymarket` | Self-scheduling (deprioritized) |
 | `backfill-polymarket` | `odds_lambda.jobs.backfill_polymarket` | Fixed: every 3 days (deprioritized) |
-| `fetch-oddsportal` | `odds_lambda.jobs.fetch_oddsportal` | Fixed: hourly |
-| `fetch-oddsportal-results` | `odds_lambda.jobs.fetch_oddsportal_results` | Fixed: 08:00 UTC daily |
-| `score-predictions` | `odds_lambda.jobs.score_predictions` | Fixed: hourly at :15 |
-| `daily-digest` | `odds_lambda.jobs.daily_digest` | Fixed: 08:00 UTC daily |
+| `fetch-oddsportal` | `odds_lambda.jobs.fetch_oddsportal` | Self-scheduling (proximity tier). Runs score-predictions inline. |
+| `fetch-oddsportal-results` | `odds_lambda.jobs.fetch_oddsportal_results` | Fixed: 08:00 UTC daily (EventBridge) |
+| `daily-digest` | `odds_lambda.jobs.daily_digest` | Local cron: 08:00 UTC daily (EPL only) |
+| `fetch-espn-fixtures` | `odds_lambda.jobs.fetch_espn_fixtures` | Local cron: 06:00 UTC daily (EPL only) |
 
 ## Intelligent Scheduling System
 

--- a/docs/DEBUGGING_SCHEDULER.md
+++ b/docs/DEBUGGING_SCHEDULER.md
@@ -129,14 +129,14 @@ Two Lambda functions handle jobs based on event payload:
 4. **`check-health`**: System health checks
 
 **Fixed-schedule jobs:**
-5. **`score-predictions`**: CLV model inference — `cron(15 * * * ? *)` (hourly at :15)
-6. **`daily-digest`**: Discord predictions digest — `cron(0 8 * * ? *)` (08:00 UTC)
-7. **`backfill-polymarket`**: Polymarket backfill — `rate(3 days)` (if enabled)
+5. **`backfill-polymarket`**: Polymarket backfill — `rate(3 days)` (if enabled)
+
+`daily-digest` (Discord predictions digest, 08:00 UTC) and `fetch-espn-fixtures` (06:00 UTC) run locally via `LocalSchedulerBackend` cron — EPL only, see `_JOB_CRON_MAP` in `odds_lambda/scheduling/jobs.py`. CLV model inference (previously `score-predictions`) is inlined at the end of `fetch-oddsportal` and no longer exists as a standalone job.
 
 ### Scraper Lambda (`odds-scheduler-dev-scraper`)
 
-8. **`fetch-oddsportal`**: Scrapes upcoming EPL match odds — `rate(1 hour)`
-9. **`fetch-oddsportal-results`**: Scrapes EPL results + closing odds — `cron(0 8 * * ? *)`
+6. **`fetch-oddsportal`**: Scrapes upcoming EPL match odds — self-scheduling (proximity tier). Runs CLV scoring inline after ingest.
+7. **`fetch-oddsportal-results`**: Scrapes EPL results + closing odds — `cron(0 8 * * ? *)`
 
 ## Intelligent Scheduling Logic
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -31,11 +31,10 @@ Both use the same Lambda handler entry point and job registry, but different Doc
 
 | Rule | Schedule | Lambda | Job |
 |------|----------|--------|-----|
-| `odds-fetch-oddsportal` | `rate(1 hour)` | Scraper | `fetch-oddsportal` |
 | `odds-fetch-oddsportal-results` | `cron(0 8 * * ? *)` | Scraper | `fetch-oddsportal-results` |
-| `odds-score-predictions` | `cron(15 * * * ? *)` | Scheduler | `score-predictions` |
-| `odds-daily-digest` | `cron(0 8 * * ? *)` | Scheduler | `daily-digest` |
 | `odds-backfill-polymarket` | `rate(3 days)` | Scheduler | `backfill-polymarket` (if enabled) |
+
+`daily-digest` and `fetch-espn-fixtures` run locally via `LocalSchedulerBackend` cron (EPL only) — see `_JOB_CRON_MAP` in `odds_lambda/scheduling/jobs.py`. `score-predictions` no longer exists as a standalone job; it is invoked inline at the end of `fetch-oddsportal`. `fetch-odds` remains on EventBridge (self-scheduling).
 
 **Self-scheduling rules** (pre-created disabled, activated by Lambda at runtime):
 

--- a/migrations/versions/f1a2b3c4d5e6_add_odds_agent_role.py
+++ b/migrations/versions/f1a2b3c4d5e6_add_odds_agent_role.py
@@ -36,6 +36,11 @@ depends_on = None
 
 
 AGENT_ROLE = "odds_agent"
+# Only INSERT/UPDATE are granted — the MCP server has been audited and does
+# not issue DELETE on any of these tables (paper trades settle via UPDATE,
+# briefs append-only, wakeups upsert). If a future MCP tool needs DELETE,
+# add a new migration that extends these grants rather than silently
+# expanding this tuple.
 WRITABLE_TABLES = ("paper_trades", "match_briefs", "agent_wakeups")
 
 

--- a/migrations/versions/f1a2b3c4d5e6_add_odds_agent_role.py
+++ b/migrations/versions/f1a2b3c4d5e6_add_odds_agent_role.py
@@ -1,0 +1,110 @@
+"""add_odds_agent_role
+
+Revision ID: f1a2b3c4d5e6
+Revises: beaf16386050
+Create Date: 2026-04-21 18:09:24.197065
+
+Creates a defense-in-depth Postgres role for the betting agent. The agent
+process connects as ``odds_agent`` which has:
+
+- ``SELECT`` on every existing table in the public schema (and on future
+  tables, via default privileges)
+- ``INSERT, UPDATE`` on ``paper_trades``, ``match_briefs``, and
+  ``agent_wakeups`` — the only tables the agent legitimately writes to
+- Corresponding sequence ``USAGE, SELECT`` so inserts can generate IDs
+
+The role is created WITH LOGIN but without a password. Operators must set a
+password out-of-band (``ALTER ROLE odds_agent WITH PASSWORD '...'``) before
+handing a connection string to the agent process; committing a password to
+migration history would leak it into every environment's git blame and into
+every backup of the migrations table. A login role with no password cannot
+authenticate via password auth on Neon, which fails closed rather than open.
+
+This migration is intentionally conservative: it does NOT run automatically
+against shared/production databases without an explicit ``alembic upgrade``.
+Apply it only once per environment, then rotate the password via the
+infrastructure secret store.
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f1a2b3c4d5e6"
+down_revision = "beaf16386050"
+branch_labels = None
+depends_on = None
+
+
+AGENT_ROLE = "odds_agent"
+WRITABLE_TABLES = ("paper_trades", "match_briefs", "agent_wakeups")
+
+
+def upgrade() -> None:
+    """Create the ``odds_agent`` role with read-mostly privileges.
+
+    Uses ``DO`` blocks so re-running against a DB where the role already
+    exists is a no-op rather than an error.
+    """
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{AGENT_ROLE}') THEN
+                CREATE ROLE {AGENT_ROLE} WITH LOGIN;
+            END IF;
+        END
+        $$;
+        """
+    )
+
+    # Read access across the whole public schema (existing + future tables).
+    op.execute(f"GRANT USAGE ON SCHEMA public TO {AGENT_ROLE};")
+    op.execute(f"GRANT SELECT ON ALL TABLES IN SCHEMA public TO {AGENT_ROLE};")
+    op.execute(f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO {AGENT_ROLE};")
+
+    # Write access only on tables the agent legitimately mutates.
+    for table in WRITABLE_TABLES:
+        op.execute(f"GRANT INSERT, UPDATE ON TABLE {table} TO {AGENT_ROLE};")
+
+    # Sequence access so INSERTs on SERIAL/identity columns can allocate IDs.
+    op.execute(f"GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO {AGENT_ROLE};")
+    op.execute(
+        f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+        f"GRANT USAGE, SELECT ON SEQUENCES TO {AGENT_ROLE};"
+    )
+
+
+def downgrade() -> None:
+    """Revoke privileges and drop the role.
+
+    Guarded with ``IF EXISTS`` so re-running or partial-upgrade teardown
+    doesn't crash. ``DROP OWNED BY`` is required before ``DROP ROLE`` to
+    clear any default-privilege grants the role owns.
+    """
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{AGENT_ROLE}') THEN
+                EXECUTE format('REVOKE ALL ON ALL TABLES IN SCHEMA public FROM %I', '{AGENT_ROLE}');
+                EXECUTE format(
+                    'REVOKE ALL ON ALL SEQUENCES IN SCHEMA public FROM %I', '{AGENT_ROLE}'
+                );
+                EXECUTE format('REVOKE USAGE ON SCHEMA public FROM %I', '{AGENT_ROLE}');
+                EXECUTE format(
+                    'ALTER DEFAULT PRIVILEGES IN SCHEMA public '
+                    'REVOKE SELECT ON TABLES FROM %I',
+                    '{AGENT_ROLE}'
+                );
+                EXECUTE format(
+                    'ALTER DEFAULT PRIVILEGES IN SCHEMA public '
+                    'REVOKE USAGE, SELECT ON SEQUENCES FROM %I',
+                    '{AGENT_ROLE}'
+                );
+                EXECUTE format('DROP OWNED BY %I', '{AGENT_ROLE}');
+                EXECUTE format('DROP ROLE %I', '{AGENT_ROLE}');
+            END IF;
+        END
+        $$;
+        """
+    )

--- a/migrations/versions/f1a2b3c4d5e6_add_odds_agent_role.py
+++ b/migrations/versions/f1a2b3c4d5e6_add_odds_agent_role.py
@@ -80,6 +80,21 @@ def downgrade() -> None:
     Guarded with ``IF EXISTS`` so re-running or partial-upgrade teardown
     doesn't crash. ``DROP OWNED BY`` is required before ``DROP ROLE`` to
     clear any default-privilege grants the role owns.
+
+    .. warning::
+
+        ``DROP ROLE`` fails with ``role "odds_agent" cannot be dropped
+        because some objects depend on it`` (or, with ``DROP OWNED BY``,
+        aborts on any active backend owned by the role) if any sessions
+        are still connected as ``odds_agent``. Before running downgrade,
+        terminate every live agent session — e.g.::
+
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE usename = 'odds_agent';
+
+        Stop any local ``odds agent run`` / scheduler subprocesses first,
+        then run the termination query, then apply the downgrade.
     """
     op.execute(
         f"""

--- a/packages/odds-cli/odds_cli/commands/agent.py
+++ b/packages/odds-cli/odds_cli/commands/agent.py
@@ -19,7 +19,7 @@ def run(
         ..., "--sport", "-s", help="Sport key (e.g. 'soccer_epl', 'baseball_mlb')"
     ),
     db: str = typer.Option(
-        "odds_test",
+        "odds",
         "--db",
         help="Database name to run against. Swapped into DATABASE_URL.",
     ),
@@ -28,9 +28,9 @@ def run(
 
     No pre-schedule, no agent_wakeups consumption, no reschedule — so repeated
     runs don't disturb the scheduler. By default the agent runs against the
-    ``odds_test`` database (same host/credentials as the configured
-    DATABASE_URL, just a different dbname); refresh it from the source-of-truth
-    DB with ``scripts/snapshot_to_dev.sh`` before use.
+    local ``odds`` database (same host/credentials as the configured
+    DATABASE_URL, just a different dbname), which is also where the local
+    scheduler writes scraper output and scored predictions.
     """
     override_database_url(db)
 

--- a/packages/odds-cli/odds_cli/commands/scheduler.py
+++ b/packages/odds-cli/odds_cli/commands/scheduler.py
@@ -87,6 +87,7 @@ def start_local(
         from odds_lambda.scheduling.jobs import (
             JobContext,
             get_bootstrap_function,
+            get_job_cron,
             is_per_sport_job,
             make_compound_job_name,
         )
@@ -103,6 +104,49 @@ def start_local(
                 )
 
             for job_name in bootstrap_jobs:
+                cron_expr = get_job_cron(job_name)
+
+                if cron_expr is not None:
+                    # Cron-triggered jobs: install a recurring CronTrigger
+                    # instead of going through the dynamic bootstrap path.
+                    if is_per_sport_job(job_name):
+                        for sport_key in app_settings.data_collection.sports:
+                            compound = make_compound_job_name(job_name, sport_key)
+                            existing = await _backend.get_job_status(compound)
+                            if existing and existing.next_run_time:
+                                console.print(
+                                    f"[dim]  {compound} already scheduled "
+                                    f"at {existing.next_run_time:%H:%M:%S UTC} — skipping[/dim]"
+                                )
+                                continue
+                            try:
+                                await _backend.schedule_cron(compound, cron_expr)
+                                console.print(
+                                    f"[green]  {compound} cron scheduled ({cron_expr})[/green]"
+                                )
+                            except Exception as e:
+                                console.print(
+                                    f"[yellow]  {compound} cron schedule failed: {e}[/yellow]"
+                                )
+                    else:
+                        existing = await _backend.get_job_status(job_name)
+                        if existing and existing.next_run_time:
+                            console.print(
+                                f"[dim]  {job_name} already scheduled "
+                                f"at {existing.next_run_time:%H:%M:%S UTC} — skipping[/dim]"
+                            )
+                            continue
+                        try:
+                            await _backend.schedule_cron(job_name, cron_expr)
+                            console.print(
+                                f"[green]  {job_name} cron scheduled ({cron_expr})[/green]"
+                            )
+                        except Exception as e:
+                            console.print(
+                                f"[yellow]  {job_name} cron schedule failed: {e}[/yellow]"
+                            )
+                    continue
+
                 bootstrap_fn = get_bootstrap_function(job_name)
 
                 if is_per_sport_job(job_name):

--- a/packages/odds-cli/odds_cli/commands/scheduler.py
+++ b/packages/odds-cli/odds_cli/commands/scheduler.py
@@ -35,7 +35,8 @@ def start_local(
     Start local scheduler for testing (APScheduler backend).
 
     Simulates AWS Lambda + EventBridge behavior locally using APScheduler.
-    Jobs will self-schedule just like in production.
+    Event-driven jobs self-schedule as they run; fixed-schedule jobs listed
+    in ``_JOB_CRON_MAP`` install recurring cron triggers at bootstrap.
 
     Requirements:
     - SCHEDULER_BACKEND=local in .env
@@ -88,6 +89,7 @@ def start_local(
             JobContext,
             get_bootstrap_function,
             get_job_cron,
+            get_job_cron_sports,
             is_per_sport_job,
             make_compound_job_name,
         )
@@ -110,7 +112,28 @@ def start_local(
                     # Cron-triggered jobs: install a recurring CronTrigger
                     # instead of going through the dynamic bootstrap path.
                     if is_per_sport_job(job_name):
-                        for sport_key in app_settings.data_collection.sports:
+                        allowed_sports = get_job_cron_sports(job_name)
+                        target_sports = (
+                            list(allowed_sports)
+                            if allowed_sports is not None
+                            else list(app_settings.data_collection.sports)
+                        )
+                        skipped_sports = (
+                            [
+                                s
+                                for s in app_settings.data_collection.sports
+                                if s not in target_sports
+                            ]
+                            if allowed_sports is not None
+                            else []
+                        )
+                        for skipped in skipped_sports:
+                            skipped_compound = make_compound_job_name(job_name, skipped)
+                            console.print(
+                                f"[dim]  {skipped_compound} skipped — "
+                                f"{job_name} does not support {skipped}[/dim]"
+                            )
+                        for sport_key in target_sports:
                             compound = make_compound_job_name(job_name, sport_key)
                             existing = await _backend.get_job_status(compound)
                             if existing and existing.next_run_time:

--- a/packages/odds-cli/odds_cli/commands/scheduler.py
+++ b/packages/odds-cli/odds_cli/commands/scheduler.py
@@ -98,6 +98,49 @@ def start_local(
 
         # Start scheduler first so bootstrap jobs can schedule via the backend
         async with LocalSchedulerBackend() as _backend:
+
+            async def _bootstrap_cron(compound: str, cron_expr: str) -> None:
+                """Install a recurring CronTrigger, re-applying on every start.
+
+                Cron jobs intentionally do NOT short-circuit on an existing
+                schedule — APScheduler's data store persists triggers across
+                restarts, so a stale cron expression would otherwise win over
+                an edit to ``_JOB_CRON_MAP``. ``ConflictPolicy.replace`` inside
+                ``LocalSchedulerBackend.schedule_cron`` makes this idempotent.
+                """
+                existing = await _backend.get_job_status(compound)
+                if existing and existing.next_run_time:
+                    console.print(
+                        f"[dim]  {compound} existing schedule "
+                        f"at {existing.next_run_time:%H:%M:%S UTC} — re-applying[/dim]"
+                    )
+                try:
+                    await _backend.schedule_cron(compound, cron_expr)
+                    console.print(f"[green]  {compound} cron scheduled ({cron_expr})[/green]")
+                except Exception as e:
+                    console.print(f"[yellow]  {compound} cron schedule failed: {e}[/yellow]")
+
+            async def _bootstrap_dynamic(compound: str, ctx: JobContext, bootstrap_fn) -> None:
+                """Run a job's bootstrap entry point once, skipping if already scheduled.
+
+                Unlike cron jobs, dynamic (self-scheduling) jobs own their next
+                fire time — re-running bootstrap would clobber an agent-requested
+                override or an in-flight proximity tier. The skip is the right
+                call here.
+                """
+                existing = await _backend.get_job_status(compound)
+                if existing and existing.next_run_time:
+                    console.print(
+                        f"[dim]  {compound} already scheduled "
+                        f"at {existing.next_run_time:%H:%M:%S UTC} — skipping[/dim]"
+                    )
+                    return
+                try:
+                    await bootstrap_fn(ctx)
+                    console.print(f"[green]  {compound} bootstrapped[/green]")
+                except Exception as e:
+                    console.print(f"[yellow]  {compound} bootstrap failed: {e}[/yellow]")
+
             if bootstrap_jobs:
                 console.print("[green]Bootstrapping jobs...[/green]")
             else:
@@ -107,23 +150,19 @@ def start_local(
 
             for job_name in bootstrap_jobs:
                 cron_expr = get_job_cron(job_name)
+                per_sport = is_per_sport_job(job_name)
 
                 if cron_expr is not None:
-                    # Cron-triggered jobs: install a recurring CronTrigger
-                    # instead of going through the dynamic bootstrap path.
-                    if is_per_sport_job(job_name):
+                    if per_sport:
                         allowed_sports = get_job_cron_sports(job_name)
+                        configured_sports = app_settings.data_collection.sports
                         target_sports = (
                             list(allowed_sports)
                             if allowed_sports is not None
-                            else list(app_settings.data_collection.sports)
+                            else list(configured_sports)
                         )
                         skipped_sports = (
-                            [
-                                s
-                                for s in app_settings.data_collection.sports
-                                if s not in target_sports
-                            ]
+                            [s for s in configured_sports if s not in target_sports]
                             if allowed_sports is not None
                             else []
                         )
@@ -134,72 +173,24 @@ def start_local(
                                 f"{job_name} does not support {skipped}[/dim]"
                             )
                         for sport_key in target_sports:
-                            compound = make_compound_job_name(job_name, sport_key)
-                            existing = await _backend.get_job_status(compound)
-                            if existing and existing.next_run_time:
-                                console.print(
-                                    f"[dim]  {compound} already scheduled "
-                                    f"at {existing.next_run_time:%H:%M:%S UTC} — skipping[/dim]"
-                                )
-                                continue
-                            try:
-                                await _backend.schedule_cron(compound, cron_expr)
-                                console.print(
-                                    f"[green]  {compound} cron scheduled ({cron_expr})[/green]"
-                                )
-                            except Exception as e:
-                                console.print(
-                                    f"[yellow]  {compound} cron schedule failed: {e}[/yellow]"
-                                )
+                            await _bootstrap_cron(
+                                make_compound_job_name(job_name, sport_key), cron_expr
+                            )
                     else:
-                        existing = await _backend.get_job_status(job_name)
-                        if existing and existing.next_run_time:
-                            console.print(
-                                f"[dim]  {job_name} already scheduled "
-                                f"at {existing.next_run_time:%H:%M:%S UTC} — skipping[/dim]"
-                            )
-                            continue
-                        try:
-                            await _backend.schedule_cron(job_name, cron_expr)
-                            console.print(
-                                f"[green]  {job_name} cron scheduled ({cron_expr})[/green]"
-                            )
-                        except Exception as e:
-                            console.print(
-                                f"[yellow]  {job_name} cron schedule failed: {e}[/yellow]"
-                            )
+                        await _bootstrap_cron(job_name, cron_expr)
                     continue
 
                 bootstrap_fn = get_bootstrap_function(job_name)
 
-                if is_per_sport_job(job_name):
+                if per_sport:
                     for sport_key in app_settings.data_collection.sports:
-                        compound = make_compound_job_name(job_name, sport_key)
-                        existing = await _backend.get_job_status(compound)
-                        if existing and existing.next_run_time:
-                            console.print(
-                                f"[dim]  {compound} already scheduled "
-                                f"at {existing.next_run_time:%H:%M:%S UTC} — skipping[/dim]"
-                            )
-                            continue
-                        try:
-                            await bootstrap_fn(JobContext(sport=sport_key))
-                            console.print(f"[green]  {compound} bootstrapped[/green]")
-                        except Exception as e:
-                            console.print(f"[yellow]  {compound} bootstrap failed: {e}[/yellow]")
-                else:
-                    existing = await _backend.get_job_status(job_name)
-                    if existing and existing.next_run_time:
-                        console.print(
-                            f"[dim]  {job_name} already scheduled "
-                            f"at {existing.next_run_time:%H:%M:%S UTC} — skipping[/dim]"
+                        await _bootstrap_dynamic(
+                            make_compound_job_name(job_name, sport_key),
+                            JobContext(sport=sport_key),
+                            bootstrap_fn,
                         )
-                        continue
-                    try:
-                        await bootstrap_fn(JobContext())
-                        console.print(f"[green]  {job_name} bootstrapped[/green]")
-                    except Exception as e:
-                        console.print(f"[yellow]  {job_name} bootstrap failed: {e}[/yellow]")
+                else:
+                    await _bootstrap_dynamic(job_name, JobContext(), bootstrap_fn)
 
             console.print()
 

--- a/packages/odds-core/odds_core/config.py
+++ b/packages/odds-core/odds_core/config.py
@@ -170,7 +170,6 @@ class AlertConfig(BaseSettings):
         default={
             "fetch-oddsportal-epl": 2,
             "fetch-oddsportal-results-epl": 26,
-            "score-predictions-epl": 2,
             "daily-digest-epl": 26,
             "fetch-oddsportal-mlb": 2,
             "fetch-oddsportal-results-mlb": 26,

--- a/packages/odds-core/odds_core/config.py
+++ b/packages/odds-core/odds_core/config.py
@@ -86,7 +86,13 @@ class SchedulerConfig(BaseSettings):
         description="How many days ahead to check for games when scheduling",
     )
     bootstrap_jobs: list[str] = Field(
-        default=["agent-run"],
+        default=[
+            "agent-run",
+            "fetch-oddsportal",
+            "fetch-oddsportal-results",
+            "daily-digest",
+            "fetch-espn-fixtures",
+        ],
         description="Jobs to bootstrap when starting the local scheduler",
     )
 

--- a/packages/odds-lambda/odds_lambda/jobs/agent_run.py
+++ b/packages/odds-lambda/odds_lambda/jobs/agent_run.py
@@ -136,6 +136,32 @@ def _log_stream_message(msg: dict[str, Any]) -> None:
         )
 
 
+def _build_agent_subprocess_env() -> dict[str, str]:
+    """Return an environment dict for the agent subprocess.
+
+    When ``AGENT_DATABASE_URL`` is set, its value replaces ``DATABASE_URL``
+    so the agent connects as the read-mostly ``odds_agent`` role rather
+    than inheriting the scraper/scheduler's write-capable DSN. When it is
+    unset the subprocess inherits the parent's ``DATABASE_URL`` and a
+    warning is logged — the security control is then disabled but the
+    agent continues to function, preserving pre-control behaviour for
+    operators who haven't provisioned the role yet.
+    """
+    env = os.environ.copy()
+    agent_dsn = env.get("AGENT_DATABASE_URL")
+    if agent_dsn:
+        env["DATABASE_URL"] = agent_dsn
+    else:
+        logger.warning(
+            "agent_database_url_not_set",
+            msg=(
+                "AGENT_DATABASE_URL not set — agent will run with scraper's "
+                "write-capable DSN (security control disabled)"
+            ),
+        )
+    return env
+
+
 async def _run_claude_agent(sport: SportKey) -> int:
     """Spawn ``claude -p`` subprocess and return exit code.
 
@@ -164,6 +190,8 @@ async def _run_claude_agent(sport: SportKey) -> int:
     # PID suffix avoids collisions when two invocations start in the same second.
     log_path = log_dir / f"{sport}_{timestamp}_{os.getpid()}.jsonl"
 
+    subprocess_env = _build_agent_subprocess_env()
+
     logger.info("agent_subprocess_starting", sport=sport, cmd=cmd, log_file=str(log_path))
 
     proc = await asyncio.create_subprocess_exec(
@@ -172,6 +200,7 @@ async def _run_claude_agent(sport: SportKey) -> int:
         stderr=asyncio.subprocess.STDOUT,
         cwd=str(settings.project_root),
         limit=AGENT_STREAM_LINE_LIMIT,
+        env=subprocess_env,
     )
 
     with log_path.open("ab") as log_file:

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
@@ -346,6 +346,22 @@ async def main(ctx: JobContext) -> None:
                 message=f"⚠️ OddsPortal scrape empty ({detail})",
             )
 
+    # Score predictions for newly arrived snapshots. Wrapped in its own
+    # try/except (outside the scrape alert context) so scoring failures
+    # don't surface as scrape alerts — they're logged independently.
+    try:
+        from odds_lambda.jobs.score_predictions import score_events
+
+        score_stats = await score_events(sport=ctx.sport)
+        logger.info("fetch_oddsportal_scoring_complete", **score_stats)
+    except Exception as e:
+        logger.error(
+            "fetch_oddsportal_scoring_failed",
+            sport=sport,
+            error=str(e),
+            exc_info=True,
+        )
+
     # On success, re-query next kickoff (scrape may have created new events)
     # and reschedule at the updated interval.
     if total_scraped > 0:

--- a/packages/odds-lambda/odds_lambda/jobs/score_predictions.py
+++ b/packages/odds-lambda/odds_lambda/jobs/score_predictions.py
@@ -6,6 +6,9 @@ the unique constraint on (event_id, snapshot_id, model_name) prevents
 duplicate predictions via ON CONFLICT DO NOTHING.
 
 Called inline at the end of fetch-oddsportal to score newly arrived data.
+The ``main()`` entry point is retained for manual invocation via
+``odds scheduler run-once score-predictions-<sport>`` (e.g. for backfills
+or ad-hoc scoring runs outside the scrape loop).
 """
 
 from __future__ import annotations

--- a/packages/odds-lambda/odds_lambda/scheduling/backends/local.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/backends/local.py
@@ -9,6 +9,7 @@ import structlog
 from apscheduler import AsyncScheduler, ConflictPolicy, SchedulerRole
 from apscheduler.datastores.sqlalchemy import SQLAlchemyDataStore
 from apscheduler.eventbrokers.asyncpg import AsyncpgEventBroker
+from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
@@ -224,6 +225,103 @@ class LocalSchedulerBackend(SchedulerBackend):
                 exc_info=True,
             )
             raise SchedulingFailedError(f"Failed to schedule {job_name}: {e}") from e
+
+    async def schedule_cron(
+        self,
+        job_name: str,
+        cron_expr: str,
+        payload: dict[str, object] | None = None,
+    ) -> None:
+        """Register a recurring cron schedule for a job.
+
+        Unlike ``schedule_next_execution`` (one-shot ``DateTrigger``), this
+        installs a ``CronTrigger`` that fires on the expression indefinitely.
+        Intended for fixed-schedule jobs (e.g. daily digest) whose fire time
+        does not depend on game proximity.
+        """
+        if self.dry_run:
+            logger.info(
+                "dry_run_schedule_cron",
+                job=job_name,
+                cron=cron_expr,
+                backend="local_apscheduler",
+            )
+            return
+
+        try:
+            from odds_lambda.scheduling.jobs import (
+                JobContext,
+                get_job_function,
+                resolve_job_name,
+            )
+
+            base_name, resolved_sport = resolve_job_name(job_name)
+            job_func = get_job_function(base_name)
+            ctx_payload: dict[str, object] = {}
+            if resolved_sport:
+                ctx_payload["sport"] = resolved_sport
+            if payload:
+                ctx_payload.update(payload)
+            ctx = JobContext.from_payload(ctx_payload)
+
+            await self._add_cron_schedule(job_func, job_name, cron_expr, ctx)
+
+            logger.info(
+                "local_cron_scheduled",
+                job=job_name,
+                cron=cron_expr,
+            )
+
+        except KeyError as e:
+            raise SchedulingFailedError(str(e)) from e
+        except Exception as e:
+            logger.error(
+                "local_cron_scheduling_failed",
+                job=job_name,
+                cron=cron_expr,
+                error=str(e),
+                exc_info=True,
+            )
+            raise SchedulingFailedError(f"Failed to schedule {job_name}: {e}") from e
+
+    async def _add_cron_schedule(
+        self,
+        job_func: object,
+        job_name: str,
+        cron_expr: str,
+        ctx: object,
+    ) -> None:
+        """Write a cron schedule to the data store, reusing a live scheduler if available."""
+        from apscheduler import current_async_scheduler
+
+        scheduler = self._scheduler or current_async_scheduler.get(None)
+        if scheduler is not None:
+            await self._write_cron_schedule(scheduler, job_func, job_name, cron_expr, ctx)
+            return
+
+        async with build_scheduler(role=SchedulerRole.scheduler) as scheduler:
+            await self._write_cron_schedule(scheduler, job_func, job_name, cron_expr, ctx)
+
+    async def _write_cron_schedule(
+        self,
+        scheduler: AsyncScheduler,
+        job_func: object,
+        job_name: str,
+        cron_expr: str,
+        ctx: object,
+    ) -> None:
+        task_key = f"{job_func.__module__}.{job_func.__qualname__}"  # type: ignore[union-attr]
+        if task_key not in self._configured_tasks:
+            await scheduler.configure_task(job_func)
+            self._configured_tasks.add(task_key)
+
+        await scheduler.add_schedule(
+            job_func,
+            trigger=CronTrigger.from_crontab(cron_expr, timezone="UTC"),
+            id=job_name,
+            args=[ctx],
+            conflict_policy=ConflictPolicy.replace,
+        )
 
     async def _add_schedule(
         self,

--- a/packages/odds-lambda/odds_lambda/scheduling/backends/local.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/backends/local.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from datetime import datetime
 from types import TracebackType
+from typing import TYPE_CHECKING
 
 import structlog
 from apscheduler import AsyncScheduler, ConflictPolicy, SchedulerRole
@@ -12,6 +14,11 @@ from apscheduler.eventbrokers.asyncpg import AsyncpgEventBroker
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+if TYPE_CHECKING:
+    from odds_lambda.scheduling.jobs import JobContext
+
+    JobFunc = Callable[[JobContext], Awaitable[None]]
 
 from odds_lambda.scheduling.backends.base import (
     BackendHealth,
@@ -286,10 +293,10 @@ class LocalSchedulerBackend(SchedulerBackend):
 
     async def _add_cron_schedule(
         self,
-        job_func: object,
+        job_func: JobFunc,
         job_name: str,
         cron_expr: str,
-        ctx: object,
+        ctx: JobContext,
     ) -> None:
         """Write a cron schedule to the data store, reusing a live scheduler if available."""
         from apscheduler import current_async_scheduler
@@ -305,12 +312,12 @@ class LocalSchedulerBackend(SchedulerBackend):
     async def _write_cron_schedule(
         self,
         scheduler: AsyncScheduler,
-        job_func: object,
+        job_func: JobFunc,
         job_name: str,
         cron_expr: str,
-        ctx: object,
+        ctx: JobContext,
     ) -> None:
-        task_key = f"{job_func.__module__}.{job_func.__qualname__}"  # type: ignore[union-attr]
+        task_key = f"{job_func.__module__}.{job_func.__qualname__}"
         if task_key not in self._configured_tasks:
             await scheduler.configure_task(job_func)
             self._configured_tasks.add(task_key)

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -104,16 +104,50 @@ _PER_SPORT_JOBS: frozenset[str] = frozenset(
 # ``fixed_schedule_expressions`` for the jobs that have moved out of
 # Lambda and into the local scheduler. Keys are base job names (no sport
 # suffix); the scheduler CLI expands per-sport jobs into one schedule per
-# configured sport, each with its own compound job name.
-_JOB_CRON_MAP: dict[str, str] = {
-    "daily-digest": "0 8 * * *",
-    "fetch-espn-fixtures": "0 6 * * *",
+# allowed sport, each with its own compound job name.
+#
+# Values are ``(cron_expression, allowed_sports_or_None)``. When the second
+# element is ``None`` the job runs for every sport in
+# ``data_collection.sports``; otherwise it runs only for the listed sport
+# keys. Use an allowlist for jobs whose ``main()`` raises on unsupported
+# sports (e.g. ``fetch-espn-fixtures`` is EPL-only) — otherwise the daily
+# cron fire on an unsupported sport would raise inside ``job_alert_context``
+# and spam critical Discord alerts.
+_JOB_CRON_MAP: dict[str, tuple[str, tuple[SportKey, ...] | None]] = {
+    # daily-digest is gated to EPL because the digest formatter and
+    # heartbeat_expectations entry are EPL-only today.
+    "daily-digest": ("0 8 * * *", ("soccer_epl",)),
+    "fetch-espn-fixtures": ("0 6 * * *", ("soccer_epl",)),
 }
 
 
 def get_job_cron(job_name: str) -> str | None:
     """Return the cron expression for a job, or None if it is event-driven."""
-    return _JOB_CRON_MAP.get(job_name)
+    entry = _JOB_CRON_MAP.get(job_name)
+    if entry is None:
+        return None
+    cron_expr, _ = entry
+    return cron_expr
+
+
+def get_job_cron_sports(job_name: str) -> tuple[SportKey, ...] | None:
+    """Return the allowlist of sports for a cron job, or ``None`` for all sports.
+
+    Returns:
+        A tuple of ``SportKey`` values when the job's cron schedule is
+        restricted, ``None`` when it runs for every configured sport, and
+        ``None`` for event-driven (non-cron) jobs.
+    """
+    entry = _JOB_CRON_MAP.get(job_name)
+    if entry is None:
+        return None
+    _, sports = entry
+    return sports
+
+
+assert set(_JOB_CRON_MAP) <= set(_JOB_MODULE_MAP), (
+    f"Unknown jobs in _JOB_CRON_MAP: {set(_JOB_CRON_MAP) - set(_JOB_MODULE_MAP)}"
+)
 
 
 # Cache of already-imported job functions.

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -100,6 +100,22 @@ _PER_SPORT_JOBS: frozenset[str] = frozenset(
     }
 )
 
+# Jobs with fixed cron schedules when run locally. Mirrors terraform's
+# ``fixed_schedule_expressions`` for the jobs that have moved out of
+# Lambda and into the local scheduler. Keys are base job names (no sport
+# suffix); the scheduler CLI expands per-sport jobs into one schedule per
+# configured sport, each with its own compound job name.
+_JOB_CRON_MAP: dict[str, str] = {
+    "daily-digest": "0 8 * * *",
+    "fetch-espn-fixtures": "0 6 * * *",
+}
+
+
+def get_job_cron(job_name: str) -> str | None:
+    """Return the cron expression for a job, or None if it is event-driven."""
+    return _JOB_CRON_MAP.get(job_name)
+
+
 # Cache of already-imported job functions.
 _loaded_jobs: dict[str, Callable[[JobContext], Awaitable[None]]] = {}
 

--- a/tests/integration/test_local_backend.py
+++ b/tests/integration/test_local_backend.py
@@ -373,3 +373,97 @@ class TestLocalSchedulerBackend:
                     assert _job2_event.is_set()
                 except TimeoutError:
                     pytest.fail("Jobs did not execute within timeout")
+
+    @pytest.mark.asyncio
+    async def test_schedule_cron_registers_cron_trigger(self):
+        """schedule_cron installs a CronTrigger that persists on the data store."""
+        from apscheduler.triggers.cron import CronTrigger
+
+        with (
+            patch(_BUILD_PATCH, side_effect=_in_memory_scheduler),
+            patch("odds_lambda.scheduling.jobs.get_job_function", return_value=_noop_job),
+        ):
+            async with LocalSchedulerBackend() as backend:
+                await backend.schedule_cron(job_name="test-cron", cron_expr="0 8 * * *")
+
+                assert backend._scheduler is not None
+                sched = await backend._scheduler.get_schedule("test-cron")
+                assert isinstance(sched.trigger, CronTrigger)
+
+                jobs = await backend.get_scheduled_jobs()
+                assert len(jobs) == 1
+                assert jobs[0].job_name == "test-cron"
+                assert jobs[0].next_run_time is not None
+
+    @pytest.mark.asyncio
+    async def test_schedule_cron_replaces_existing_expression(self):
+        """Re-applying schedule_cron with a new expression swaps the trigger.
+
+        Regression guard for the bootstrap short-circuit bug: editing
+        ``_JOB_CRON_MAP`` must propagate to the stored schedule on the
+        next ``odds scheduler start``.
+        """
+        from apscheduler.triggers.cron import CronTrigger
+
+        with (
+            patch(_BUILD_PATCH, side_effect=_in_memory_scheduler),
+            patch("odds_lambda.scheduling.jobs.get_job_function", return_value=_noop_job),
+        ):
+            async with LocalSchedulerBackend() as backend:
+                await backend.schedule_cron(job_name="test-cron", cron_expr="0 8 * * *")
+                await backend.schedule_cron(job_name="test-cron", cron_expr="0 9 * * *")
+
+                jobs = await backend.get_scheduled_jobs()
+                assert len(jobs) == 1
+
+                assert backend._scheduler is not None
+                sched = await backend._scheduler.get_schedule("test-cron")
+                assert isinstance(sched.trigger, CronTrigger)
+                # CronTrigger stringifies to a canonical crontab; assert the
+                # minute/hour reflect the second (replaced) expression.
+                assert "hour='9'" in str(sched.trigger) or "'9'" in str(sched.trigger)
+
+    @pytest.mark.asyncio
+    async def test_cron_and_date_schedules_coexist(self):
+        """CronTrigger and DateTrigger schedules may coexist on the same backend."""
+        from apscheduler.triggers.cron import CronTrigger
+        from apscheduler.triggers.date import DateTrigger
+
+        with (
+            patch(_BUILD_PATCH, side_effect=_in_memory_scheduler),
+            patch("odds_lambda.scheduling.jobs.get_job_function", return_value=_noop_job),
+        ):
+            async with LocalSchedulerBackend() as backend:
+                await backend.schedule_cron(job_name="cron-job", cron_expr="0 8 * * *")
+                await backend.schedule_next_execution(
+                    job_name="date-job",
+                    next_time=datetime.now(UTC) + timedelta(hours=1),
+                )
+
+                jobs = await backend.get_scheduled_jobs()
+                assert {j.job_name for j in jobs} == {"cron-job", "date-job"}
+
+                assert backend._scheduler is not None
+                cron_sched = await backend._scheduler.get_schedule("cron-job")
+                date_sched = await backend._scheduler.get_schedule("date-job")
+                assert isinstance(cron_sched.trigger, CronTrigger)
+                assert isinstance(date_sched.trigger, DateTrigger)
+
+    @pytest.mark.asyncio
+    async def test_schedule_cron_dry_run_is_noop(self):
+        backend = LocalSchedulerBackend(dry_run=True)
+        await backend.schedule_cron(job_name="cron-job", cron_expr="0 8 * * *")
+        # No scheduler built, no exception raised — call is a no-op by design.
+
+    @pytest.mark.asyncio
+    async def test_schedule_cron_unknown_job_raises(self):
+        with (
+            patch(_BUILD_PATCH, side_effect=_in_memory_scheduler),
+            patch(
+                "odds_lambda.scheduling.jobs.get_job_function",
+                side_effect=KeyError("Unknown job 'invalid'"),
+            ),
+        ):
+            async with LocalSchedulerBackend() as backend:
+                with pytest.raises(SchedulingFailedError):
+                    await backend.schedule_cron(job_name="invalid", cron_expr="0 8 * * *")

--- a/tests/unit/test_agent_run.py
+++ b/tests/unit/test_agent_run.py
@@ -14,6 +14,7 @@ from odds_lambda.jobs.agent_run import (
     TIER_NO_FIXTURES_HOURS,
     TIER_RESEARCH_HOURS,
     ScheduleResult,
+    _build_agent_subprocess_env,
     _compute_wake_interval,
     _log_stream_message,
     _preview_tool_input,
@@ -433,3 +434,77 @@ class TestLogStreamMessage:
             _log_stream_message({"type": "system", "subtype": "init"})
 
         mock_logger.info.assert_not_called()
+
+
+class TestBuildAgentSubprocessEnv:
+    """Tests for the AGENT_DATABASE_URL override behaviour."""
+
+    def test_unset_inherits_parent_dsn_and_warns(self) -> None:
+        """When AGENT_DATABASE_URL is unset, inherit parent DATABASE_URL + warn."""
+        parent_env = {
+            "DATABASE_URL": "postgresql://parent:pw@host/db",
+            "PATH": "/usr/bin",
+        }
+        with (
+            patch.dict("os.environ", parent_env, clear=True),
+            patch("odds_lambda.jobs.agent_run.logger") as mock_logger,
+        ):
+            env = _build_agent_subprocess_env()
+
+        assert env["DATABASE_URL"] == "postgresql://parent:pw@host/db"
+        assert "PATH" in env  # other env inherited
+        mock_logger.warning.assert_called_once()
+        assert mock_logger.warning.call_args[0][0] == "agent_database_url_not_set"
+
+    def test_set_overrides_parent_dsn(self) -> None:
+        """When AGENT_DATABASE_URL is set, it replaces DATABASE_URL without warning."""
+        parent_env = {
+            "DATABASE_URL": "postgresql://parent:pw@host/db",
+            "AGENT_DATABASE_URL": "postgresql://odds_agent:pw@host/db",
+            "PATH": "/usr/bin",
+        }
+        with (
+            patch.dict("os.environ", parent_env, clear=True),
+            patch("odds_lambda.jobs.agent_run.logger") as mock_logger,
+        ):
+            env = _build_agent_subprocess_env()
+
+        assert env["DATABASE_URL"] == "postgresql://odds_agent:pw@host/db"
+        assert env["AGENT_DATABASE_URL"] == "postgresql://odds_agent:pw@host/db"
+        mock_logger.warning.assert_not_called()
+
+    def test_empty_string_treated_as_unset(self) -> None:
+        """An empty AGENT_DATABASE_URL is treated the same as missing."""
+        parent_env = {
+            "DATABASE_URL": "postgresql://parent:pw@host/db",
+            "AGENT_DATABASE_URL": "",
+        }
+        with (
+            patch.dict("os.environ", parent_env, clear=True),
+            patch("odds_lambda.jobs.agent_run.logger") as mock_logger,
+        ):
+            env = _build_agent_subprocess_env()
+
+        assert env["DATABASE_URL"] == "postgresql://parent:pw@host/db"
+        mock_logger.warning.assert_called_once()
+        assert mock_logger.warning.call_args[0][0] == "agent_database_url_not_set"
+
+    def test_returned_env_is_a_copy(self) -> None:
+        """Mutating the returned env dict must not affect ``os.environ``."""
+        import os
+
+        parent_env = {
+            "DATABASE_URL": "postgresql://parent:pw@host/db",
+            "EXISTING_KEY": "original",
+        }
+        with (
+            patch.dict("os.environ", parent_env, clear=True),
+            patch("odds_lambda.jobs.agent_run.logger"),
+        ):
+            env = _build_agent_subprocess_env()
+            env["EXISTING_KEY"] = "mutated"
+            env["NEW_KEY"] = "added_in_copy"
+
+            # os.environ is untouched.
+            assert os.environ["EXISTING_KEY"] == "original"
+            assert "NEW_KEY" not in os.environ

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -36,7 +36,13 @@ class TestSettings:
             assert settings.scheduler.backend == "local"
             assert settings.scheduler.dry_run is False
             assert settings.scheduler.lookahead_days == 7
-            assert settings.scheduler.bootstrap_jobs == ["agent-run"]
+            assert settings.scheduler.bootstrap_jobs == [
+                "agent-run",
+                "fetch-oddsportal",
+                "fetch-oddsportal-results",
+                "daily-digest",
+                "fetch-espn-fixtures",
+            ]
             assert settings.data_quality.enable_validation is True
             assert settings.data_quality.reject_invalid_odds is False
             assert settings.alerts.alert_enabled is False

--- a/tests/unit/test_job_routing.py
+++ b/tests/unit/test_job_routing.py
@@ -4,8 +4,12 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from odds_lambda.scheduling.jobs import (
+    _JOB_CRON_MAP,
+    _JOB_MODULE_MAP,
     JobContext,
     get_bootstrap_function,
+    get_job_cron,
+    get_job_cron_sports,
     make_compound_job_name,
     resolve_job_name,
     sport_key_to_suffix,
@@ -188,3 +192,39 @@ class TestGetBootstrapFunction:
     def test_unknown_job_raises_key_error(self) -> None:
         with pytest.raises(KeyError, match="Unknown job"):
             get_bootstrap_function("nonexistent-job")
+
+
+class TestJobCronRegistry:
+    """Tests for cron schedule + sport-allowlist lookups on ``_JOB_CRON_MAP``."""
+
+    def test_get_job_cron_returns_none_for_event_driven_job(self) -> None:
+        assert get_job_cron("fetch-odds") is None
+
+    def test_get_job_cron_returns_expression_for_mapped_job(self) -> None:
+        assert get_job_cron("daily-digest") == "0 8 * * *"
+
+    def test_get_job_cron_returns_none_for_unknown_job(self) -> None:
+        assert get_job_cron("totally-made-up") is None
+
+    def test_get_job_cron_sports_returns_allowlist_when_restricted(self) -> None:
+        # daily-digest and fetch-espn-fixtures are EPL-only — the sport
+        # allowlist is load-bearing (prevents the MLB digest from crashing
+        # inside job_alert_context each morning).
+        sports = get_job_cron_sports("daily-digest")
+        assert sports == ("soccer_epl",)
+
+    def test_get_job_cron_sports_restricted_for_fetch_espn_fixtures(self) -> None:
+        sports = get_job_cron_sports("fetch-espn-fixtures")
+        assert sports == ("soccer_epl",)
+
+    def test_get_job_cron_sports_returns_none_for_event_driven_job(self) -> None:
+        assert get_job_cron_sports("fetch-odds") is None
+
+    def test_get_job_cron_sports_returns_none_for_unknown_job(self) -> None:
+        assert get_job_cron_sports("totally-made-up") is None
+
+    def test_every_cron_job_is_in_module_map(self) -> None:
+        """Cron jobs must be registered as importable — the import-time
+        assertion in ``jobs.py`` guards this, but the test pins the contract.
+        """
+        assert set(_JOB_CRON_MAP) <= set(_JOB_MODULE_MAP)


### PR DESCRIPTION
## Summary

- **Agent CLI points at local `odds` DB** (default changed from `odds_test`) so the agent reads predictions from the same database the local scraper and scorer write to.
- **Scoring runs inline at the end of `fetch_oddsportal`** (wrapped in its own try/except so scoring bugs don't surface as scrape alerts). `score-predictions` is no longer a standalone scheduled job.
- **`LocalSchedulerBackend` gains `schedule_cron`.** New `_JOB_CRON_MAP: dict[str, tuple[str, tuple[SportKey, ...] | None]]` drives cron bootstrap; `daily-digest` and `fetch-espn-fixtures` are both gated to `soccer_epl` to avoid daily-critical Discord alerts for unsupported sports (MLB).
- **`bootstrap_jobs` default** promoted to `[agent-run, fetch-oddsportal, fetch-oddsportal-results, daily-digest, fetch-espn-fixtures]` so `odds scheduler start` covers the full local workflow without env overrides.
- **EventBridge no longer schedules** `score-predictions`, `daily-digest`, or `fetch-espn-fixtures`. `fetch-odds` unchanged. `terraform apply` required after merge — otherwise EventBridge keeps invoking removed jobs.
- **`odds_agent` Postgres role** added via migration `f1a2b3c4d5e6`: `SELECT` on all tables + `INSERT/UPDATE` on `paper_trades`, `match_briefs`, `agent_wakeups`. Role is `WITH LOGIN` but no password — operator sets credentials out-of-band. Agent subprocess reads `AGENT_DATABASE_URL` override; falls back to `DATABASE_URL` with a warning log if unset.
- **`heartbeat_expectations`** drops the now-stale `score-predictions-epl` key so health monitor no longer alerts for a job that was renamed to an inline call.
- **`.env.example`** adds `MODEL_NAME`, `MODEL_BUCKET`, `AGENT_DATABASE_URL`, and refreshes the `BOOTSTRAP_JOBS` comment.

## Follow-ups

- Operator must `terraform apply` after merge to drop the now-orphan EventBridge rules.
- Operator must provision the `odds_agent` role password and set `AGENT_DATABASE_URL` to realize the defense-in-depth control; otherwise the subprocess runs with the scraper's write-capable DSN (logged as a warning).
- Doc drift flagged but not addressed in this PR: `docs/ARCHITECTURE.md`, `docs/DEPLOYMENT.md`, and `docs/DEBUGGING_SCHEDULER.md` still describe these jobs as EventBridge-hosted. Worth a follow-up pass.

## Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)