### PR TITLE
Use XGBoostAdapter in score_predictions for multi-feature-group scoring

### DIFF
--- a/packages/odds-analytics/odds_analytics/backtesting/models.py
+++ b/packages/odds-analytics/odds_analytics/backtesting/models.py
@@ -25,14 +25,21 @@ __all__ = [
 
 
 class BacktestEvent(BaseModel):
-    """Event validated for backtesting - guaranteed to have final scores."""
+    """Event payload used for both backtesting and live scoring.
+
+    Constructed via ``from_db_event`` for completed events (scores guaranteed
+    non-None) and via ``feature_groups.make_backtest_event`` for upcoming
+    events at inference time (scores may be ``None``). Score fields are
+    therefore optional; backtest call sites that read them are reached only
+    after ``from_db_event`` has filtered out scoreless events.
+    """
 
     id: str
     commence_time: datetime
     home_team: str
     away_team: str
-    home_score: int
-    away_score: int
+    home_score: int | None
+    away_score: int | None
     status: EventStatus
 
     @field_validator("commence_time")

--- a/packages/odds-analytics/odds_analytics/backtesting/services.py
+++ b/packages/odds-analytics/odds_analytics/backtesting/services.py
@@ -41,6 +41,20 @@ __all__ = ["BettingStrategy", "BacktestEngine"]
 logger = structlog.get_logger()
 
 
+def _require_scores(event: BacktestEvent) -> tuple[int, int]:
+    """Narrow ``BacktestEvent`` scores to non-None for outcome evaluation.
+
+    ``BacktestEvent.home_score`` / ``away_score`` are typed ``int | None`` so
+    the same model can carry pre-match events through feature extraction, but
+    all bet-evaluation paths must run on completed events. Raises
+    ``AssertionError`` if a caller reaches here with missing scores.
+    """
+    assert event.home_score is not None and event.away_score is not None, (
+        f"BacktestEvent {event.id} reached outcome evaluation without final scores"
+    )
+    return event.home_score, event.away_score
+
+
 class BettingStrategy(ABC):
     """Abstract base class for all betting strategies."""
 
@@ -304,7 +318,8 @@ class BacktestEngine:
         wins, backing a team loses. For 2-way markets (basketball), a tie is
         a push (returns None).
         """
-        side = determine_h2h_winner(event.home_score, event.away_score)
+        home_score, away_score = _require_scores(event)
+        side = determine_h2h_winner(home_score, away_score)
         if side == "draw":
             if is_three_way:
                 return outcome.lower() == "draw"
@@ -320,15 +335,16 @@ class BacktestEngine:
         if line is None:
             return None
 
+        home_score, away_score = _require_scores(event)
         if outcome == event.home_team:
-            adjusted_score = event.home_score + line
-            won = adjusted_score > event.away_score
-            push = adjusted_score == event.away_score
+            adjusted_score = home_score + line
+            won = adjusted_score > away_score
+            push = adjusted_score == away_score
         else:
             away_line = -line
-            adjusted_score = event.away_score + away_line
-            won = adjusted_score > event.home_score
-            push = adjusted_score == event.home_score
+            adjusted_score = away_score + away_line
+            won = adjusted_score > home_score
+            push = adjusted_score == home_score
 
         if push:
             return None
@@ -342,7 +358,8 @@ class BacktestEngine:
         if line is None:
             return None
 
-        total_points = event.home_score + event.away_score
+        home_score, away_score = _require_scores(event)
+        total_points = home_score + away_score
 
         if outcome.lower() == "over":
             won = total_points > line

--- a/packages/odds-analytics/odds_analytics/feature_groups.py
+++ b/packages/odds-analytics/odds_analytics/feature_groups.py
@@ -80,6 +80,10 @@ __all__ = [
     "filter_completed_events",
     "resolve_outcome_name",
     "snapshot_has_bookmaker",
+    "FeatureGroupCaches",
+    "preload_feature_group_caches",
+    "load_fixtures_df",
+    "load_lineup_cache",
 ]
 
 
@@ -989,7 +993,7 @@ def _select_closing_snapshot(
 # =============================================================================
 
 
-async def _load_fixtures_df(session: AsyncSession) -> pd.DataFrame | None:
+async def load_fixtures_df(session: AsyncSession) -> pd.DataFrame | None:
     """Load all ESPN fixtures from DB into a DataFrame.
 
     Returns None if no fixtures exist in the database.
@@ -1009,7 +1013,7 @@ async def _load_fixtures_df(session: AsyncSession) -> pd.DataFrame | None:
     return df
 
 
-async def _load_lineup_cache(session: AsyncSession) -> LineupCache | None:
+async def load_lineup_cache(session: AsyncSession) -> LineupCache | None:
     """Load all ESPN lineups from DB and build a per-team starting XI cache.
 
     Loads the full roster (starters + subs) with player_name so that downstream
@@ -1038,6 +1042,51 @@ async def _load_lineup_cache(session: AsyncSession) -> LineupCache | None:
 
     logger.info("espn_lineups_loaded_from_db", rows=len(df))
     return build_lineup_cache(df[df["starter"]].drop(columns=["starter"]))
+
+
+@dataclass
+class FeatureGroupCaches:
+    """Bulk-loaded caches shared across events during feature extraction.
+
+    Populated by :func:`preload_feature_group_caches` and forwarded into
+    :func:`collect_event_data` so per-event DB queries stay O(1).
+    """
+
+    standings: dict[str, list[Event]] | None = None
+    match_stats: MatchStatsCache | None = None
+    fixtures_df: pd.DataFrame | None = None
+    lineup_cache: LineupCache | None = None
+
+
+async def preload_feature_group_caches(
+    session: AsyncSession,
+    config: FeatureConfig,
+    sport_key: str | None,
+) -> FeatureGroupCaches:
+    """Load every cache required by ``config.feature_groups`` in one pass.
+
+    Each cache is gated on its feature groups; sport-scoped caches
+    (standings, match_stats) are skipped when ``sport_key`` is ``None``.
+    """
+    caches = FeatureGroupCaches()
+
+    if {"standings", "epl_schedule"} & set(config.feature_groups) and sport_key:
+        from odds_analytics.standings_features import load_season_events_cache
+
+        caches.standings = await load_season_events_cache(session, sport_key)
+
+    if "match_stats" in config.feature_groups and sport_key:
+        from odds_analytics.match_stats_features import load_match_stats_cache
+
+        caches.match_stats = await load_match_stats_cache(session, sport_key)
+
+    if "epl_schedule" in config.feature_groups:
+        caches.fixtures_df = await load_fixtures_df(session)
+
+    if "epl_lineup" in config.feature_groups:
+        caches.lineup_cache = await load_lineup_cache(session)
+
+    return caches
 
 
 class PreparedFeatureData:
@@ -1119,31 +1168,7 @@ async def prepare_training_data(
     # Resolve sport_key once for cache loaders
     sport_key = config.sport_key or (valid_events[0].sport_key if valid_events else None)
 
-    # Preload standings cache to avoid N+1 queries (also used by epl_schedule)
-    standings_cache: dict[str, list[Event]] | None = None
-    if {"standings", "epl_schedule"} & set(config.feature_groups):
-        from odds_analytics.standings_features import load_season_events_cache
-
-        if sport_key:
-            standings_cache = await load_season_events_cache(session, sport_key)
-
-    # Preload match stats cache to avoid N+1 queries
-    match_stats_cache: MatchStatsCache | None = None
-    if "match_stats" in config.feature_groups:
-        from odds_analytics.match_stats_features import load_match_stats_cache
-
-        if sport_key:
-            match_stats_cache = await load_match_stats_cache(session, sport_key)
-
-    # Preload all-competition fixtures DataFrame for rest/congestion features
-    fixtures_df: pd.DataFrame | None = None
-    if "epl_schedule" in config.feature_groups:
-        fixtures_df = await _load_fixtures_df(session)
-
-    # Preload lineup cache for lineup-delta features
-    lineup_cache: LineupCache | None = None
-    if "epl_lineup" in config.feature_groups:
-        lineup_cache = await _load_lineup_cache(session)
+    caches = await preload_feature_group_caches(session, config, sport_key)
 
     for event in valid_events:
         # Load all data for this event in bulk
@@ -1151,10 +1176,10 @@ async def prepare_training_data(
             event,
             session,
             config,
-            standings_cache=standings_cache,
-            match_stats_cache=match_stats_cache,
-            fixtures_df=fixtures_df,
-            lineup_cache=lineup_cache,
+            standings_cache=caches.standings,
+            match_stats_cache=caches.match_stats,
+            fixtures_df=caches.fixtures_df,
+            lineup_cache=caches.lineup_cache,
         )
 
         # Closing snapshot is required

--- a/packages/odds-analytics/odds_analytics/feature_groups.py
+++ b/packages/odds-analytics/odds_analytics/feature_groups.py
@@ -432,14 +432,19 @@ def filter_completed_events(events: list[Event]) -> list[Event]:
 
 
 def make_backtest_event(event: Event) -> BacktestEvent:
-    """Convert Event to BacktestEvent for feature extraction."""
+    """Convert Event to BacktestEvent for feature extraction.
+
+    Scores default to 0 for SCHEDULED events (used at inference time):
+    feature extractors do not consume score fields, but BacktestEvent
+    validates them as ints.
+    """
     return BacktestEvent(
         id=event.id,
         commence_time=event.commence_time,
         home_team=event.home_team,
         away_team=event.away_team,
-        home_score=event.home_score,
-        away_score=event.away_score,
+        home_score=event.home_score if event.home_score is not None else 0,
+        away_score=event.away_score if event.away_score is not None else 0,
         status=event.status,
     )
 

--- a/packages/odds-analytics/odds_analytics/feature_groups.py
+++ b/packages/odds-analytics/odds_analytics/feature_groups.py
@@ -434,17 +434,17 @@ def filter_completed_events(events: list[Event]) -> list[Event]:
 def make_backtest_event(event: Event) -> BacktestEvent:
     """Convert Event to BacktestEvent for feature extraction.
 
-    Scores default to 0 for SCHEDULED events (used at inference time):
-    feature extractors do not consume score fields, but BacktestEvent
-    validates them as ints.
+    Scores are passed through as-is; SCHEDULED events at inference time
+    will have ``None`` scores. Feature extractors do not consume score
+    fields, so this is safe.
     """
     return BacktestEvent(
         id=event.id,
         commence_time=event.commence_time,
         home_team=event.home_team,
         away_team=event.away_team,
-        home_score=event.home_score if event.home_score is not None else 0,
-        away_score=event.away_score if event.away_score is not None else 0,
+        home_score=event.home_score,
+        away_score=event.away_score,
         status=event.status,
     )
 

--- a/packages/odds-lambda/odds_lambda/jobs/score_predictions.py
+++ b/packages/odds-lambda/odds_lambda/jobs/score_predictions.py
@@ -15,15 +15,13 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
 
 import numpy as np
 import structlog
 from odds_analytics.feature_groups import (
     XGBoostAdapter,
-    _load_fixtures_df,
-    _load_lineup_cache,
     collect_event_data,
+    preload_feature_group_caches,
 )
 from odds_analytics.training.config import FeatureConfig
 from odds_core.config import get_settings
@@ -36,11 +34,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from odds_lambda.model_loader import get_cached_version, load_model
 from odds_lambda.scheduling.jobs import JobContext, make_compound_job_name
-
-if TYPE_CHECKING:
-    import pandas as pd
-    from odds_analytics.epl_lineup_features import LineupCache
-    from odds_analytics.match_stats_features import MatchStatsCache
 
 logger = structlog.get_logger()
 
@@ -86,45 +79,6 @@ async def _get_unscored_snapshots(
     )
     result = await session.execute(query)
     return list(result.scalars().all())
-
-
-async def _preload_caches(
-    session: AsyncSession,
-    config: FeatureConfig,
-    sport_key: str,
-) -> tuple[
-    dict[str, list[Event]] | None,
-    MatchStatsCache | None,
-    pd.DataFrame | None,
-    LineupCache | None,
-]:
-    """Load feature-group caches once per scoring invocation.
-
-    Mirrors the guarded-preload pattern used in
-    ``feature_groups.prepare_training_data`` so that caches are only built
-    when their corresponding feature group is configured.
-    """
-    standings_cache: dict[str, list[Event]] | None = None
-    if {"standings", "epl_schedule"} & set(config.feature_groups):
-        from odds_analytics.standings_features import load_season_events_cache
-
-        standings_cache = await load_season_events_cache(session, sport_key)
-
-    match_stats_cache: MatchStatsCache | None = None
-    if "match_stats" in config.feature_groups:
-        from odds_analytics.match_stats_features import load_match_stats_cache
-
-        match_stats_cache = await load_match_stats_cache(session, sport_key)
-
-    fixtures_df: pd.DataFrame | None = None
-    if "epl_schedule" in config.feature_groups:
-        fixtures_df = await _load_fixtures_df(session)
-
-    lineup_cache: LineupCache | None = None
-    if "epl_lineup" in config.feature_groups:
-        lineup_cache = await _load_lineup_cache(session)
-
-    return standings_cache, match_stats_cache, fixtures_df, lineup_cache
 
 
 async def score_events(
@@ -208,9 +162,7 @@ async def score_events(
             logger.info("no_upcoming_events", sport_key=sport_key)
             return stats
 
-        standings_cache, match_stats_cache, fixtures_df, lineup_cache = await _preload_caches(
-            session, config, sport_key
-        )
+        caches = await preload_feature_group_caches(session, config, sport_key)
 
         for event in events:
             snapshots = await _get_unscored_snapshots(session, event.id, model_name)
@@ -221,10 +173,10 @@ async def score_events(
                 event,
                 session,
                 config,
-                standings_cache=standings_cache,
-                match_stats_cache=match_stats_cache,
-                fixtures_df=fixtures_df,
-                lineup_cache=lineup_cache,
+                standings_cache=caches.standings,
+                match_stats_cache=caches.match_stats,
+                fixtures_df=caches.fixtures_df,
+                lineup_cache=caches.lineup_cache,
             )
 
             for snapshot in snapshots:

--- a/packages/odds-lambda/odds_lambda/jobs/score_predictions.py
+++ b/packages/odds-lambda/odds_lambda/jobs/score_predictions.py
@@ -15,24 +15,32 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 import numpy as np
 import structlog
-from odds_analytics.backtesting import BacktestEvent
-from odds_analytics.feature_extraction import TabularFeatureExtractor
-from odds_analytics.feature_groups import resolve_outcome_name
+from odds_analytics.feature_groups import (
+    XGBoostAdapter,
+    _load_fixtures_df,
+    _load_lineup_cache,
+    collect_event_data,
+)
 from odds_analytics.training.config import FeatureConfig
 from odds_core.config import get_settings
 from odds_core.database import async_session_maker
 from odds_core.models import Event, EventStatus, OddsSnapshot
 from odds_core.prediction_models import Prediction
-from odds_core.snapshot_utils import extract_odds_from_snapshot
 from sqlalchemy import and_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from odds_lambda.model_loader import get_cached_version, load_model
 from odds_lambda.scheduling.jobs import JobContext, make_compound_job_name
+
+if TYPE_CHECKING:
+    import pandas as pd
+    from odds_analytics.epl_lineup_features import LineupCache
+    from odds_analytics.match_stats_features import MatchStatsCache
 
 logger = structlog.get_logger()
 
@@ -80,58 +88,43 @@ async def _get_unscored_snapshots(
     return list(result.scalars().all())
 
 
-def _extract_features(
-    event: Event,
-    snapshot: OddsSnapshot,
+async def _preload_caches(
+    session: AsyncSession,
     config: FeatureConfig,
-    expected_features: list[str],
-) -> np.ndarray | None:
-    """Extract feature vector for a single snapshot.
+    sport_key: str,
+) -> tuple[
+    dict[str, list[Event]] | None,
+    MatchStatsCache | None,
+    pd.DataFrame | None,
+    LineupCache | None,
+]:
+    """Load feature-group caches once per scoring invocation.
 
-    Returns None if feature extraction fails (e.g. no odds data in snapshot)
-    or if the produced feature names don't match what the model expects.
+    Mirrors the guarded-preload pattern used in
+    ``feature_groups.prepare_training_data`` so that caches are only built
+    when their corresponding feature group is configured.
     """
-    market = config.primary_market
-    outcome_name = resolve_outcome_name(config, event)
+    standings_cache: dict[str, list[Event]] | None = None
+    if {"standings", "epl_schedule"} & set(config.feature_groups):
+        from odds_analytics.standings_features import load_season_events_cache
 
-    odds = extract_odds_from_snapshot(snapshot, event.id, market=market)
-    if not odds:
-        return None
+        standings_cache = await load_season_events_cache(session, sport_key)
 
-    backtest_event = BacktestEvent(
-        id=event.id,
-        commence_time=event.commence_time,
-        home_team=event.home_team,
-        away_team=event.away_team,
-        home_score=0,
-        away_score=0,
-        status=event.status,
-    )
+    match_stats_cache: MatchStatsCache | None = None
+    if "match_stats" in config.feature_groups:
+        from odds_analytics.match_stats_features import load_match_stats_cache
 
-    extractor = TabularFeatureExtractor.from_config(config)
-    tab_feats = extractor.extract_features(
-        event=backtest_event,
-        odds_data=odds,
-        outcome=outcome_name,
-        market=market,
-    )
-    tab_array = tab_feats.to_array()
+        match_stats_cache = await load_match_stats_cache(session, sport_key)
 
-    hours_until = (event.commence_time - snapshot.snapshot_time).total_seconds() / 3600
-    feature_vector = np.concatenate([tab_array, np.array([hours_until])])
-    feature_vector = np.nan_to_num(feature_vector, nan=0.0).astype(np.float32)
+    fixtures_df: pd.DataFrame | None = None
+    if "epl_schedule" in config.feature_groups:
+        fixtures_df = await _load_fixtures_df(session)
 
-    # Verify feature alignment — mismatched features produce garbage predictions
-    produced_names = [f"tab_{n}" for n in extractor.get_feature_names()] + ["hours_until_event"]
-    if produced_names != expected_features:
-        logger.error(
-            "feature_name_mismatch",
-            expected=expected_features,
-            produced=produced_names,
-        )
-        return None
+    lineup_cache: LineupCache | None = None
+    if "epl_lineup" in config.feature_groups:
+        lineup_cache = await _load_lineup_cache(session)
 
-    return feature_vector
+    return standings_cache, match_stats_cache, fixtures_df, lineup_cache
 
 
 async def score_events(
@@ -168,7 +161,7 @@ async def score_events(
         return stats
 
     model = model_data["model"]
-    feature_names: list[str] = model_data["feature_names"]
+    expected_feature_names: list[str] = model_data["feature_names"]
     model_version = get_cached_version() or "unknown"
 
     bundled_config: FeatureConfig | None = model_data.get("feature_config")
@@ -187,7 +180,6 @@ async def score_events(
         )
         return stats
 
-    # Validate that requested sport matches the model's sport
     if sport and sport != sport_key:
         logger.error(
             "sport_mismatch",
@@ -195,6 +187,16 @@ async def score_events(
             model_sport=sport_key,
             model_name=model_name,
             msg="Requested sport does not match model's sport_key",
+        )
+        return stats
+
+    adapter = XGBoostAdapter()
+    produced_feature_names = adapter.feature_names(config)
+    if produced_feature_names != expected_feature_names:
+        logger.error(
+            "feature_name_mismatch",
+            expected=expected_feature_names,
+            produced=produced_feature_names,
         )
         return stats
 
@@ -206,17 +208,34 @@ async def score_events(
             logger.info("no_upcoming_events", sport_key=sport_key)
             return stats
 
+        standings_cache, match_stats_cache, fixtures_df, lineup_cache = await _preload_caches(
+            session, config, sport_key
+        )
+
         for event in events:
             snapshots = await _get_unscored_snapshots(session, event.id, model_name)
+            if not snapshots:
+                continue
+
+            bundle = await collect_event_data(
+                event,
+                session,
+                config,
+                standings_cache=standings_cache,
+                match_stats_cache=match_stats_cache,
+                fixtures_df=fixtures_df,
+                lineup_cache=lineup_cache,
+            )
 
             for snapshot in snapshots:
                 try:
-                    features = _extract_features(event, snapshot, config, feature_names)
-                    if features is None:
+                    output = adapter.transform(bundle, snapshot, config)
+                    if output is None:
                         stats["snapshots_skipped"] += 1
                         continue
 
-                    predicted_clv = float(model.predict(features.reshape(1, -1))[0])
+                    feature_vector = output.features.astype(np.float32)
+                    predicted_clv = float(model.predict(feature_vector.reshape(1, -1))[0])
 
                     stmt = (
                         pg_insert(Prediction)

--- a/tests/unit/test_epl_data_storage.py
+++ b/tests/unit/test_epl_data_storage.py
@@ -352,14 +352,14 @@ class TestFplAvailabilityReader:
 class TestLoadFixturesDf:
     @pytest.mark.asyncio
     async def test_returns_none_when_empty(self, pglite_async_session):
-        from odds_analytics.feature_groups import _load_fixtures_df
+        from odds_analytics.feature_groups import load_fixtures_df
 
-        df = await _load_fixtures_df(pglite_async_session)
+        df = await load_fixtures_df(pglite_async_session)
         assert df is None
 
     @pytest.mark.asyncio
     async def test_returns_dataframe_with_expected_columns(self, pglite_async_session):
-        from odds_analytics.feature_groups import _load_fixtures_df
+        from odds_analytics.feature_groups import load_fixtures_df
 
         writer = EspnFixtureWriter(pglite_async_session)
         await writer.upsert_fixtures(
@@ -367,7 +367,7 @@ class TestLoadFixturesDf:
         )
         await pglite_async_session.commit()
 
-        df = await _load_fixtures_df(pglite_async_session)
+        df = await load_fixtures_df(pglite_async_session)
         assert df is not None
         assert len(df) == 2
         expected_cols = {
@@ -387,13 +387,13 @@ class TestLoadFixturesDf:
 
     @pytest.mark.asyncio
     async def test_dates_are_utc_aware(self, pglite_async_session):
-        from odds_analytics.feature_groups import _load_fixtures_df
+        from odds_analytics.feature_groups import load_fixtures_df
 
         writer = EspnFixtureWriter(pglite_async_session)
         await writer.upsert_fixtures([_fixture_record()])
         await pglite_async_session.commit()
 
-        df = await _load_fixtures_df(pglite_async_session)
+        df = await load_fixtures_df(pglite_async_session)
         assert df is not None
         assert df["date"].dt.tz is not None
 
@@ -401,14 +401,14 @@ class TestLoadFixturesDf:
 class TestLoadLineupCache:
     @pytest.mark.asyncio
     async def test_returns_none_when_empty(self, pglite_async_session):
-        from odds_analytics.feature_groups import _load_lineup_cache
+        from odds_analytics.feature_groups import load_lineup_cache
 
-        cache = await _load_lineup_cache(pglite_async_session)
+        cache = await load_lineup_cache(pglite_async_session)
         assert cache is None
 
     @pytest.mark.asyncio
     async def test_returns_cache_from_db_records(self, pglite_async_session):
-        from odds_analytics.feature_groups import _load_lineup_cache
+        from odds_analytics.feature_groups import load_lineup_cache
 
         writer = EspnLineupWriter(pglite_async_session)
         await writer.upsert_lineups(
@@ -420,6 +420,6 @@ class TestLoadLineupCache:
         )
         await pglite_async_session.commit()
 
-        cache = await _load_lineup_cache(pglite_async_session)
+        cache = await load_lineup_cache(pglite_async_session)
         assert cache is not None
         assert "Arsenal" in cache

--- a/tests/unit/test_feature_groups.py
+++ b/tests/unit/test_feature_groups.py
@@ -1,9 +1,12 @@
 """Unit tests for feature_groups helpers."""
 
 from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from odds_analytics.feature_groups import (
     _should_filter_missing_sharp,
+    preload_feature_group_caches,
     snapshot_has_bookmaker,
 )
 from odds_analytics.training.config import FeatureConfig
@@ -160,3 +163,232 @@ class TestShouldFilterMissingSharp:
     def test_multiple_sharp_none_is_target(self) -> None:
         config = self._make_config(["pinnacle", "circa"], "bet365")
         assert _should_filter_missing_sharp(config) is True
+
+
+def _config_with_groups(*groups: str) -> FeatureConfig:
+    return FeatureConfig(
+        adapter="xgboost",
+        sharp_bookmakers=["bet365"],
+        retail_bookmakers=["betway", "betfred", "bwin"],
+        markets=["h2h"],
+        outcome="home",
+        feature_groups=tuple(groups),
+        target_type="devigged_bookmaker",
+        target_bookmaker="bet365",
+        sport_key="soccer_epl",
+    )
+
+
+class TestPreloadFeatureGroupCaches:
+    """Gating behaviour of the shared preload helper."""
+
+    @pytest.mark.asyncio
+    @patch("odds_analytics.feature_groups.load_lineup_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.feature_groups.load_fixtures_df", new_callable=AsyncMock)
+    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
+    async def test_tabular_only_loads_no_caches(
+        self,
+        mock_standings: AsyncMock,
+        mock_match_stats: AsyncMock,
+        mock_fixtures: AsyncMock,
+        mock_lineup: AsyncMock,
+    ) -> None:
+        config = _config_with_groups("tabular")
+        session = AsyncMock()
+
+        caches = await preload_feature_group_caches(session, config, "soccer_epl")
+
+        assert caches.standings is None
+        assert caches.match_stats is None
+        assert caches.fixtures_df is None
+        assert caches.lineup_cache is None
+        mock_standings.assert_not_called()
+        mock_match_stats.assert_not_called()
+        mock_fixtures.assert_not_called()
+        mock_lineup.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("odds_analytics.feature_groups.load_lineup_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.feature_groups.load_fixtures_df", new_callable=AsyncMock)
+    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
+    async def test_standings_only_loads_standings_cache(
+        self,
+        mock_standings: AsyncMock,
+        mock_match_stats: AsyncMock,
+        mock_fixtures: AsyncMock,
+        mock_lineup: AsyncMock,
+    ) -> None:
+        sentinel: dict[str, list[Event]] = {"2025-26": []}
+        mock_standings.return_value = sentinel
+        config = _config_with_groups("tabular", "standings")
+        session = AsyncMock()
+
+        caches = await preload_feature_group_caches(session, config, "soccer_epl")
+
+        assert caches.standings is sentinel
+        assert caches.match_stats is None
+        assert caches.fixtures_df is None
+        assert caches.lineup_cache is None
+        mock_standings.assert_awaited_once_with(session, "soccer_epl")
+        mock_match_stats.assert_not_called()
+        mock_fixtures.assert_not_called()
+        mock_lineup.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("odds_analytics.feature_groups.load_lineup_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.feature_groups.load_fixtures_df", new_callable=AsyncMock)
+    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
+    async def test_match_stats_only_loads_match_stats_cache(
+        self,
+        mock_standings: AsyncMock,
+        mock_match_stats: AsyncMock,
+        mock_fixtures: AsyncMock,
+        mock_lineup: AsyncMock,
+    ) -> None:
+        sentinel = MagicMock(name="match_stats_cache")
+        mock_match_stats.return_value = sentinel
+        config = _config_with_groups("tabular", "match_stats")
+        session = AsyncMock()
+
+        caches = await preload_feature_group_caches(session, config, "soccer_epl")
+
+        assert caches.standings is None
+        assert caches.match_stats is sentinel
+        assert caches.fixtures_df is None
+        assert caches.lineup_cache is None
+        mock_standings.assert_not_called()
+        mock_match_stats.assert_awaited_once_with(session, "soccer_epl")
+        mock_fixtures.assert_not_called()
+        mock_lineup.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("odds_analytics.feature_groups.load_lineup_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.feature_groups.load_fixtures_df", new_callable=AsyncMock)
+    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
+    async def test_epl_schedule_loads_fixtures_and_standings(
+        self,
+        mock_standings: AsyncMock,
+        mock_match_stats: AsyncMock,
+        mock_fixtures: AsyncMock,
+        mock_lineup: AsyncMock,
+    ) -> None:
+        """epl_schedule pulls in standings_cache too (shared by season-rest features)."""
+        standings_sentinel: dict[str, list[Event]] = {"2025-26": []}
+        fixtures_sentinel = MagicMock(name="fixtures_df")
+        mock_standings.return_value = standings_sentinel
+        mock_fixtures.return_value = fixtures_sentinel
+        config = _config_with_groups("tabular", "epl_schedule")
+        session = AsyncMock()
+
+        caches = await preload_feature_group_caches(session, config, "soccer_epl")
+
+        assert caches.standings is standings_sentinel
+        assert caches.match_stats is None
+        assert caches.fixtures_df is fixtures_sentinel
+        assert caches.lineup_cache is None
+        mock_standings.assert_awaited_once_with(session, "soccer_epl")
+        mock_fixtures.assert_awaited_once_with(session)
+        mock_match_stats.assert_not_called()
+        mock_lineup.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("odds_analytics.feature_groups.load_lineup_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.feature_groups.load_fixtures_df", new_callable=AsyncMock)
+    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
+    async def test_epl_lineup_loads_lineup_cache(
+        self,
+        mock_standings: AsyncMock,
+        mock_match_stats: AsyncMock,
+        mock_fixtures: AsyncMock,
+        mock_lineup: AsyncMock,
+    ) -> None:
+        sentinel = MagicMock(name="lineup_cache")
+        mock_lineup.return_value = sentinel
+        config = _config_with_groups("tabular", "epl_lineup")
+        session = AsyncMock()
+
+        caches = await preload_feature_group_caches(session, config, "soccer_epl")
+
+        assert caches.standings is None
+        assert caches.match_stats is None
+        assert caches.fixtures_df is None
+        assert caches.lineup_cache is sentinel
+        mock_standings.assert_not_called()
+        mock_match_stats.assert_not_called()
+        mock_fixtures.assert_not_called()
+        mock_lineup.assert_awaited_once_with(session)
+
+    @pytest.mark.asyncio
+    @patch("odds_analytics.feature_groups.load_lineup_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.feature_groups.load_fixtures_df", new_callable=AsyncMock)
+    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
+    async def test_all_groups_load_all_caches(
+        self,
+        mock_standings: AsyncMock,
+        mock_match_stats: AsyncMock,
+        mock_fixtures: AsyncMock,
+        mock_lineup: AsyncMock,
+    ) -> None:
+        standings_sentinel: dict[str, list[Event]] = {"2025-26": []}
+        match_stats_sentinel = MagicMock(name="match_stats_cache")
+        fixtures_sentinel = MagicMock(name="fixtures_df")
+        lineup_sentinel = MagicMock(name="lineup_cache")
+        mock_standings.return_value = standings_sentinel
+        mock_match_stats.return_value = match_stats_sentinel
+        mock_fixtures.return_value = fixtures_sentinel
+        mock_lineup.return_value = lineup_sentinel
+
+        config = _config_with_groups(
+            "tabular",
+            "standings",
+            "match_stats",
+            "epl_schedule",
+            "epl_lineup",
+        )
+        session = AsyncMock()
+
+        caches = await preload_feature_group_caches(session, config, "soccer_epl")
+
+        assert caches.standings is standings_sentinel
+        assert caches.match_stats is match_stats_sentinel
+        assert caches.fixtures_df is fixtures_sentinel
+        assert caches.lineup_cache is lineup_sentinel
+        mock_standings.assert_awaited_once_with(session, "soccer_epl")
+        mock_match_stats.assert_awaited_once_with(session, "soccer_epl")
+        mock_fixtures.assert_awaited_once_with(session)
+        mock_lineup.assert_awaited_once_with(session)
+
+    @pytest.mark.asyncio
+    @patch("odds_analytics.feature_groups.load_lineup_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.feature_groups.load_fixtures_df", new_callable=AsyncMock)
+    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
+    async def test_sport_scoped_caches_skipped_when_sport_key_missing(
+        self,
+        mock_standings: AsyncMock,
+        mock_match_stats: AsyncMock,
+        mock_fixtures: AsyncMock,
+        mock_lineup: AsyncMock,
+    ) -> None:
+        """Standings and match_stats skip when sport_key is None; sport-agnostic caches still load."""
+        fixtures_sentinel = MagicMock(name="fixtures_df")
+        mock_fixtures.return_value = fixtures_sentinel
+        config = _config_with_groups("standings", "match_stats", "epl_schedule")
+        session = AsyncMock()
+
+        caches = await preload_feature_group_caches(session, config, None)
+
+        assert caches.standings is None
+        assert caches.match_stats is None
+        assert caches.fixtures_df is fixtures_sentinel
+        assert caches.lineup_cache is None
+        mock_standings.assert_not_called()
+        mock_match_stats.assert_not_called()
+        mock_fixtures.assert_awaited_once_with(session)
+        mock_lineup.assert_not_called()

--- a/tests/unit/test_score_predictions.py
+++ b/tests/unit/test_score_predictions.py
@@ -8,7 +8,7 @@ import pytest
 from odds_analytics.feature_groups import XGBoostAdapter, collect_event_data
 from odds_analytics.training.config import FeatureConfig
 from odds_core.models import Event, EventStatus, OddsSnapshot
-from odds_lambda.jobs.score_predictions import score_events
+from odds_lambda.jobs.score_predictions import _preload_caches, score_events
 
 _TEST_FEATURE_CONFIG = FeatureConfig(
     adapter="xgboost",
@@ -407,3 +407,210 @@ class TestScoreEvents:
 
         assert stats["events_checked"] == 0
         assert stats["snapshots_scored"] == 0
+
+
+def _config_with_groups(*groups: str) -> FeatureConfig:
+    return FeatureConfig(
+        adapter="xgboost",
+        sharp_bookmakers=["bet365"],
+        retail_bookmakers=["betway", "betfred", "bwin"],
+        markets=["h2h"],
+        outcome="home",
+        feature_groups=tuple(groups),
+        target_type="devigged_bookmaker",
+        target_bookmaker="bet365",
+        sport_key="soccer_epl",
+    )
+
+
+class TestPreloadCaches:
+    """Direct unit tests for _preload_caches gating."""
+
+    @pytest.mark.asyncio
+    @patch("odds_lambda.jobs.score_predictions._load_lineup_cache", new_callable=AsyncMock)
+    @patch("odds_lambda.jobs.score_predictions._load_fixtures_df", new_callable=AsyncMock)
+    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
+    async def test_tabular_only_loads_no_caches(
+        self,
+        mock_standings: AsyncMock,
+        mock_match_stats: AsyncMock,
+        mock_fixtures: AsyncMock,
+        mock_lineup: AsyncMock,
+    ) -> None:
+        config = _config_with_groups("tabular")
+        session = AsyncMock()
+
+        result = await _preload_caches(session, config, "soccer_epl")
+
+        assert result == (None, None, None, None)
+        mock_standings.assert_not_called()
+        mock_match_stats.assert_not_called()
+        mock_fixtures.assert_not_called()
+        mock_lineup.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("odds_lambda.jobs.score_predictions._load_lineup_cache", new_callable=AsyncMock)
+    @patch("odds_lambda.jobs.score_predictions._load_fixtures_df", new_callable=AsyncMock)
+    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
+    async def test_standings_only_loads_standings_cache(
+        self,
+        mock_standings: AsyncMock,
+        mock_match_stats: AsyncMock,
+        mock_fixtures: AsyncMock,
+        mock_lineup: AsyncMock,
+    ) -> None:
+        sentinel: dict[str, list[Event]] = {"2025-26": []}
+        mock_standings.return_value = sentinel
+        config = _config_with_groups("tabular", "standings")
+        session = AsyncMock()
+
+        standings_cache, match_stats_cache, fixtures_df, lineup_cache = await _preload_caches(
+            session, config, "soccer_epl"
+        )
+
+        assert standings_cache is sentinel
+        assert match_stats_cache is None
+        assert fixtures_df is None
+        assert lineup_cache is None
+        mock_standings.assert_awaited_once_with(session, "soccer_epl")
+        mock_match_stats.assert_not_called()
+        mock_fixtures.assert_not_called()
+        mock_lineup.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("odds_lambda.jobs.score_predictions._load_lineup_cache", new_callable=AsyncMock)
+    @patch("odds_lambda.jobs.score_predictions._load_fixtures_df", new_callable=AsyncMock)
+    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
+    async def test_match_stats_only_loads_match_stats_cache(
+        self,
+        mock_standings: AsyncMock,
+        mock_match_stats: AsyncMock,
+        mock_fixtures: AsyncMock,
+        mock_lineup: AsyncMock,
+    ) -> None:
+        sentinel = MagicMock(name="match_stats_cache")
+        mock_match_stats.return_value = sentinel
+        config = _config_with_groups("tabular", "match_stats")
+        session = AsyncMock()
+
+        standings_cache, match_stats_cache, fixtures_df, lineup_cache = await _preload_caches(
+            session, config, "soccer_epl"
+        )
+
+        assert standings_cache is None
+        assert match_stats_cache is sentinel
+        assert fixtures_df is None
+        assert lineup_cache is None
+        mock_standings.assert_not_called()
+        mock_match_stats.assert_awaited_once_with(session, "soccer_epl")
+        mock_fixtures.assert_not_called()
+        mock_lineup.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("odds_lambda.jobs.score_predictions._load_lineup_cache", new_callable=AsyncMock)
+    @patch("odds_lambda.jobs.score_predictions._load_fixtures_df", new_callable=AsyncMock)
+    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
+    async def test_epl_schedule_loads_fixtures_and_standings(
+        self,
+        mock_standings: AsyncMock,
+        mock_match_stats: AsyncMock,
+        mock_fixtures: AsyncMock,
+        mock_lineup: AsyncMock,
+    ) -> None:
+        """epl_schedule pulls in standings_cache too (shared by season-rest features)."""
+        standings_sentinel: dict[str, list[Event]] = {"2025-26": []}
+        fixtures_sentinel = MagicMock(name="fixtures_df")
+        mock_standings.return_value = standings_sentinel
+        mock_fixtures.return_value = fixtures_sentinel
+        config = _config_with_groups("tabular", "epl_schedule")
+        session = AsyncMock()
+
+        standings_cache, match_stats_cache, fixtures_df, lineup_cache = await _preload_caches(
+            session, config, "soccer_epl"
+        )
+
+        assert standings_cache is standings_sentinel
+        assert match_stats_cache is None
+        assert fixtures_df is fixtures_sentinel
+        assert lineup_cache is None
+        mock_standings.assert_awaited_once_with(session, "soccer_epl")
+        mock_fixtures.assert_awaited_once_with(session)
+        mock_match_stats.assert_not_called()
+        mock_lineup.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("odds_lambda.jobs.score_predictions._load_lineup_cache", new_callable=AsyncMock)
+    @patch("odds_lambda.jobs.score_predictions._load_fixtures_df", new_callable=AsyncMock)
+    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
+    async def test_epl_lineup_loads_lineup_cache(
+        self,
+        mock_standings: AsyncMock,
+        mock_match_stats: AsyncMock,
+        mock_fixtures: AsyncMock,
+        mock_lineup: AsyncMock,
+    ) -> None:
+        sentinel = MagicMock(name="lineup_cache")
+        mock_lineup.return_value = sentinel
+        config = _config_with_groups("tabular", "epl_lineup")
+        session = AsyncMock()
+
+        standings_cache, match_stats_cache, fixtures_df, lineup_cache = await _preload_caches(
+            session, config, "soccer_epl"
+        )
+
+        assert standings_cache is None
+        assert match_stats_cache is None
+        assert fixtures_df is None
+        assert lineup_cache is sentinel
+        mock_standings.assert_not_called()
+        mock_match_stats.assert_not_called()
+        mock_fixtures.assert_not_called()
+        mock_lineup.assert_awaited_once_with(session)
+
+    @pytest.mark.asyncio
+    @patch("odds_lambda.jobs.score_predictions._load_lineup_cache", new_callable=AsyncMock)
+    @patch("odds_lambda.jobs.score_predictions._load_fixtures_df", new_callable=AsyncMock)
+    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
+    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
+    async def test_all_groups_load_all_caches(
+        self,
+        mock_standings: AsyncMock,
+        mock_match_stats: AsyncMock,
+        mock_fixtures: AsyncMock,
+        mock_lineup: AsyncMock,
+    ) -> None:
+        standings_sentinel: dict[str, list[Event]] = {"2025-26": []}
+        match_stats_sentinel = MagicMock(name="match_stats_cache")
+        fixtures_sentinel = MagicMock(name="fixtures_df")
+        lineup_sentinel = MagicMock(name="lineup_cache")
+        mock_standings.return_value = standings_sentinel
+        mock_match_stats.return_value = match_stats_sentinel
+        mock_fixtures.return_value = fixtures_sentinel
+        mock_lineup.return_value = lineup_sentinel
+
+        config = _config_with_groups(
+            "tabular",
+            "standings",
+            "match_stats",
+            "epl_schedule",
+            "epl_lineup",
+        )
+        session = AsyncMock()
+
+        standings_cache, match_stats_cache, fixtures_df, lineup_cache = await _preload_caches(
+            session, config, "soccer_epl"
+        )
+
+        assert standings_cache is standings_sentinel
+        assert match_stats_cache is match_stats_sentinel
+        assert fixtures_df is fixtures_sentinel
+        assert lineup_cache is lineup_sentinel
+        mock_standings.assert_awaited_once_with(session, "soccer_epl")
+        mock_match_stats.assert_awaited_once_with(session, "soccer_epl")
+        mock_fixtures.assert_awaited_once_with(session)
+        mock_lineup.assert_awaited_once_with(session)

--- a/tests/unit/test_score_predictions.py
+++ b/tests/unit/test_score_predictions.py
@@ -5,10 +5,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
 import pytest
-from odds_analytics.feature_groups import XGBoostAdapter, collect_event_data
+from odds_analytics.feature_groups import FeatureGroupCaches, XGBoostAdapter, collect_event_data
 from odds_analytics.training.config import FeatureConfig
 from odds_core.models import Event, EventStatus, OddsSnapshot
-from odds_lambda.jobs.score_predictions import _preload_caches, score_events
+from odds_lambda.jobs.score_predictions import score_events
 
 _TEST_FEATURE_CONFIG = FeatureConfig(
     adapter="xgboost",
@@ -239,7 +239,7 @@ class TestScoreEvents:
         mock_model.predict.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("odds_lambda.jobs.score_predictions._preload_caches")
+    @patch("odds_lambda.jobs.score_predictions.preload_feature_group_caches")
     @patch("odds_lambda.jobs.score_predictions.collect_event_data")
     @patch("odds_lambda.jobs.score_predictions.load_model")
     @patch("odds_lambda.jobs.score_predictions.get_cached_version")
@@ -266,7 +266,7 @@ class TestScoreEvents:
         event = _make_event()
         snapshot = _make_snapshot(event)
         sentinel_standings: dict[str, list[Event]] = {"2025-26": []}
-        mock_preload.return_value = (sentinel_standings, None, None, None)
+        mock_preload.return_value = FeatureGroupCaches(standings=sentinel_standings)
 
         from odds_analytics.feature_groups import EventDataBundle
 
@@ -407,210 +407,3 @@ class TestScoreEvents:
 
         assert stats["events_checked"] == 0
         assert stats["snapshots_scored"] == 0
-
-
-def _config_with_groups(*groups: str) -> FeatureConfig:
-    return FeatureConfig(
-        adapter="xgboost",
-        sharp_bookmakers=["bet365"],
-        retail_bookmakers=["betway", "betfred", "bwin"],
-        markets=["h2h"],
-        outcome="home",
-        feature_groups=tuple(groups),
-        target_type="devigged_bookmaker",
-        target_bookmaker="bet365",
-        sport_key="soccer_epl",
-    )
-
-
-class TestPreloadCaches:
-    """Direct unit tests for _preload_caches gating."""
-
-    @pytest.mark.asyncio
-    @patch("odds_lambda.jobs.score_predictions._load_lineup_cache", new_callable=AsyncMock)
-    @patch("odds_lambda.jobs.score_predictions._load_fixtures_df", new_callable=AsyncMock)
-    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
-    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
-    async def test_tabular_only_loads_no_caches(
-        self,
-        mock_standings: AsyncMock,
-        mock_match_stats: AsyncMock,
-        mock_fixtures: AsyncMock,
-        mock_lineup: AsyncMock,
-    ) -> None:
-        config = _config_with_groups("tabular")
-        session = AsyncMock()
-
-        result = await _preload_caches(session, config, "soccer_epl")
-
-        assert result == (None, None, None, None)
-        mock_standings.assert_not_called()
-        mock_match_stats.assert_not_called()
-        mock_fixtures.assert_not_called()
-        mock_lineup.assert_not_called()
-
-    @pytest.mark.asyncio
-    @patch("odds_lambda.jobs.score_predictions._load_lineup_cache", new_callable=AsyncMock)
-    @patch("odds_lambda.jobs.score_predictions._load_fixtures_df", new_callable=AsyncMock)
-    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
-    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
-    async def test_standings_only_loads_standings_cache(
-        self,
-        mock_standings: AsyncMock,
-        mock_match_stats: AsyncMock,
-        mock_fixtures: AsyncMock,
-        mock_lineup: AsyncMock,
-    ) -> None:
-        sentinel: dict[str, list[Event]] = {"2025-26": []}
-        mock_standings.return_value = sentinel
-        config = _config_with_groups("tabular", "standings")
-        session = AsyncMock()
-
-        standings_cache, match_stats_cache, fixtures_df, lineup_cache = await _preload_caches(
-            session, config, "soccer_epl"
-        )
-
-        assert standings_cache is sentinel
-        assert match_stats_cache is None
-        assert fixtures_df is None
-        assert lineup_cache is None
-        mock_standings.assert_awaited_once_with(session, "soccer_epl")
-        mock_match_stats.assert_not_called()
-        mock_fixtures.assert_not_called()
-        mock_lineup.assert_not_called()
-
-    @pytest.mark.asyncio
-    @patch("odds_lambda.jobs.score_predictions._load_lineup_cache", new_callable=AsyncMock)
-    @patch("odds_lambda.jobs.score_predictions._load_fixtures_df", new_callable=AsyncMock)
-    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
-    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
-    async def test_match_stats_only_loads_match_stats_cache(
-        self,
-        mock_standings: AsyncMock,
-        mock_match_stats: AsyncMock,
-        mock_fixtures: AsyncMock,
-        mock_lineup: AsyncMock,
-    ) -> None:
-        sentinel = MagicMock(name="match_stats_cache")
-        mock_match_stats.return_value = sentinel
-        config = _config_with_groups("tabular", "match_stats")
-        session = AsyncMock()
-
-        standings_cache, match_stats_cache, fixtures_df, lineup_cache = await _preload_caches(
-            session, config, "soccer_epl"
-        )
-
-        assert standings_cache is None
-        assert match_stats_cache is sentinel
-        assert fixtures_df is None
-        assert lineup_cache is None
-        mock_standings.assert_not_called()
-        mock_match_stats.assert_awaited_once_with(session, "soccer_epl")
-        mock_fixtures.assert_not_called()
-        mock_lineup.assert_not_called()
-
-    @pytest.mark.asyncio
-    @patch("odds_lambda.jobs.score_predictions._load_lineup_cache", new_callable=AsyncMock)
-    @patch("odds_lambda.jobs.score_predictions._load_fixtures_df", new_callable=AsyncMock)
-    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
-    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
-    async def test_epl_schedule_loads_fixtures_and_standings(
-        self,
-        mock_standings: AsyncMock,
-        mock_match_stats: AsyncMock,
-        mock_fixtures: AsyncMock,
-        mock_lineup: AsyncMock,
-    ) -> None:
-        """epl_schedule pulls in standings_cache too (shared by season-rest features)."""
-        standings_sentinel: dict[str, list[Event]] = {"2025-26": []}
-        fixtures_sentinel = MagicMock(name="fixtures_df")
-        mock_standings.return_value = standings_sentinel
-        mock_fixtures.return_value = fixtures_sentinel
-        config = _config_with_groups("tabular", "epl_schedule")
-        session = AsyncMock()
-
-        standings_cache, match_stats_cache, fixtures_df, lineup_cache = await _preload_caches(
-            session, config, "soccer_epl"
-        )
-
-        assert standings_cache is standings_sentinel
-        assert match_stats_cache is None
-        assert fixtures_df is fixtures_sentinel
-        assert lineup_cache is None
-        mock_standings.assert_awaited_once_with(session, "soccer_epl")
-        mock_fixtures.assert_awaited_once_with(session)
-        mock_match_stats.assert_not_called()
-        mock_lineup.assert_not_called()
-
-    @pytest.mark.asyncio
-    @patch("odds_lambda.jobs.score_predictions._load_lineup_cache", new_callable=AsyncMock)
-    @patch("odds_lambda.jobs.score_predictions._load_fixtures_df", new_callable=AsyncMock)
-    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
-    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
-    async def test_epl_lineup_loads_lineup_cache(
-        self,
-        mock_standings: AsyncMock,
-        mock_match_stats: AsyncMock,
-        mock_fixtures: AsyncMock,
-        mock_lineup: AsyncMock,
-    ) -> None:
-        sentinel = MagicMock(name="lineup_cache")
-        mock_lineup.return_value = sentinel
-        config = _config_with_groups("tabular", "epl_lineup")
-        session = AsyncMock()
-
-        standings_cache, match_stats_cache, fixtures_df, lineup_cache = await _preload_caches(
-            session, config, "soccer_epl"
-        )
-
-        assert standings_cache is None
-        assert match_stats_cache is None
-        assert fixtures_df is None
-        assert lineup_cache is sentinel
-        mock_standings.assert_not_called()
-        mock_match_stats.assert_not_called()
-        mock_fixtures.assert_not_called()
-        mock_lineup.assert_awaited_once_with(session)
-
-    @pytest.mark.asyncio
-    @patch("odds_lambda.jobs.score_predictions._load_lineup_cache", new_callable=AsyncMock)
-    @patch("odds_lambda.jobs.score_predictions._load_fixtures_df", new_callable=AsyncMock)
-    @patch("odds_analytics.match_stats_features.load_match_stats_cache", new_callable=AsyncMock)
-    @patch("odds_analytics.standings_features.load_season_events_cache", new_callable=AsyncMock)
-    async def test_all_groups_load_all_caches(
-        self,
-        mock_standings: AsyncMock,
-        mock_match_stats: AsyncMock,
-        mock_fixtures: AsyncMock,
-        mock_lineup: AsyncMock,
-    ) -> None:
-        standings_sentinel: dict[str, list[Event]] = {"2025-26": []}
-        match_stats_sentinel = MagicMock(name="match_stats_cache")
-        fixtures_sentinel = MagicMock(name="fixtures_df")
-        lineup_sentinel = MagicMock(name="lineup_cache")
-        mock_standings.return_value = standings_sentinel
-        mock_match_stats.return_value = match_stats_sentinel
-        mock_fixtures.return_value = fixtures_sentinel
-        mock_lineup.return_value = lineup_sentinel
-
-        config = _config_with_groups(
-            "tabular",
-            "standings",
-            "match_stats",
-            "epl_schedule",
-            "epl_lineup",
-        )
-        session = AsyncMock()
-
-        standings_cache, match_stats_cache, fixtures_df, lineup_cache = await _preload_caches(
-            session, config, "soccer_epl"
-        )
-
-        assert standings_cache is standings_sentinel
-        assert match_stats_cache is match_stats_sentinel
-        assert fixtures_df is fixtures_sentinel
-        assert lineup_cache is lineup_sentinel
-        mock_standings.assert_awaited_once_with(session, "soccer_epl")
-        mock_match_stats.assert_awaited_once_with(session, "soccer_epl")
-        mock_fixtures.assert_awaited_once_with(session)
-        mock_lineup.assert_awaited_once_with(session)

--- a/tests/unit/test_score_predictions.py
+++ b/tests/unit/test_score_predictions.py
@@ -5,12 +5,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
 import pytest
+from odds_analytics.feature_groups import XGBoostAdapter, collect_event_data
 from odds_analytics.training.config import FeatureConfig
 from odds_core.models import Event, EventStatus, OddsSnapshot
-from odds_lambda.jobs.score_predictions import (
-    _extract_features,
-    score_events,
-)
+from odds_lambda.jobs.score_predictions import score_events
 
 _TEST_FEATURE_CONFIG = FeatureConfig(
     adapter="xgboost",
@@ -24,17 +22,21 @@ _TEST_FEATURE_CONFIG = FeatureConfig(
     sport_key="soccer_epl",
 )
 
-_EXPECTED_FEATURE_NAMES = [
-    f"tab_{n}"
-    for n in [
-        "consensus_prob",
-        "sharp_prob",
-        "retail_sharp_diff",
-        "num_bookmakers",
-        "is_weekend",
-        "day_of_week",
-    ]
-] + ["hours_until_event"]
+_EXPECTED_FEATURE_NAMES = XGBoostAdapter().feature_names(_TEST_FEATURE_CONFIG)
+
+_TABULAR_STANDINGS_CONFIG = FeatureConfig(
+    adapter="xgboost",
+    sharp_bookmakers=["bet365"],
+    retail_bookmakers=["betway", "betfred", "bwin"],
+    markets=["h2h"],
+    outcome="home",
+    feature_groups=("tabular", "standings"),
+    target_type="devigged_bookmaker",
+    target_bookmaker="bet365",
+    sport_key="soccer_epl",
+)
+
+_TABULAR_STANDINGS_FEATURE_NAMES = XGBoostAdapter().feature_names(_TABULAR_STANDINGS_CONFIG)
 
 
 def _make_event(
@@ -104,20 +106,61 @@ def _make_snapshot(
     )
 
 
-class TestExtractFeatures:
-    def test_extracts_features_successfully(self) -> None:
+class TestAdapterTabular:
+    @pytest.mark.asyncio
+    async def test_tabular_only_vector_matches_legacy_extraction(self) -> None:
+        """Adapter output for tabular-only must equal the prior hand-rolled vector.
+
+        Replicates the pre-#354 extraction (TabularFeatureExtractor +
+        hours_until_event concatenation, modulo np.nan_to_num) and asserts
+        byte equality with the new XGBoostAdapter path.
+        """
+        from odds_analytics.backtesting import BacktestEvent
+        from odds_analytics.feature_extraction import TabularFeatureExtractor
+        from odds_analytics.feature_groups import resolve_outcome_name
+        from odds_core.snapshot_utils import extract_odds_from_snapshot
+
         event = _make_event()
         snapshot = _make_snapshot(event)
 
-        result = _extract_features(event, snapshot, _TEST_FEATURE_CONFIG, _EXPECTED_FEATURE_NAMES)
+        market = _TEST_FEATURE_CONFIG.primary_market
+        outcome_name = resolve_outcome_name(_TEST_FEATURE_CONFIG, event)
+        odds = extract_odds_from_snapshot(snapshot, event.id, market=market)
+        backtest_event = BacktestEvent(
+            id=event.id,
+            commence_time=event.commence_time,
+            home_team=event.home_team,
+            away_team=event.away_team,
+            home_score=0,
+            away_score=0,
+            status=event.status,
+        )
+        extractor = TabularFeatureExtractor.from_config(_TEST_FEATURE_CONFIG)
+        tab_array = extractor.extract_features(
+            event=backtest_event,
+            odds_data=odds,
+            outcome=outcome_name,
+            market=market,
+        ).to_array()
+        hours_until = (event.commence_time - snapshot.snapshot_time).total_seconds() / 3600
+        legacy_vector = np.concatenate([tab_array, np.array([hours_until])]).astype(np.float32)
 
-        assert result is not None
-        assert isinstance(result, np.ndarray)
-        assert result.shape == (len(_EXPECTED_FEATURE_NAMES),)
-        assert result.dtype == np.float32
-        assert not np.any(np.isnan(result))
+        session = AsyncMock()
+        snapshots_result = MagicMock()
+        snapshots_result.scalars.return_value.all.return_value = [snapshot]
+        session.execute = AsyncMock(return_value=snapshots_result)
 
-    def test_returns_none_for_empty_snapshot(self) -> None:
+        bundle = await collect_event_data(event, session, _TEST_FEATURE_CONFIG)
+        adapter = XGBoostAdapter()
+        output = adapter.transform(bundle, snapshot, _TEST_FEATURE_CONFIG)
+
+        assert output is not None
+        adapter_vector = output.features.astype(np.float32)
+        assert adapter_vector.shape == legacy_vector.shape
+        assert np.array_equal(adapter_vector, legacy_vector, equal_nan=True)
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_empty_snapshot(self) -> None:
         event = _make_event()
         snapshot = OddsSnapshot(
             id=1,
@@ -127,32 +170,21 @@ class TestExtractFeatures:
             bookmaker_count=0,
         )
 
-        result = _extract_features(event, snapshot, _TEST_FEATURE_CONFIG, [])
+        session = AsyncMock()
+        snapshots_result = MagicMock()
+        snapshots_result.scalars.return_value.all.return_value = [snapshot]
+        session.execute = AsyncMock(return_value=snapshots_result)
 
-        assert result is None
+        bundle = await collect_event_data(event, session, _TEST_FEATURE_CONFIG)
+        adapter = XGBoostAdapter()
+        output = adapter.transform(bundle, snapshot, _TEST_FEATURE_CONFIG)
 
-    def test_returns_none_on_feature_name_mismatch(self) -> None:
-        event = _make_event()
-        snapshot = _make_snapshot(event)
-
-        wrong_names = ["wrong_feature_1", "wrong_feature_2"]
-        result = _extract_features(event, snapshot, _TEST_FEATURE_CONFIG, wrong_names)
-
-        assert result is None
-
-    def test_hours_until_is_positive_for_future_event(self) -> None:
-        event = _make_event(hours_from_now=48.0)
-        snapshot = _make_snapshot(event, hours_before=24.0)
-
-        result = _extract_features(event, snapshot, _TEST_FEATURE_CONFIG, _EXPECTED_FEATURE_NAMES)
-
-        assert result is not None
-        hours_until = result[-1]
-        assert hours_until > 0
+        assert output is None
 
 
 class TestScoreEvents:
     @pytest.mark.asyncio
+    @patch("odds_lambda.jobs.score_predictions.collect_event_data")
     @patch("odds_lambda.jobs.score_predictions.load_model")
     @patch("odds_lambda.jobs.score_predictions.get_cached_version")
     @patch("odds_lambda.jobs.score_predictions.async_session_maker")
@@ -161,6 +193,7 @@ class TestScoreEvents:
         mock_session_maker: MagicMock,
         mock_version: MagicMock,
         mock_load: MagicMock,
+        mock_collect: MagicMock,
     ) -> None:
         mock_model = MagicMock()
         mock_model.predict.return_value = np.array([0.015])
@@ -175,10 +208,16 @@ class TestScoreEvents:
         event = _make_event()
         snapshot = _make_snapshot(event)
 
-        mock_session = AsyncMock()
+        from odds_analytics.feature_groups import EventDataBundle
 
-        # First execute returns events, second returns unscored snapshots,
-        # third is the INSERT ON CONFLICT
+        mock_collect.return_value = EventDataBundle(
+            event=event,
+            snapshots=[snapshot],
+            closing_snapshot=snapshot,
+            pm_context=None,
+        )
+
+        mock_session = AsyncMock()
         events_result = MagicMock()
         events_result.scalars.return_value.all.return_value = [event]
         snapshots_result = MagicMock()
@@ -196,10 +235,103 @@ class TestScoreEvents:
         assert stats["events_checked"] == 1
         assert stats["snapshots_scored"] == 1
         assert stats["errors"] == 0
-
-        # Verify the INSERT statement was executed (3rd call)
         assert mock_session.execute.call_count == 3
         mock_model.predict.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("odds_lambda.jobs.score_predictions._preload_caches")
+    @patch("odds_lambda.jobs.score_predictions.collect_event_data")
+    @patch("odds_lambda.jobs.score_predictions.load_model")
+    @patch("odds_lambda.jobs.score_predictions.get_cached_version")
+    @patch("odds_lambda.jobs.score_predictions.async_session_maker")
+    async def test_scores_multi_group_path(
+        self,
+        mock_session_maker: MagicMock,
+        mock_version: MagicMock,
+        mock_load: MagicMock,
+        mock_collect: MagicMock,
+        mock_preload: AsyncMock,
+    ) -> None:
+        """Tabular + standings model scores end-to-end with caches provided."""
+        mock_model = MagicMock()
+        mock_model.predict.return_value = np.array([0.02])
+        mock_load.return_value = {
+            "model": mock_model,
+            "feature_names": _TABULAR_STANDINGS_FEATURE_NAMES,
+            "params": {},
+            "feature_config": _TABULAR_STANDINGS_CONFIG,
+        }
+        mock_version.return_value = '"v2"'
+
+        event = _make_event()
+        snapshot = _make_snapshot(event)
+        sentinel_standings: dict[str, list[Event]] = {"2025-26": []}
+        mock_preload.return_value = (sentinel_standings, None, None, None)
+
+        from odds_analytics.feature_groups import EventDataBundle
+
+        mock_collect.return_value = EventDataBundle(
+            event=event,
+            snapshots=[snapshot],
+            closing_snapshot=snapshot,
+            pm_context=None,
+        )
+
+        mock_session = AsyncMock()
+        events_result = MagicMock()
+        events_result.scalars.return_value.all.return_value = [event]
+        snapshots_result = MagicMock()
+        snapshots_result.scalars.return_value.all.return_value = [snapshot]
+        insert_result = MagicMock()
+        insert_result.rowcount = 1
+        mock_session.execute = AsyncMock(
+            side_effect=[events_result, snapshots_result, insert_result]
+        )
+        mock_session_maker.return_value.__aenter__.return_value = mock_session
+
+        stats = await score_events(model_name="epl-clv-multi", bucket="test-bucket")
+
+        assert stats["events_checked"] == 1
+        assert stats["snapshots_scored"] == 1
+        assert stats["errors"] == 0
+
+        mock_preload.assert_awaited_once()
+        collect_kwargs = mock_collect.await_args.kwargs
+        assert collect_kwargs["standings_cache"] is sentinel_standings
+        assert collect_kwargs["match_stats_cache"] is None
+        assert collect_kwargs["fixtures_df"] is None
+        assert collect_kwargs["lineup_cache"] is None
+
+        predict_input = mock_model.predict.call_args.args[0]
+        assert predict_input.shape == (1, len(_TABULAR_STANDINGS_FEATURE_NAMES))
+
+    @pytest.mark.asyncio
+    @patch("odds_lambda.jobs.score_predictions.async_session_maker")
+    @patch("odds_lambda.jobs.score_predictions.get_cached_version")
+    @patch("odds_lambda.jobs.score_predictions.load_model")
+    async def test_skips_on_feature_name_mismatch(
+        self,
+        mock_load: MagicMock,
+        mock_version: MagicMock,
+        mock_session_maker: MagicMock,
+    ) -> None:
+        """When the model's bundled feature names diverge from the adapter's,
+        scoring logs and returns without invoking the model or DB."""
+        mock_model = MagicMock()
+        mock_load.return_value = {
+            "model": mock_model,
+            "feature_names": ["wrong_feature_1", "wrong_feature_2"],
+            "params": {},
+            "feature_config": _TEST_FEATURE_CONFIG,
+        }
+        mock_version.return_value = '"etag123"'
+
+        stats = await score_events(model_name="bad-model", bucket="test-bucket")
+
+        assert stats["events_checked"] == 0
+        assert stats["snapshots_scored"] == 0
+        mock_model.predict.assert_not_called()
+        mock_session_maker.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("odds_lambda.jobs.score_predictions.load_model")
@@ -223,18 +355,16 @@ class TestScoreEvents:
     ) -> None:
         mock_load.return_value = {
             "model": MagicMock(),
-            "feature_names": [],
+            "feature_names": _EXPECTED_FEATURE_NAMES,
             "params": {},
             "feature_config": _TEST_FEATURE_CONFIG,
         }
         mock_version.return_value = '"v1"'
 
         mock_session = AsyncMock()
-
         events_result = MagicMock()
         events_result.scalars.return_value.all.return_value = []
         mock_session.execute = AsyncMock(return_value=events_result)
-
         mock_session_maker.return_value.__aenter__.return_value = mock_session
 
         stats = await score_events(model_name="test", bucket="test-bucket")


### PR DESCRIPTION
## Summary
- Replace hand-rolled `_extract_features` in `score_predictions.py` with `collect_event_data` + `XGBoostAdapter().transform(...)`, mirroring training. Unblocks shipping `standings`, `match_stats`, `epl_schedule` models with zero risk to the deployed tabular-only `epl-clv-home`.
- Conditionally preload `standings_cache`, `match_stats_cache`, `fixtures_df`, `lineup_cache` once per `score_events()` invocation, gated on `config.feature_groups` — mirrors training preload pattern at `feature_groups.py:1117-1141`.
- Move the `feature_name_mismatch` guard from per-snapshot to once-per-invocation (adapter feature names depend only on `config`, not snapshots — preserves log-and-skip semantics, removes per-snapshot log noise).
- Drop `np.nan_to_num(..., nan=0.0)` to match training (XGBoost handles NaN natively after #231).
- Loosen `BacktestEvent.home_score` / `away_score` to `int | None` so the adapter can run on `SCHEDULED` events at inference time. All existing consumers in `backtesting/services.py` are reached only after `BacktestEvent.from_db_event` filters out scoreless events.

## Test plan
- [x] Unit tests: tabular-only adapter output is byte-identical to the legacy hand-rolled vector (modulo dropped `nan_to_num`).
- [x] Unit tests: multi-group path (tabular + standings) succeeds end-to-end.
- [x] Unit tests: `feature_name_mismatch` path returns empty stats and skips cleanly.
- [x] Unit tests: `_preload_caches` gating verified across 6 cases (tabular only, standings, match_stats, epl_schedule, epl_lineup, all groups).
- [x] CI green (1878 unit tests + integration tests pass).
- [x] **Live smoke test against dev DB**: ran `score_events` with `feature_groups=("tabular", "standings")` against a stub model (XGBoostAdapter feature_names asserted as 18: 6 tabular + 11 standings + 1 hours_until_event). Result: 19 upcoming EPL events checked, 1134 snapshots scored, 905 skipped (missing odds — expected), 0 errors. Standings cache loaded (11 seasons, 4103 events). Prediction rows written and cleaned up afterwards.

## Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)