### PR TITLE
Fix tabular_standings production config to use expanding window

### DIFF
--- a/experiments/configs/xgboost_epl_production_tabular_standings.yaml
+++ b/experiments/configs/xgboost_epl_production_tabular_standings.yaml
@@ -30,9 +30,9 @@ training:
     cv_method: walk_forward
     n_folds: 5
     kfold_shuffle: false
-    window_type: sliding
-    min_train_events: 380
-    max_train_events: 380
+    window_type: expanding
+    min_train_events: 700
+    max_train_events: null
     val_step_events: 50
   model:
     n_estimators: 200


### PR DESCRIPTION
## Summary
- `experiments/configs/xgboost_epl_production_tabular_standings.yaml` was using `window_type: sliding, min_train_events: 380` while every other `xgboost_epl_production_*.yaml` uses `window_type: expanding, min_train_events: 700`.
- The config name implies feature set only (`tabular + standings`); the window should match the production-family default (expanding:50, val_step=50).

## Why this matters
Discovered while running per-feature-group ablations on top of #359. Copying this config as a template for new ablation experiments silently inherited the sliding-380 window. Under sliding-380:50 + the standard Optuna search space + 100 trials, the tuner converges on hyperparams that produce a constant predictor (verified: 50 val examples, 1 unique prediction, std=0.0). That made the ablation report a misleading R²=−0.0172 for "tabular + standings" when the real expanding:50 result is R²=+0.0367 (essentially neutral, consistent with prior expanding findings).

## Note
Post-fix, this config is functionally identical to `xgboost_epl_production_expanding_50.yaml`. Leaving both for now — one can be retired once we settle on a consistent naming convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)