### PR TITLE
Add direct Betfair Exchange ingestion for EPL and MLB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,8 @@ SCHEDULER_LOOKAHEAD_DAYS=7
 # the fixed-schedule jobs (daily-digest, fetch-espn-fixtures) that now run
 # on the local scheduler instead of EventBridge.
 # Default: ["agent-run", "fetch-oddsportal", "fetch-oddsportal-results",
-#           "daily-digest", "fetch-espn-fixtures"]
-# SCHEDULER_BOOTSTRAP_JOBS=fetch-oddsportal,fetch-oddsportal-results,daily-digest,fetch-espn-fixtures,agent-run
+#           "daily-digest", "fetch-espn-fixtures", "fetch-betfair-exchange"]
+# SCHEDULER_BOOTSTRAP_JOBS=fetch-oddsportal,fetch-oddsportal-results,daily-digest,fetch-espn-fixtures,agent-run,fetch-betfair-exchange
 
 # =============================================================================
 # AWS CONFIGURATION (only needed if SCHEDULER_BACKEND=aws)
@@ -145,6 +145,33 @@ DATA_QUALITY_ERROR_THRESHOLD=10
 # Alert rate limiting
 # Minimum minutes between identical alerts (default: 30)
 ALERT_RATE_LIMIT_MINUTES=30
+
+# =============================================================================
+# BETFAIR EXCHANGE API (read-only sharp benchmark)
+# =============================================================================
+# Direct ingestion of Match Odds via the free delayed application key.
+# Replaces the indirect-via-OddsPortal BFE path. Sport scope: EPL + MLB.
+#
+# Cert-based non-interactive login is the production path (bypasses 2FA).
+# Leaving cert paths unset falls back to interactive login (dev-only;
+# prompts 2FA if enabled on the account).
+
+# Toggle ingestion. Defaults to false; set to true once credentials are in place.
+BETFAIR_ENABLED=false
+
+# Account credentials and delayed app key
+BETFAIR_USERNAME=
+BETFAIR_PASSWORD=
+BETFAIR_APP_KEY=
+
+# Optional: cert paths for non-interactive login. Generate via XCA / openssl
+# and upload the .crt to your Betfair account at developer.betfair.com.
+# Cert lifetime is 365 days; rotate annually.
+BETFAIR_CERT_FILE=
+BETFAIR_CERT_KEY=
+
+# Look-ahead window for event discovery (hours)
+BETFAIR_LOOKAHEAD_HOURS=168
 
 # =============================================================================
 # LOGGING

--- a/.env.example
+++ b/.env.example
@@ -173,6 +173,10 @@ BETFAIR_CERT_KEY=
 # Look-ahead window for event discovery (hours)
 BETFAIR_LOOKAHEAD_HOURS=168
 
+# Optional: comma-separated sport scope override
+# (default: every sport supported by the BFE adapter; currently EPL + MLB)
+# BETFAIR_SPORTS=soccer_epl,baseball_mlb
+
 # =============================================================================
 # LOGGING
 # =============================================================================

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ ENV/
 .env.local
 .env.prod
 
+# Betfair Exchange API certificates (never commit private keys)
+.betfair/
+secrets/
+
 # IDE
 .vscode/
 .idea/

--- a/packages/odds-core/odds_core/config.py
+++ b/packages/odds-core/odds_core/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from functools import lru_cache
 from pathlib import Path
 
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from odds_core.sports import SportKey
@@ -266,16 +266,35 @@ class BetfairConfig(BaseSettings):
     cert_file: str | None = Field(default=None, description="Path to client SSL cert (.crt)")
     cert_key: str | None = Field(default=None, description="Path to client SSL key (.key)")
 
-    # Sport scoping — only fetch sports listed here even if other settings reference them
-    sports: list[SportKey] = Field(
-        default=["soccer_epl", "baseball_mlb"],
-        description="Sports to fetch via Betfair Exchange API",
+    # Sport scoping override. ``None`` means "all sports the BFE adapter supports"
+    # (resolved at job-execution time from ``odds_lambda.betfair.SPORT_CONFIG``).
+    sports: list[SportKey] | None = Field(
+        default=None,
+        description="Override sport scope; defaults to all BFE-supported sports",
     )
 
     # Look-ahead window for event discovery (covers an EPL gameweek + MLB week)
     lookahead_hours: int = Field(
         default=168, description="Hours ahead to look when discovering events"
     )
+
+    @model_validator(mode="after")
+    def _require_creds_when_enabled(self) -> BetfairConfig:
+        if self.enabled:
+            missing = [
+                name
+                for name, value in (
+                    ("BETFAIR_USERNAME", self.username),
+                    ("BETFAIR_PASSWORD", self.password),
+                    ("BETFAIR_APP_KEY", self.app_key),
+                )
+                if not value
+            ]
+            if missing:
+                raise ValueError(
+                    f"BETFAIR_ENABLED=true but credentials missing: {', '.join(missing)}"
+                )
+        return self
 
 
 class LoggingConfig(BaseSettings):

--- a/packages/odds-core/odds_core/config.py
+++ b/packages/odds-core/odds_core/config.py
@@ -92,6 +92,7 @@ class SchedulerConfig(BaseSettings):
             "fetch-oddsportal-results",
             "daily-digest",
             "fetch-espn-fixtures",
+            "fetch-betfair-exchange",
         ],
         description="Jobs to bootstrap when starting the local scheduler",
     )
@@ -242,6 +243,41 @@ class PolymarketConfig(BaseSettings):
     )
 
 
+class BetfairConfig(BaseSettings):
+    """Betfair Exchange API configuration.
+
+    Read-only ingestion via the delayed application key. The free delayed key
+    returns prices with a 1-180s variable lag — sufficient as a sharp benchmark
+    for pre-match decisions made hours before kickoff.
+
+    Authentication: cert-based non-interactive login is the production path.
+    For dev/local probes, leaving cert paths unset falls back to interactive
+    login (which prompts 2FA if enabled — not viable unattended).
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="BETFAIR_", env_file=".env", env_file_encoding="utf-8", extra="ignore"
+    )
+
+    enabled: bool = Field(default=False, description="Enable Betfair Exchange ingestion")
+    username: str | None = Field(default=None, description="Betfair account username")
+    password: str | None = Field(default=None, description="Betfair account password")
+    app_key: str | None = Field(default=None, description="Betfair application key (delayed)")
+    cert_file: str | None = Field(default=None, description="Path to client SSL cert (.crt)")
+    cert_key: str | None = Field(default=None, description="Path to client SSL key (.key)")
+
+    # Sport scoping — only fetch sports listed here even if other settings reference them
+    sports: list[SportKey] = Field(
+        default=["soccer_epl", "baseball_mlb"],
+        description="Sports to fetch via Betfair Exchange API",
+    )
+
+    # Look-ahead window for event discovery (covers an EPL gameweek + MLB week)
+    lookahead_hours: int = Field(
+        default=168, description="Hours ahead to look when discovering events"
+    )
+
+
 class LoggingConfig(BaseSettings):
     """Logging configuration."""
 
@@ -288,6 +324,7 @@ class Settings(BaseSettings):
     alerts: AlertConfig = Field(default_factory=AlertConfig)
     logging: LoggingConfig = Field(default_factory=LoggingConfig)
     polymarket: PolymarketConfig = Field(default_factory=PolymarketConfig)
+    betfair: BetfairConfig = Field(default_factory=BetfairConfig)
 
 
 @lru_cache

--- a/packages/odds-core/odds_core/team.py
+++ b/packages/odds-core/odds_core/team.py
@@ -13,10 +13,22 @@ from __future__ import annotations
 #   Leeds, Leicester, Liverpool, Luton, Manchester City, Manchester Utd,
 #   Middlesbrough, Newcastle, Norwich, Nottingham, Sheffield Utd, Southampton,
 #   Stoke, Sunderland, Swansea, Tottenham, Watford, West Brom, West Ham, Wolves
+#
+# Pipeline canonical MLB names (from The Odds API / events table):
+#   Arizona Diamondbacks, Athletics, Atlanta Braves, Baltimore Orioles,
+#   Boston Red Sox, Chicago Cubs, Chicago White Sox, Cincinnati Reds,
+#   Cleveland Guardians, Colorado Rockies, Detroit Tigers, Houston Astros,
+#   Kansas City Royals, Los Angeles Angels, Los Angeles Dodgers, Miami Marlins,
+#   Milwaukee Brewers, Minnesota Twins, New York Mets, New York Yankees,
+#   Philadelphia Phillies, Pittsburgh Pirates, San Diego Padres,
+#   San Francisco Giants, Seattle Mariners, St.Louis Cardinals, Tampa Bay Rays,
+#   Texas Rangers, Toronto Blue Jays, Washington Nationals.
 
 # Alias -> canonical. Keys are lowercased for case-insensitive lookup.
+# Cross-sport aliases share one map; lowercased keys do not collide between
+# the EPL and MLB canonical sets above.
 _TEAM_ALIASES: dict[str, str] = {
-    # OddsPortal / football-data.co.uk / ESPN / FBref variants
+    # ---- EPL: OddsPortal / football-data.co.uk / ESPN / FBref / Betfair variants
     "afc bournemouth": "Bournemouth",
     "brighton & hove albion": "Brighton",
     "brighton and hove albion": "Brighton",
@@ -35,7 +47,9 @@ _TEAM_ALIASES: dict[str, str] = {
     "norwich city": "Norwich",
     "nott'm forest": "Nottingham",
     "nott'ham forest": "Nottingham",
+    "nottm forest": "Nottingham",
     "nottingham forest": "Nottingham",
+    "sheff utd": "Sheffield Utd",
     "sheffield united": "Sheffield Utd",
     "stoke city": "Stoke",
     "swansea city": "Swansea",
@@ -44,6 +58,15 @@ _TEAM_ALIASES: dict[str, str] = {
     "west bromwich albion": "West Brom",
     "west ham united": "West Ham",
     "wolverhampton wanderers": "Wolves",
+    # ---- MLB: Betfair short forms (and a few common variants)
+    "arizona d'backs": "Arizona Diamondbacks",
+    "la angels": "Los Angeles Angels",
+    "la dodgers": "Los Angeles Dodgers",
+    "ny mets": "New York Mets",
+    "ny yankees": "New York Yankees",
+    "oakland athletics": "Athletics",
+    "st louis cardinals": "St.Louis Cardinals",
+    "st. louis cardinals": "St.Louis Cardinals",
 }
 
 

--- a/packages/odds-lambda/odds_lambda/betfair/__init__.py
+++ b/packages/odds-lambda/odds_lambda/betfair/__init__.py
@@ -1,0 +1,25 @@
+"""Betfair Exchange API integration.
+
+Direct ingestion of Match Odds via the delayed application key, written into
+``odds_snapshots.raw_data`` with ``key="betfair_exchange"`` so the existing
+agent / analytics / sharp-fallback consumers pick it up unchanged.
+"""
+
+from odds_lambda.betfair.adapter import betfair_book_to_bookmaker_entry, resolve_teams
+from odds_lambda.betfair.client import BetfairBook, BetfairEvent, BetfairExchangeClient
+from odds_lambda.betfair.constants import (
+    EPL_COMPETITION_ID,
+    SPORT_CONFIG,
+    SportBetfairConfig,
+)
+
+__all__ = [
+    "BetfairBook",
+    "BetfairEvent",
+    "BetfairExchangeClient",
+    "EPL_COMPETITION_ID",
+    "SPORT_CONFIG",
+    "SportBetfairConfig",
+    "betfair_book_to_bookmaker_entry",
+    "resolve_teams",
+]

--- a/packages/odds-lambda/odds_lambda/betfair/adapter.py
+++ b/packages/odds-lambda/odds_lambda/betfair/adapter.py
@@ -39,14 +39,16 @@ from odds_core.odds_math import decimal_to_american
 from odds_core.team import normalize_team_name
 
 from odds_lambda.betfair.client import BetfairBook, BetfairRunner
-from odds_lambda.betfair.constants import BETFAIR_TEAM_ALIASES, SportBetfairConfig
+from odds_lambda.betfair.constants import SportBetfairConfig
 
 logger = structlog.get_logger()
 
 DRAW_RUNNER_NAMES: frozenset[str] = frozenset({"the draw", "draw"})
 
 # Strip parenthetical annotations Betfair appends to baseball runner/event
-# names (e.g. "(TBD)", "(Cole)" for starting pitchers).
+# names (e.g. "(TBD)", "(Cole)" for starting pitchers). This is a Betfair-API
+# quirk — kept here rather than in odds_core.team because trailing parens can
+# legitimately disambiguate teams in other contexts (e.g. "(W)" for women's).
 _PAREN_ANNOTATION_RE = re.compile(r"\s*\([^)]*\)\s*$")
 
 
@@ -56,12 +58,8 @@ def _strip_pitcher_annotation(name: str) -> str:
 
 
 def _normalize_runner_name(name: str) -> str:
-    """Apply Betfair-specific aliases first, then odds_core normalization."""
-    cleaned = _strip_pitcher_annotation(" ".join(name.split()))
-    aliased = BETFAIR_TEAM_ALIASES.get(cleaned.lower())
-    if aliased is not None:
-        return aliased
-    return normalize_team_name(cleaned)
+    """Strip Betfair's pitcher annotation, then delegate to canonical normalization."""
+    return normalize_team_name(_strip_pitcher_annotation(name))
 
 
 def _is_draw(runner_name: str) -> bool:
@@ -124,6 +122,13 @@ def _runner_to_outcome(
         else:
             # Fallback: use the canonical (may not equal home/away if
             # alias incomplete, but downstream sees a stable name).
+            logger.warning(
+                "betfair_runner_name_fallback",
+                runner_name=name_in,
+                normalized=canonical,
+                home_team=home_team,
+                away_team=away_team,
+            )
             outcome_name = canonical
 
     return {

--- a/packages/odds-lambda/odds_lambda/betfair/adapter.py
+++ b/packages/odds-lambda/odds_lambda/betfair/adapter.py
@@ -1,0 +1,182 @@
+"""Adapt Betfair Exchange ``BetfairBook`` into pipeline ``raw_data`` shape.
+
+The pipeline's canonical bookmaker entry is::
+
+    {
+      "key": "betfair_exchange",
+      "title": "Betfair Exchange",
+      "last_update": "2026-04-25T14:35:00+00:00",
+      "markets": [
+        {
+          "key": "1x2" | "h2h",
+          "outcomes": [{"name": <canonical team>, "price": <American int>}, ...]
+        }
+      ],
+      "betfair_meta": {  # optional, supplemental
+        "market_id": "1.123",
+        "market_status": "OPEN",
+        "inplay": false,
+        "total_matched": 385702,
+        "runners": [
+            {"name": "Liverpool",
+             "best_back": 1.64, "best_lay": 1.65,
+             "back_size": 292, "lay_size": 314,
+             "last_price_traded": 1.64}
+        ],
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from odds_core.odds_math import decimal_to_american
+from odds_core.team import normalize_team_name
+
+from odds_lambda.betfair.client import BetfairBook, BetfairRunner
+from odds_lambda.betfair.constants import BETFAIR_TEAM_ALIASES, SportBetfairConfig
+
+logger = structlog.get_logger()
+
+DRAW_RUNNER_NAMES: frozenset[str] = frozenset({"the draw", "draw"})
+
+# Strip parenthetical annotations Betfair appends to baseball runner/event
+# names (e.g. "(TBD)", "(Cole)" for starting pitchers).
+_PAREN_ANNOTATION_RE = re.compile(r"\s*\([^)]*\)\s*$")
+
+
+def _strip_pitcher_annotation(name: str) -> str:
+    """Remove trailing parenthetical (e.g. '(TBD)' or '(Cole)') from MLB names."""
+    return _PAREN_ANNOTATION_RE.sub("", name).strip()
+
+
+def _normalize_runner_name(name: str) -> str:
+    """Apply Betfair-specific aliases first, then odds_core normalization."""
+    cleaned = _strip_pitcher_annotation(" ".join(name.split()))
+    aliased = BETFAIR_TEAM_ALIASES.get(cleaned.lower())
+    if aliased is not None:
+        return aliased
+    return normalize_team_name(cleaned)
+
+
+def _is_draw(runner_name: str) -> bool:
+    return runner_name.strip().lower() in DRAW_RUNNER_NAMES
+
+
+def resolve_teams(
+    book: BetfairBook,
+    sport_cfg: SportBetfairConfig,
+) -> tuple[str, str] | None:
+    """Resolve (home_team, away_team) from the Betfair event name.
+
+    Soccer event names: ``"<Home> v <Away>"``.
+    Baseball event names: ``"<Away> @ <Home>"`` (with optional pitcher
+    annotations like ``"(TBD)"``).
+
+    Returns canonical (home, away) pair, or None if parsing fails.
+    """
+    sep = sport_cfg.name_separator
+    parts = [p.strip() for p in book.betfair_event_name.split(sep)]
+    if len(parts) != 2:
+        logger.warning(
+            "betfair_unparseable_event_name",
+            sport=sport_cfg.sport_key,
+            betfair_event_id=book.betfair_event_id,
+            name=book.betfair_event_name,
+            separator=sep,
+        )
+        return None
+
+    if sport_cfg.name_order == "home_first":
+        home_raw, away_raw = parts
+    else:
+        away_raw, home_raw = parts
+    return _normalize_runner_name(home_raw), _normalize_runner_name(away_raw)
+
+
+def _runner_to_outcome(
+    runner: BetfairRunner,
+    home_team: str,
+    away_team: str,
+    has_draw: bool,
+) -> dict[str, Any] | None:
+    """Build one outcome dict from a Betfair runner.
+
+    Skips runners with no best-back price.
+    """
+    if runner.best_back is None:
+        return None
+
+    name_in = runner.runner_name or ""
+    if has_draw and _is_draw(name_in):
+        outcome_name = "Draw"
+    else:
+        canonical = _normalize_runner_name(name_in)
+        if canonical == home_team:
+            outcome_name = home_team
+        elif canonical == away_team:
+            outcome_name = away_team
+        else:
+            # Fallback: use the canonical (may not equal home/away if
+            # alias incomplete, but downstream sees a stable name).
+            outcome_name = canonical
+
+    return {
+        "name": outcome_name,
+        "price": decimal_to_american(runner.best_back),
+    }
+
+
+def betfair_book_to_bookmaker_entry(
+    book: BetfairBook,
+    sport_cfg: SportBetfairConfig,
+    home_team: str,
+    away_team: str,
+    snapshot_time: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Convert a ``BetfairBook`` into a pipeline ``bookmakers[]`` entry.
+
+    Returns None if the book has no usable outcomes (all prices missing).
+    """
+    snapshot_time = snapshot_time or datetime.now(UTC)
+    outcomes: list[dict[str, Any]] = []
+    for r in book.runners:
+        out = _runner_to_outcome(r, home_team, away_team, sport_cfg.has_draw)
+        if out is not None:
+            outcomes.append(out)
+
+    expected_outcomes = 3 if sport_cfg.has_draw else 2
+    if len(outcomes) < expected_outcomes:
+        logger.warning(
+            "betfair_book_missing_outcomes",
+            market_id=book.market_id,
+            sport=sport_cfg.sport_key,
+            got=len(outcomes),
+            expected=expected_outcomes,
+            event_name=book.betfair_event_name,
+        )
+        return None
+
+    return {
+        "key": "betfair_exchange",
+        "title": "Betfair Exchange",
+        "last_update": snapshot_time.isoformat(),
+        "markets": [{"key": sport_cfg.market_key, "outcomes": outcomes}],
+        "betfair_meta": {
+            "market_id": book.market_id,
+            "market_status": book.market_status,
+            "inplay": book.inplay,
+            "total_matched": book.total_matched,
+            "runners": [asdict(r) for r in book.runners],
+        },
+    }
+
+
+def build_raw_data(bookmaker_entry: dict[str, Any]) -> dict[str, Any]:
+    """Wrap a single bookmaker entry into a snapshot ``raw_data`` payload."""
+    return {"bookmakers": [bookmaker_entry], "source": "betfair_api"}

--- a/packages/odds-lambda/odds_lambda/betfair/client.py
+++ b/packages/odds-lambda/odds_lambda/betfair/client.py
@@ -16,7 +16,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import betfairlightweight
 import structlog
@@ -24,9 +24,6 @@ from betfairlightweight import filters
 from betfairlightweight.exceptions import APIError, BetfairError
 
 from odds_lambda.betfair.constants import SportBetfairConfig
-
-if TYPE_CHECKING:
-    pass
 
 logger = structlog.get_logger()
 

--- a/packages/odds-lambda/odds_lambda/betfair/client.py
+++ b/packages/odds-lambda/odds_lambda/betfair/client.py
@@ -1,0 +1,345 @@
+"""Betfair Exchange API client wrapping ``betfairlightweight``.
+
+Read-only data access via the delayed application key. Provides:
+  - ``BetfairExchangeClient.connect()`` — login (cert-based or interactive)
+  - ``list_events(sport_cfg, lookahead_hours)``
+  - ``list_match_odds_books(sport_cfg, event_ids)``
+
+Returned dataclasses (``BetfairEvent``, ``BetfairBook``) are sport-agnostic
+and feed the adapter layer.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+import betfairlightweight
+import structlog
+from betfairlightweight import filters
+from betfairlightweight.exceptions import APIError, BetfairError
+
+from odds_lambda.betfair.constants import SportBetfairConfig
+
+if TYPE_CHECKING:
+    pass
+
+logger = structlog.get_logger()
+
+
+@dataclass(frozen=True)
+class BetfairEvent:
+    """Subset of Betfair Event we care about."""
+
+    betfair_event_id: str
+    name: str
+    open_date: datetime
+    market_count: int
+
+
+@dataclass(frozen=True)
+class BetfairRunner:
+    """One side of a Match Odds market."""
+
+    selection_id: int
+    runner_name: str
+    best_back: float | None
+    best_lay: float | None
+    back_size: float | None
+    lay_size: float | None
+    last_price_traded: float | None
+
+
+@dataclass(frozen=True)
+class BetfairBook:
+    """Full price snapshot for a single MATCH_ODDS market on one event."""
+
+    market_id: str
+    betfair_event_id: str
+    betfair_event_name: str
+    market_start_time: datetime
+    market_status: str
+    inplay: bool
+    total_matched: float | None
+    runners: list[BetfairRunner]
+
+
+class BetfairExchangeClient:
+    """Thin wrapper around ``betfairlightweight.APIClient``.
+
+    Login mode is determined by whether a cert path is provided:
+        - ``cert_file`` and ``cert_key`` set → non-interactive cert login
+          (production: bypasses 2FA, suitable for unattended/Lambda use).
+        - both unset → interactive login (development only; will prompt
+          for 2FA if account has it enabled).
+    """
+
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        app_key: str,
+        cert_file: str | None = None,
+        cert_key: str | None = None,
+    ) -> None:
+        self._username = username
+        self._password = password
+        self._app_key = app_key
+        self._cert_file = cert_file
+        self._cert_key = cert_key
+
+        kwargs: dict[str, Any] = {
+            "username": username,
+            "password": password,
+            "app_key": app_key,
+        }
+        if cert_file and cert_key:
+            kwargs["cert_files"] = (cert_file, cert_key)
+        self._trading = betfairlightweight.APIClient(**kwargs)
+
+    @property
+    def trading(self) -> betfairlightweight.APIClient:
+        return self._trading
+
+    def login(self) -> None:
+        if self._cert_file and self._cert_key:
+            logger.info("betfair_login_cert")
+            self._trading.login()
+        else:
+            logger.warning(
+                "betfair_login_interactive",
+                note="cert paths not configured; falling back to identitysso login",
+            )
+            self._trading.login_interactive()
+
+    def keep_alive(self) -> None:
+        self._trading.keep_alive()
+
+    def logout(self) -> None:
+        try:
+            self._trading.logout()
+        except (BetfairError, APIError) as e:  # pragma: no cover — best-effort cleanup
+            logger.warning("betfair_logout_failed", error=str(e))
+
+    # ---------------------------------------------------------------- discovery
+
+    def list_competitions(self, event_type_id: str) -> list[dict[str, Any]]:
+        """Return all competitions for a sport (id, name, market_count)."""
+        market_filter = filters.market_filter(event_type_ids=[event_type_id])
+        comps = self._trading.betting.list_competitions(filter=market_filter)
+        return [
+            {
+                "id": c.competition.id,
+                "name": c.competition.name,
+                "market_count": c.market_count,
+            }
+            for c in comps
+        ]
+
+    def resolve_competition_id(self, sport_cfg: SportBetfairConfig) -> str:
+        """Return a single competition_id for the given sport.
+
+        Strategy:
+          1. If ``sport_cfg.competition_id`` is set, return it directly.
+          2. Otherwise list competitions for the sport's event_type_id and pick
+             the first one whose name matches any of the configured hints.
+          3. Raise ValueError if nothing matches.
+        """
+        if sport_cfg.competition_id:
+            return sport_cfg.competition_id
+
+        comps = self.list_competitions(sport_cfg.event_type_id)
+        for comp in comps:
+            name_lc = (comp["name"] or "").lower()
+            for hint in sport_cfg.competition_name_hints:
+                if hint.lower() in name_lc:
+                    logger.info(
+                        "betfair_resolved_competition",
+                        sport=sport_cfg.sport_key,
+                        competition_id=comp["id"],
+                        competition_name=comp["name"],
+                    )
+                    return str(comp["id"])
+
+        # Surface the candidates to ease debugging
+        candidates = ", ".join(f"{c['id']}={c['name']}" for c in comps[:20])
+        raise ValueError(
+            f"No matching competition for {sport_cfg.sport_key} "
+            f"(hints={sport_cfg.competition_name_hints}). Candidates: {candidates}"
+        )
+
+    def list_events(
+        self,
+        sport_cfg: SportBetfairConfig,
+        lookahead_hours: int,
+    ) -> list[BetfairEvent]:
+        """List upcoming events for a sport+competition within a window."""
+        competition_id = self.resolve_competition_id(sport_cfg)
+
+        now = datetime.now(UTC)
+        time_range = filters.time_range(
+            from_=now.isoformat(),
+            to=(now + timedelta(hours=lookahead_hours)).isoformat(),
+        )
+        market_filter = filters.market_filter(
+            event_type_ids=[sport_cfg.event_type_id],
+            competition_ids=[competition_id],
+            market_start_time=time_range,
+        )
+        events = self._trading.betting.list_events(filter=market_filter)
+
+        out: list[BetfairEvent] = []
+        for ev in events:
+            open_date = ev.event.open_date
+            if open_date.tzinfo is None:
+                open_date = open_date.replace(tzinfo=UTC)
+            out.append(
+                BetfairEvent(
+                    betfair_event_id=str(ev.event.id),
+                    name=ev.event.name,
+                    open_date=open_date,
+                    market_count=ev.market_count,
+                )
+            )
+        out.sort(key=lambda e: e.open_date)
+        return out
+
+    # --------------------------------------------------------------------- books
+
+    def list_match_odds_books(
+        self,
+        sport_cfg: SportBetfairConfig,
+        events: list[BetfairEvent],
+    ) -> list[BetfairBook]:
+        """Fetch best back/lay for the configured market type for given events."""
+        if not events:
+            return []
+
+        event_ids = [e.betfair_event_id for e in events]
+        cat_filter = filters.market_filter(
+            event_type_ids=[sport_cfg.event_type_id],
+            event_ids=event_ids,
+            market_type_codes=[sport_cfg.market_type_code],
+        )
+        catalogues = self._trading.betting.list_market_catalogue(
+            filter=cat_filter,
+            market_projection=["RUNNER_DESCRIPTION", "EVENT", "MARKET_START_TIME"],
+            max_results=200,
+        )
+
+        if not catalogues:
+            return []
+
+        market_ids = [c.market_id for c in catalogues]
+        # 200-point weight budget. EX_BEST_OFFERS = 5/market at depth=3.
+        # 40 markets safe per call; chunk to be conservative.
+        BATCH = 25
+        price_proj = filters.price_projection(price_data=["EX_BEST_OFFERS"])
+        book_by_id: dict[str, Any] = {}
+        for i in range(0, len(market_ids), BATCH):
+            batch = market_ids[i : i + BATCH]
+            books = self._trading.betting.list_market_book(
+                market_ids=batch,
+                price_projection=price_proj,
+            )
+            for b in books:
+                book_by_id[b.market_id] = b
+
+        results: list[BetfairBook] = []
+        for cat in catalogues:
+            book = book_by_id.get(cat.market_id)
+            if book is None:
+                continue
+
+            runners: list[BetfairRunner] = []
+            for runner in book.runners:
+                runner_name = ""
+                for cr in cat.runners:
+                    if cr.selection_id == runner.selection_id:
+                        runner_name = cr.runner_name or ""
+                        break
+                ex = runner.ex
+                back = ex.available_to_back[0] if ex and ex.available_to_back else None
+                lay = ex.available_to_lay[0] if ex and ex.available_to_lay else None
+                runners.append(
+                    BetfairRunner(
+                        selection_id=runner.selection_id,
+                        runner_name=runner_name,
+                        best_back=float(back.price) if back else None,
+                        best_lay=float(lay.price) if lay else None,
+                        back_size=float(back.size) if back else None,
+                        lay_size=float(lay.size) if lay else None,
+                        last_price_traded=(
+                            float(runner.last_price_traded)
+                            if runner.last_price_traded is not None
+                            else None
+                        ),
+                    )
+                )
+
+            event_name = cat.event.name if cat.event else ""
+            event_id = str(cat.event.id) if cat.event else ""
+            start = cat.market_start_time
+            if start and start.tzinfo is None:
+                start = start.replace(tzinfo=UTC)
+
+            results.append(
+                BetfairBook(
+                    market_id=cat.market_id,
+                    betfair_event_id=event_id,
+                    betfair_event_name=event_name,
+                    market_start_time=start or datetime.now(UTC),
+                    market_status=str(book.status or ""),
+                    inplay=bool(book.inplay),
+                    total_matched=(
+                        float(book.total_matched) if book.total_matched is not None else None
+                    ),
+                    runners=runners,
+                )
+            )
+
+        return results
+
+
+@asynccontextmanager
+async def betfair_session(
+    *,
+    username: str | None,
+    password: str | None,
+    app_key: str | None,
+    cert_file: str | None = None,
+    cert_key: str | None = None,
+) -> AsyncIterator[BetfairExchangeClient]:
+    """Context manager: login, yield client, logout on exit."""
+    if not (username and password and app_key):
+        raise ValueError(
+            "Betfair credentials missing: BETFAIR_USERNAME / BETFAIR_PASSWORD / BETFAIR_APP_KEY"
+        )
+
+    client = BetfairExchangeClient(
+        username=username,
+        password=password,
+        app_key=app_key,
+        cert_file=cert_file,
+        cert_key=cert_key,
+    )
+    client.login()
+    try:
+        yield client
+    finally:
+        client.logout()
+
+
+def client_from_env() -> BetfairExchangeClient:
+    """Convenience constructor for scripts: read ``BETFAIR_*`` from env."""
+    return BetfairExchangeClient(
+        username=os.environ["BETFAIR_USERNAME"],
+        password=os.environ["BETFAIR_PASSWORD"],
+        app_key=os.environ["BETFAIR_APP_KEY"],
+        cert_file=os.environ.get("BETFAIR_CERT_FILE"),
+        cert_key=os.environ.get("BETFAIR_CERT_KEY"),
+    )

--- a/packages/odds-lambda/odds_lambda/betfair/constants.py
+++ b/packages/odds-lambda/odds_lambda/betfair/constants.py
@@ -11,74 +11,15 @@ EVENT_TYPE_SOCCER = "1"
 EVENT_TYPE_BASEBALL = "7511"
 
 # Premier League competition ID — community-stable across seasons.
+# Hints are a fallback in case Betfair re-issues the competition_id.
 EPL_COMPETITION_ID = "10932509"
+EPL_COMPETITION_NAME_HINTS: tuple[str, ...] = ("English Premier League", "Premier League")
 
 # MLB competition ID — Betfair calls it "Major League Baseball".
 # Pinning the discovered ID here as the primary path; the name hint is
 # kept as a fallback in case Betfair re-issues the competition_id.
 MLB_COMPETITION_ID = "11196870"
 MLB_COMPETITION_NAME_HINTS: tuple[str, ...] = ("Major League Baseball", "MLB")
-
-
-# Betfair runner-name aliases → pipeline canonical team names.
-# Soccer entries supplement odds_core.team alias map; baseball is exhaustive.
-BETFAIR_TEAM_ALIASES: dict[str, str] = {
-    # EPL — Betfair renders many short forms not in odds_core.team
-    "spurs": "Tottenham",
-    "wolves": "Wolves",
-    "man utd": "Manchester Utd",
-    "man city": "Manchester City",
-    "newcastle": "Newcastle",
-    "leeds": "Leeds",
-    "leicester": "Leicester",
-    "brighton": "Brighton",
-    "bournemouth": "Bournemouth",
-    "burnley": "Burnley",
-    "ipswich": "Ipswich",
-    "nottm forest": "Nottingham",
-    "nott'm forest": "Nottingham",
-    "sheff utd": "Sheffield Utd",
-    "west ham": "West Ham",
-    "west brom": "West Brom",
-    # MLB — Betfair short forms → canonical "events.home_team" names
-    "arizona d'backs": "Arizona Diamondbacks",
-    "arizona diamondbacks": "Arizona Diamondbacks",
-    "atlanta braves": "Atlanta Braves",
-    "baltimore orioles": "Baltimore Orioles",
-    "boston red sox": "Boston Red Sox",
-    "chicago cubs": "Chicago Cubs",
-    "chicago white sox": "Chicago White Sox",
-    "cincinnati reds": "Cincinnati Reds",
-    "cleveland guardians": "Cleveland Guardians",
-    "colorado rockies": "Colorado Rockies",
-    "detroit tigers": "Detroit Tigers",
-    "houston astros": "Houston Astros",
-    "kansas city royals": "Kansas City Royals",
-    "la angels": "Los Angeles Angels",
-    "los angeles angels": "Los Angeles Angels",
-    "la dodgers": "Los Angeles Dodgers",
-    "los angeles dodgers": "Los Angeles Dodgers",
-    "miami marlins": "Miami Marlins",
-    "milwaukee brewers": "Milwaukee Brewers",
-    "minnesota twins": "Minnesota Twins",
-    "ny mets": "New York Mets",
-    "new york mets": "New York Mets",
-    "ny yankees": "New York Yankees",
-    "new york yankees": "New York Yankees",
-    "oakland athletics": "Athletics",
-    "athletics": "Athletics",
-    "philadelphia phillies": "Philadelphia Phillies",
-    "pittsburgh pirates": "Pittsburgh Pirates",
-    "san diego padres": "San Diego Padres",
-    "san francisco giants": "San Francisco Giants",
-    "seattle mariners": "Seattle Mariners",
-    "st louis cardinals": "St.Louis Cardinals",
-    "st. louis cardinals": "St.Louis Cardinals",
-    "tampa bay rays": "Tampa Bay Rays",
-    "texas rangers": "Texas Rangers",
-    "toronto blue jays": "Toronto Blue Jays",
-    "washington nationals": "Washington Nationals",
-}
 
 
 @dataclass(frozen=True)
@@ -112,6 +53,7 @@ SPORT_CONFIG: dict[SportKey, SportBetfairConfig] = {
         market_type_code="MATCH_ODDS",
         market_key="1x2",
         competition_id=EPL_COMPETITION_ID,
+        competition_name_hints=EPL_COMPETITION_NAME_HINTS,
         has_draw=True,
     ),
     "baseball_mlb": SportBetfairConfig(

--- a/packages/odds-lambda/odds_lambda/betfair/constants.py
+++ b/packages/odds-lambda/odds_lambda/betfair/constants.py
@@ -1,0 +1,129 @@
+"""Betfair Exchange constants and per-sport config."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from odds_core.sports import SportKey
+
+# Betfair event-type IDs (stable; see developer.betfair.com).
+EVENT_TYPE_SOCCER = "1"
+EVENT_TYPE_BASEBALL = "7511"
+
+# Premier League competition ID — community-stable across seasons.
+EPL_COMPETITION_ID = "10932509"
+
+# MLB competition ID — Betfair calls it "Major League Baseball".
+# Pinning the discovered ID here as the primary path; the name hint is
+# kept as a fallback in case Betfair re-issues the competition_id.
+MLB_COMPETITION_ID = "11196870"
+MLB_COMPETITION_NAME_HINTS: tuple[str, ...] = ("Major League Baseball", "MLB")
+
+
+# Betfair runner-name aliases → pipeline canonical team names.
+# Soccer entries supplement odds_core.team alias map; baseball is exhaustive.
+BETFAIR_TEAM_ALIASES: dict[str, str] = {
+    # EPL — Betfair renders many short forms not in odds_core.team
+    "spurs": "Tottenham",
+    "wolves": "Wolves",
+    "man utd": "Manchester Utd",
+    "man city": "Manchester City",
+    "newcastle": "Newcastle",
+    "leeds": "Leeds",
+    "leicester": "Leicester",
+    "brighton": "Brighton",
+    "bournemouth": "Bournemouth",
+    "burnley": "Burnley",
+    "ipswich": "Ipswich",
+    "nottm forest": "Nottingham",
+    "nott'm forest": "Nottingham",
+    "sheff utd": "Sheffield Utd",
+    "west ham": "West Ham",
+    "west brom": "West Brom",
+    # MLB — Betfair short forms → canonical "events.home_team" names
+    "arizona d'backs": "Arizona Diamondbacks",
+    "arizona diamondbacks": "Arizona Diamondbacks",
+    "atlanta braves": "Atlanta Braves",
+    "baltimore orioles": "Baltimore Orioles",
+    "boston red sox": "Boston Red Sox",
+    "chicago cubs": "Chicago Cubs",
+    "chicago white sox": "Chicago White Sox",
+    "cincinnati reds": "Cincinnati Reds",
+    "cleveland guardians": "Cleveland Guardians",
+    "colorado rockies": "Colorado Rockies",
+    "detroit tigers": "Detroit Tigers",
+    "houston astros": "Houston Astros",
+    "kansas city royals": "Kansas City Royals",
+    "la angels": "Los Angeles Angels",
+    "los angeles angels": "Los Angeles Angels",
+    "la dodgers": "Los Angeles Dodgers",
+    "los angeles dodgers": "Los Angeles Dodgers",
+    "miami marlins": "Miami Marlins",
+    "milwaukee brewers": "Milwaukee Brewers",
+    "minnesota twins": "Minnesota Twins",
+    "ny mets": "New York Mets",
+    "new york mets": "New York Mets",
+    "ny yankees": "New York Yankees",
+    "new york yankees": "New York Yankees",
+    "oakland athletics": "Athletics",
+    "athletics": "Athletics",
+    "philadelphia phillies": "Philadelphia Phillies",
+    "pittsburgh pirates": "Pittsburgh Pirates",
+    "san diego padres": "San Diego Padres",
+    "san francisco giants": "San Francisco Giants",
+    "seattle mariners": "Seattle Mariners",
+    "st louis cardinals": "St.Louis Cardinals",
+    "st. louis cardinals": "St.Louis Cardinals",
+    "tampa bay rays": "Tampa Bay Rays",
+    "texas rangers": "Texas Rangers",
+    "toronto blue jays": "Toronto Blue Jays",
+    "washington nationals": "Washington Nationals",
+}
+
+
+@dataclass(frozen=True)
+class SportBetfairConfig:
+    """Per-sport Betfair Exchange ingestion config."""
+
+    sport_key: SportKey
+    sport_title: str
+    event_type_id: str
+    market_type_code: str
+    # Pipeline market_key written into raw_data.bookmakers[].markets[].key
+    market_key: str
+    # Optional: pin a competition_id (preferred). If None, client uses
+    # competition_name_hints to discover via list_competitions.
+    competition_id: str | None
+    competition_name_hints: tuple[str, ...] = ()
+    # If True, the market is a 3-way h2h with a "draw" outcome.
+    has_draw: bool = False
+    # Betfair event-name separator and ordering. Soccer: "Home v Away".
+    # Baseball: "Away @ Home". The first token in the tuple is the literal
+    # separator; the second is "home_first" or "away_first".
+    name_separator: str = " v "
+    name_order: str = "home_first"
+
+
+SPORT_CONFIG: dict[SportKey, SportBetfairConfig] = {
+    "soccer_epl": SportBetfairConfig(
+        sport_key="soccer_epl",
+        sport_title="EPL",
+        event_type_id=EVENT_TYPE_SOCCER,
+        market_type_code="MATCH_ODDS",
+        market_key="1x2",
+        competition_id=EPL_COMPETITION_ID,
+        has_draw=True,
+    ),
+    "baseball_mlb": SportBetfairConfig(
+        sport_key="baseball_mlb",
+        sport_title="MLB",
+        event_type_id=EVENT_TYPE_BASEBALL,
+        market_type_code="MATCH_ODDS",
+        market_key="h2h",
+        competition_id=MLB_COMPETITION_ID,
+        competition_name_hints=MLB_COMPETITION_NAME_HINTS,
+        has_draw=False,
+        name_separator=" @ ",
+        name_order="away_first",
+    ),
+}

--- a/packages/odds-lambda/odds_lambda/betfair/constants.py
+++ b/packages/odds-lambda/odds_lambda/betfair/constants.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 from odds_core.sports import SportKey
 
@@ -39,10 +40,10 @@ class SportBetfairConfig:
     # If True, the market is a 3-way h2h with a "draw" outcome.
     has_draw: bool = False
     # Betfair event-name separator and ordering. Soccer: "Home v Away".
-    # Baseball: "Away @ Home". The first token in the tuple is the literal
-    # separator; the second is "home_first" or "away_first".
+    # Baseball: "Away @ Home". ``name_separator`` splits the event name and
+    # ``name_order`` says which side comes first in the resulting parts.
     name_separator: str = " v "
-    name_order: str = "home_first"
+    name_order: Literal["home_first", "away_first"] = "home_first"
 
 
 SPORT_CONFIG: dict[SportKey, SportBetfairConfig] = {

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_betfair_exchange.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_betfair_exchange.py
@@ -50,7 +50,7 @@ SCHEDULE = ProximitySchedule(closing=0.25, pregame=0.5, far=2.0, db_fallback=1.0
 class IngestionStats:
     """Per-sport ingestion stats for one fetch_betfair_exchange run."""
 
-    sport: SportKey | str = ""
+    sport: SportKey
     events_seen: int = 0
     books_fetched: int = 0
     books_in_play: int = 0
@@ -292,7 +292,8 @@ async def main(ctx: JobContext) -> None:
             if ko is not None and (soonest is None or ko < soonest):
                 soonest = ko
         post_interval = SCHEDULE.interval_for(soonest)
-    except Exception:
+    except Exception as e:
+        logger.warning("betfair_post_kickoff_query_failed", error=str(e), exc_info=True)
         post_interval = pre_interval
 
     post_next_time = datetime.now(UTC) + timedelta(hours=post_interval)

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_betfair_exchange.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_betfair_exchange.py
@@ -31,18 +31,19 @@ from odds_lambda.betfair import (
     betfair_book_to_bookmaker_entry,
     resolve_teams,
 )
-from odds_lambda.fetch_tier import FetchTier
-from odds_lambda.scheduling.helpers import get_next_kickoff, self_schedule
+from odds_lambda.scheduling.helpers import (
+    ProximitySchedule,
+    get_next_kickoff,
+    self_schedule,
+)
 from odds_lambda.scheduling.jobs import JobContext, make_compound_job_name
 from odds_lambda.storage.writers import OddsWriter
 
 logger = structlog.get_logger()
 
-# Proximity-based scheduling intervals (hours), mirroring fetch-oddsportal.
-CLOSING_INTERVAL_HOURS = 0.25  # < 3h to kickoff — every 15min
-PREGAME_INTERVAL_HOURS = 0.5  # 3–12h
-FAR_INTERVAL_HOURS = 2.0  # 12h+ or no upcoming games
-DB_FALLBACK_INTERVAL_HOURS = 1.0
+# Proximity-based scheduling intervals (hours): cheap delayed API — poll
+# more aggressively than browser-driven fetch-oddsportal.
+SCHEDULE = ProximitySchedule(closing=0.25, pregame=0.5, far=2.0, db_fallback=1.0)
 
 
 @dataclass
@@ -53,28 +54,11 @@ class IngestionStats:
     events_seen: int = 0
     books_fetched: int = 0
     books_in_play: int = 0
+    books_suspended: int = 0
     snapshots_stored: int = 0
     events_matched: int = 0
     events_created: int = 0
     errors: list[str] = field(default_factory=list)
-
-
-def _interval_for_kickoff(
-    next_kickoff: datetime | None,
-    *,
-    now: datetime | None = None,
-) -> float:
-    """Compute scheduling interval (hours) based on proximity to next kickoff."""
-    if next_kickoff is None:
-        return FAR_INTERVAL_HOURS
-    if now is None:
-        now = datetime.now(UTC)
-    hours_until = (next_kickoff - now).total_seconds() / 3600
-    if hours_until < FetchTier.CLOSING.max_hours:
-        return CLOSING_INTERVAL_HOURS
-    if hours_until < FetchTier.PREGAME.max_hours:
-        return PREGAME_INTERVAL_HOURS
-    return FAR_INTERVAL_HOURS
 
 
 def _should_skip_book(book: BetfairBook, sport_cfg: SportBetfairConfig) -> bool:
@@ -122,6 +106,9 @@ async def ingest_sport(
                 if book.inplay:
                     stats.books_in_play += 1
                 continue
+
+            if (book.market_status or "").upper() == "SUSPENDED":
+                stats.books_suspended += 1
 
             teams = resolve_teams(book, sport_cfg)
             if teams is None:
@@ -192,6 +179,7 @@ async def ingest_sport(
         events_seen=stats.events_seen,
         books_fetched=stats.books_fetched,
         books_in_play=stats.books_in_play,
+        books_suspended=stats.books_suspended,
         snapshots_stored=stats.snapshots_stored,
         events_matched=stats.events_matched,
         events_created=stats.events_created,
@@ -209,13 +197,6 @@ async def main(ctx: JobContext) -> None:
         logger.info("betfair_job_disabled", reason="betfair.enabled=False")
         return
 
-    if not (bf.username and bf.password and bf.app_key):
-        logger.error(
-            "betfair_credentials_missing",
-            note="Set BETFAIR_USERNAME / BETFAIR_PASSWORD / BETFAIR_APP_KEY",
-        )
-        return
-
     sport: SportKey | None = ctx.sport
     if sport:
         if sport not in SPORT_CONFIG:
@@ -223,7 +204,9 @@ async def main(ctx: JobContext) -> None:
             return
         target_sports: list[SportKey] = [sport]
     else:
-        target_sports = [s for s in bf.sports if s in SPORT_CONFIG]
+        # Default to every adapter-supported sport; honour an explicit override.
+        configured = bf.sports if bf.sports is not None else list(SPORT_CONFIG)
+        target_sports = [s for s in configured if s in SPORT_CONFIG]
 
     if not target_sports:
         logger.warning("betfair_no_target_sports")
@@ -233,14 +216,14 @@ async def main(ctx: JobContext) -> None:
 
     # Pre-schedule before doing the work, so a crash mid-fetch doesn't break
     # the chain. Use the soonest kickoff across configured sports.
-    pre_interval = DB_FALLBACK_INTERVAL_HOURS
+    pre_interval = SCHEDULE.db_fallback
     try:
         soonest: datetime | None = None
         for sk in target_sports:
             ko = await get_next_kickoff(sk)
             if ko is not None and (soonest is None or ko < soonest):
                 soonest = ko
-        pre_interval = _interval_for_kickoff(soonest)
+        pre_interval = SCHEDULE.interval_for(soonest)
     except Exception as e:
         logger.warning("betfair_next_kickoff_query_failed", error=str(e), exc_info=True)
 
@@ -255,9 +238,12 @@ async def main(ctx: JobContext) -> None:
         )
     except Exception as e:
         logger.error("betfair_pre_schedule_failed", error=str(e), exc_info=True)
+        raise
 
     snapshot_time = datetime.now(UTC)
     all_stats: list[IngestionStats] = []
+    # BetfairConfig validator guarantees these are non-None when enabled=True.
+    assert bf.username and bf.password and bf.app_key
     async with job_alert_context(compound_job_name):
         client = BetfairExchangeClient(
             username=bf.username,
@@ -305,7 +291,7 @@ async def main(ctx: JobContext) -> None:
             ko = await get_next_kickoff(sk)
             if ko is not None and (soonest is None or ko < soonest):
                 soonest = ko
-        post_interval = _interval_for_kickoff(soonest)
+        post_interval = SCHEDULE.interval_for(soonest)
     except Exception:
         post_interval = pre_interval
 

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_betfair_exchange.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_betfair_exchange.py
@@ -1,0 +1,323 @@
+"""Fetch Match Odds from Betfair Exchange directly.
+
+Polls the Betfair Exchange API for upcoming events in a sport, fetches the
+best back/lay for the configured Match Odds market, converts to canonical
+``raw_data`` format, and writes a ``betfair_exchange`` snapshot row via
+``OddsWriter.store_odds_snapshot``. Self-schedules with proximity-based
+intervals matching ``fetch_oddsportal``.
+
+Replaces the previous BFE-via-OddsPortal data path that broke 2026-04-21
+when OP moved exchanges into a separate (encrypted) AJAX endpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from odds_core.alerts import job_alert_context, send_job_warning
+from odds_core.config import get_settings
+from odds_core.database import async_session_maker
+from odds_core.models import FetchLog
+from odds_core.sports import SportKey
+
+from odds_lambda.betfair import (
+    SPORT_CONFIG,
+    BetfairBook,
+    BetfairExchangeClient,
+    SportBetfairConfig,
+    betfair_book_to_bookmaker_entry,
+    resolve_teams,
+)
+from odds_lambda.fetch_tier import FetchTier
+from odds_lambda.scheduling.helpers import get_next_kickoff, self_schedule
+from odds_lambda.scheduling.jobs import JobContext, make_compound_job_name
+from odds_lambda.storage.writers import OddsWriter
+
+logger = structlog.get_logger()
+
+# Proximity-based scheduling intervals (hours), mirroring fetch-oddsportal.
+CLOSING_INTERVAL_HOURS = 0.25  # < 3h to kickoff — every 15min
+PREGAME_INTERVAL_HOURS = 0.5  # 3–12h
+FAR_INTERVAL_HOURS = 2.0  # 12h+ or no upcoming games
+DB_FALLBACK_INTERVAL_HOURS = 1.0
+
+
+@dataclass
+class IngestionStats:
+    """Per-sport ingestion stats for one fetch_betfair_exchange run."""
+
+    sport: SportKey | str = ""
+    events_seen: int = 0
+    books_fetched: int = 0
+    books_in_play: int = 0
+    snapshots_stored: int = 0
+    events_matched: int = 0
+    events_created: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+def _interval_for_kickoff(
+    next_kickoff: datetime | None,
+    *,
+    now: datetime | None = None,
+) -> float:
+    """Compute scheduling interval (hours) based on proximity to next kickoff."""
+    if next_kickoff is None:
+        return FAR_INTERVAL_HOURS
+    if now is None:
+        now = datetime.now(UTC)
+    hours_until = (next_kickoff - now).total_seconds() / 3600
+    if hours_until < FetchTier.CLOSING.max_hours:
+        return CLOSING_INTERVAL_HOURS
+    if hours_until < FetchTier.PREGAME.max_hours:
+        return PREGAME_INTERVAL_HOURS
+    return FAR_INTERVAL_HOURS
+
+
+def _should_skip_book(book: BetfairBook, sport_cfg: SportBetfairConfig) -> bool:
+    """Skip in-play and clearly-closed markets; we ingest pre-match only."""
+    if book.inplay:
+        return True
+    status = (book.market_status or "").upper()
+    if status in {"CLOSED", "INACTIVE"}:
+        return True
+    if len(book.runners) < (3 if sport_cfg.has_draw else 2):
+        return True
+    return False
+
+
+async def ingest_sport(
+    sport_cfg: SportBetfairConfig,
+    *,
+    client: BetfairExchangeClient,
+    lookahead_hours: int,
+    snapshot_time: datetime,
+) -> IngestionStats:
+    """Discover events, fetch books, write snapshots for one sport."""
+    stats = IngestionStats(sport=sport_cfg.sport_key)
+
+    # API calls are blocking; run in worker thread to avoid stalling the loop.
+    events = await asyncio.to_thread(client.list_events, sport_cfg, lookahead_hours)
+    stats.events_seen = len(events)
+    if not events:
+        logger.warning("betfair_no_events_found", sport=sport_cfg.sport_key)
+        return stats
+
+    books = await asyncio.to_thread(client.list_match_odds_books, sport_cfg, events)
+    stats.books_fetched = len(books)
+    if not books:
+        logger.warning(
+            "betfair_no_books_returned", sport=sport_cfg.sport_key, events_seen=len(events)
+        )
+        return stats
+
+    async with async_session_maker() as session:
+        writer = OddsWriter(session)
+
+        for book in books:
+            if _should_skip_book(book, sport_cfg):
+                if book.inplay:
+                    stats.books_in_play += 1
+                continue
+
+            teams = resolve_teams(book, sport_cfg)
+            if teams is None:
+                stats.errors.append(f"unparseable_event_name: {book.betfair_event_name}")
+                continue
+            home, away = teams
+
+            entry = betfair_book_to_bookmaker_entry(
+                book,
+                sport_cfg,
+                home_team=home,
+                away_team=away,
+                snapshot_time=snapshot_time,
+            )
+            if entry is None:
+                stats.errors.append(f"unusable_outcomes: {book.betfair_event_name}")
+                continue
+
+            try:
+                event_id, created = await writer.find_or_create_event(
+                    home_team=home,
+                    away_team=away,
+                    match_date=book.market_start_time,
+                    sport_key=sport_cfg.sport_key,
+                    sport_title=sport_cfg.sport_title,
+                )
+                if created:
+                    stats.events_created += 1
+                else:
+                    stats.events_matched += 1
+
+                raw_data = {
+                    "bookmakers": [entry],
+                    "source": "betfair_api",
+                    "betfair_event_id": book.betfair_event_id,
+                }
+                snapshot, _ = await writer.store_odds_snapshot(
+                    event_id=event_id,
+                    raw_data=raw_data,
+                    snapshot_time=snapshot_time,
+                )
+                snapshot.api_request_id = f"betfair_api_{snapshot_time.isoformat()}"
+                stats.snapshots_stored += 1
+
+            except Exception as e:
+                msg = f"{book.betfair_event_name}: {type(e).__name__}: {e}"
+                stats.errors.append(msg)
+                logger.error("betfair_book_ingestion_failed", error=msg, exc_info=True)
+
+        # FetchLog for observability — sport-level summary.
+        if stats.snapshots_stored or stats.events_seen:
+            session.add(
+                FetchLog(
+                    fetch_time=snapshot_time,
+                    sport_key=sport_cfg.sport_key,
+                    events_count=stats.snapshots_stored,
+                    bookmakers_count=1,
+                    success=stats.snapshots_stored > 0,
+                    error_message=None if not stats.errors else "; ".join(stats.errors[:3]),
+                )
+            )
+
+        await session.commit()
+
+    logger.info(
+        "betfair_sport_ingestion_complete",
+        sport=sport_cfg.sport_key,
+        events_seen=stats.events_seen,
+        books_fetched=stats.books_fetched,
+        books_in_play=stats.books_in_play,
+        snapshots_stored=stats.snapshots_stored,
+        events_matched=stats.events_matched,
+        events_created=stats.events_created,
+        errors=len(stats.errors),
+    )
+    return stats
+
+
+async def main(ctx: JobContext) -> None:
+    """Job entry. Reads BetfairConfig, ingests one or all configured sports."""
+    settings = get_settings()
+    bf = settings.betfair
+
+    if not bf.enabled:
+        logger.info("betfair_job_disabled", reason="betfair.enabled=False")
+        return
+
+    if not (bf.username and bf.password and bf.app_key):
+        logger.error(
+            "betfair_credentials_missing",
+            note="Set BETFAIR_USERNAME / BETFAIR_PASSWORD / BETFAIR_APP_KEY",
+        )
+        return
+
+    sport: SportKey | None = ctx.sport
+    if sport:
+        if sport not in SPORT_CONFIG:
+            logger.error("betfair_unknown_sport", sport=sport, supported=list(SPORT_CONFIG))
+            return
+        target_sports: list[SportKey] = [sport]
+    else:
+        target_sports = [s for s in bf.sports if s in SPORT_CONFIG]
+
+    if not target_sports:
+        logger.warning("betfair_no_target_sports")
+        return
+
+    compound_job_name = make_compound_job_name("fetch-betfair-exchange", sport)
+
+    # Pre-schedule before doing the work, so a crash mid-fetch doesn't break
+    # the chain. Use the soonest kickoff across configured sports.
+    pre_interval = DB_FALLBACK_INTERVAL_HOURS
+    try:
+        soonest: datetime | None = None
+        for sk in target_sports:
+            ko = await get_next_kickoff(sk)
+            if ko is not None and (soonest is None or ko < soonest):
+                soonest = ko
+        pre_interval = _interval_for_kickoff(soonest)
+    except Exception as e:
+        logger.warning("betfair_next_kickoff_query_failed", error=str(e), exc_info=True)
+
+    pre_next_time = datetime.now(UTC) + timedelta(hours=pre_interval)
+    try:
+        await self_schedule(
+            job_name=compound_job_name,
+            next_time=pre_next_time,
+            dry_run=settings.scheduler.dry_run,
+            sport=sport,
+            interval_hours=pre_interval,
+        )
+    except Exception as e:
+        logger.error("betfair_pre_schedule_failed", error=str(e), exc_info=True)
+
+    snapshot_time = datetime.now(UTC)
+    all_stats: list[IngestionStats] = []
+    async with job_alert_context(compound_job_name):
+        client = BetfairExchangeClient(
+            username=bf.username,
+            password=bf.password,
+            app_key=bf.app_key,
+            cert_file=bf.cert_file,
+            cert_key=bf.cert_key,
+        )
+        await asyncio.to_thread(client.login)
+        try:
+            for sport_key in target_sports:
+                cfg = SPORT_CONFIG[sport_key]
+                try:
+                    stats = await ingest_sport(
+                        cfg,
+                        client=client,
+                        lookahead_hours=bf.lookahead_hours,
+                        snapshot_time=snapshot_time,
+                    )
+                except Exception as e:
+                    logger.error(
+                        "betfair_sport_ingestion_failed",
+                        sport=sport_key,
+                        error=str(e),
+                        exc_info=True,
+                    )
+                    stats = IngestionStats(sport=sport_key, errors=[str(e)])
+                all_stats.append(stats)
+        finally:
+            await asyncio.to_thread(client.logout)
+
+    # Soft warning when zero snapshots stored across all sports — likely
+    # cert/auth/credentials/geo issue worth investigating.
+    total_stored = sum(s.snapshots_stored for s in all_stats)
+    if total_stored == 0:
+        await send_job_warning(
+            f"job_empty:{compound_job_name}",
+            f"⚠️ {compound_job_name} stored 0 snapshots across {len(all_stats)} sport(s).",
+        )
+
+    # Reschedule based on (possibly updated) next kickoff after fetch.
+    try:
+        soonest = None
+        for sk in target_sports:
+            ko = await get_next_kickoff(sk)
+            if ko is not None and (soonest is None or ko < soonest):
+                soonest = ko
+        post_interval = _interval_for_kickoff(soonest)
+    except Exception:
+        post_interval = pre_interval
+
+    post_next_time = datetime.now(UTC) + timedelta(hours=post_interval)
+    try:
+        await self_schedule(
+            job_name=compound_job_name,
+            next_time=post_next_time,
+            dry_run=settings.scheduler.dry_run,
+            sport=sport,
+            interval_hours=post_interval,
+            reason="post_fetch",
+        )
+    except Exception as e:
+        logger.error("betfair_post_schedule_failed", error=str(e), exc_info=True)

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
@@ -25,23 +25,24 @@ from typing import Any
 import structlog
 from odds_core.database import async_session_maker
 
-from odds_lambda.fetch_tier import FetchTier
 from odds_lambda.oddsportal_adapter import (
     MatchOdds,
     convert_upcoming_matches,
 )
 from odds_lambda.oddsportal_common import run_scraper_with_retry
-from odds_lambda.scheduling.helpers import apply_overnight_skip, get_next_kickoff, self_schedule
+from odds_lambda.scheduling.helpers import (
+    ProximitySchedule,
+    apply_overnight_skip,
+    get_next_kickoff,
+    self_schedule,
+)
 from odds_lambda.scheduling.jobs import JobContext, make_compound_job_name
 from odds_lambda.storage.writers import OddsWriter
 
 logger = structlog.get_logger()
 
-# Proximity-based scheduling intervals (hours)
-CLOSING_INTERVAL_HOURS = 0.5  # < 3h to kickoff
-PREGAME_INTERVAL_HOURS = 1.0  # 3–12h to kickoff
-FAR_INTERVAL_HOURS = 2.0  # 12h+ or no upcoming games
-DB_FALLBACK_INTERVAL_HOURS = 1.0  # DB unreachable
+# Proximity-based scheduling intervals (hours): browser scrape — moderate cadence.
+SCHEDULE = ProximitySchedule(closing=0.5, pregame=1.0, far=2.0, db_fallback=1.0)
 
 
 @dataclass
@@ -217,27 +218,6 @@ async def ingest_league(
     return stats
 
 
-def _interval_for_kickoff(
-    next_kickoff: datetime | None,
-    *,
-    now: datetime | None = None,
-) -> float:
-    """Compute scheduling interval (hours) based on proximity to next kickoff."""
-    if next_kickoff is None:
-        return FAR_INTERVAL_HOURS
-
-    if now is None:
-        now = datetime.now(UTC)
-
-    hours_until = (next_kickoff - now).total_seconds() / 3600
-
-    if hours_until < FetchTier.CLOSING.max_hours:
-        return CLOSING_INTERVAL_HOURS
-    if hours_until < FetchTier.PREGAME.max_hours:
-        return PREGAME_INTERVAL_HOURS
-    return FAR_INTERVAL_HOURS
-
-
 async def main(ctx: JobContext) -> None:
     """Main job execution — scrapes configured league(s), then self-schedules.
 
@@ -268,10 +248,10 @@ async def main(ctx: JobContext) -> None:
 
     # Query DB for next kickoff to determine scheduling interval.
     # On failure, fall back to 1h so we don't block on DB availability.
-    pre_interval = DB_FALLBACK_INTERVAL_HOURS
+    pre_interval = SCHEDULE.db_fallback
     try:
         next_kickoff = await get_next_kickoff(primary_spec.sport_key)
-        pre_interval = _interval_for_kickoff(next_kickoff)
+        pre_interval = SCHEDULE.interval_for(next_kickoff)
         logger.info(
             "proximity_schedule",
             next_kickoff=next_kickoff.isoformat() if next_kickoff else None,
@@ -365,10 +345,10 @@ async def main(ctx: JobContext) -> None:
     # On success, re-query next kickoff (scrape may have created new events)
     # and reschedule at the updated interval.
     if total_scraped > 0:
-        post_interval = DB_FALLBACK_INTERVAL_HOURS
+        post_interval = SCHEDULE.db_fallback
         try:
             post_kickoff = await get_next_kickoff(primary_spec.sport_key)
-            post_interval = _interval_for_kickoff(post_kickoff)
+            post_interval = SCHEDULE.interval_for(post_kickoff)
         except Exception as e:
             logger.warning("post_scrape_kickoff_query_failed", error=str(e), exc_info=True)
 

--- a/packages/odds-lambda/odds_lambda/scheduling/helpers.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/helpers.py
@@ -2,13 +2,48 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 
 import structlog
 
+from odds_lambda.fetch_tier import FetchTier
 from odds_lambda.scheduling.backends import get_scheduler_backend
 
 logger = structlog.get_logger()
+
+
+@dataclass(frozen=True)
+class ProximitySchedule:
+    """Per-job proximity-based scheduling intervals (hours).
+
+    The boundary thresholds come from ``FetchTier`` so all jobs agree on what
+    "closing" / "pregame" / "far" mean; only the polling cadence varies per
+    job (e.g. cheap API polls more aggressively than browser-driven scrapes).
+    """
+
+    closing: float
+    pregame: float
+    far: float
+    db_fallback: float = 1.0
+
+    def interval_for(
+        self,
+        next_kickoff: datetime | None,
+        *,
+        now: datetime | None = None,
+    ) -> float:
+        """Compute the next-fire interval (hours) from proximity to kickoff."""
+        if next_kickoff is None:
+            return self.far
+        if now is None:
+            now = datetime.now(UTC)
+        hours_until = (next_kickoff - now).total_seconds() / 3600
+        if hours_until < FetchTier.CLOSING.max_hours:
+            return self.closing
+        if hours_until < FetchTier.PREGAME.max_hours:
+            return self.pregame
+        return self.far
 
 
 async def get_next_kickoff(sport_key: str) -> datetime | None:

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -9,6 +9,8 @@ from importlib import import_module
 import structlog
 from odds_core.sports import SportKey
 
+from odds_lambda.betfair.constants import SPORT_CONFIG as BETFAIR_SPORT_CONFIG
+
 logger = structlog.get_logger()
 
 
@@ -122,8 +124,10 @@ _JOB_CRON_MAP: dict[str, tuple[str, tuple[SportKey, ...] | None]] = {
     "fetch-espn-fixtures": ("0 6 * * *", ("soccer_epl",)),
     # Betfair Exchange direct ingestion. The job self-schedules a tighter
     # cadence near kickoff; this cron is the safety floor that catches
-    # cold-start gaps and backfills if self-scheduling stalls.
-    "fetch-betfair-exchange": ("*/30 * * * *", ("soccer_epl", "baseball_mlb")),
+    # cold-start gaps and backfills if self-scheduling stalls. Allowlist
+    # is derived from the BFE adapter's supported-sports map so adding a
+    # new sport requires only a SPORT_CONFIG entry.
+    "fetch-betfair-exchange": ("*/30 * * * *", tuple(BETFAIR_SPORT_CONFIG)),
 }
 
 

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -67,6 +67,7 @@ _JOB_MODULE_MAP: dict[str, tuple[str, str]] = {
     "daily-digest": ("odds_lambda.jobs.daily_digest", "main"),
     "agent-run": ("odds_lambda.jobs.agent_run", "main"),
     "fetch-espn-fixtures": ("odds_lambda.jobs.fetch_espn_fixtures", "main"),
+    "fetch-betfair-exchange": ("odds_lambda.jobs.fetch_betfair_exchange", "main"),
 }
 
 # Bootstrap entry-point overrides: jobs listed here use a different function
@@ -97,6 +98,7 @@ _PER_SPORT_JOBS: frozenset[str] = frozenset(
         "daily-digest",
         "agent-run",
         "fetch-espn-fixtures",
+        "fetch-betfair-exchange",
     }
 )
 
@@ -118,6 +120,10 @@ _JOB_CRON_MAP: dict[str, tuple[str, tuple[SportKey, ...] | None]] = {
     # heartbeat_expectations entry are EPL-only today.
     "daily-digest": ("0 8 * * *", ("soccer_epl",)),
     "fetch-espn-fixtures": ("0 6 * * *", ("soccer_epl",)),
+    # Betfair Exchange direct ingestion. The job self-schedules a tighter
+    # cadence near kickoff; this cron is the safety floor that catches
+    # cold-start gaps and backfills if self-scheduling stalls.
+    "fetch-betfair-exchange": ("*/30 * * * *", ("soccer_epl", "baseball_mlb")),
 }
 
 

--- a/packages/odds-lambda/pyproject.toml
+++ b/packages/odds-lambda/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "playwright>=1.58.0",
     "requests>=2.31.0",
     "fake-useragent>=2.2.0",
+    "betfairlightweight>=2.23.2",
 ]
 
 [tool.uv.sources]

--- a/tests/unit/test_betfair_adapter.py
+++ b/tests/unit/test_betfair_adapter.py
@@ -1,0 +1,264 @@
+"""Unit tests for Betfair Exchange adapter logic."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from odds_lambda.betfair.adapter import (
+    _is_draw,
+    _normalize_runner_name,
+    _strip_pitcher_annotation,
+    betfair_book_to_bookmaker_entry,
+    resolve_teams,
+)
+from odds_lambda.betfair.client import BetfairBook, BetfairRunner
+from odds_lambda.betfair.constants import SPORT_CONFIG
+
+
+def _runner(
+    selection_id: int,
+    name: str,
+    back: float | None,
+    lay: float | None = None,
+    *,
+    back_size: float | None = None,
+    lay_size: float | None = None,
+    ltp: float | None = None,
+) -> BetfairRunner:
+    return BetfairRunner(
+        selection_id=selection_id,
+        runner_name=name,
+        best_back=back,
+        best_lay=lay,
+        back_size=back_size,
+        lay_size=lay_size,
+        last_price_traded=ltp,
+    )
+
+
+def _book(
+    *,
+    market_id: str,
+    event_id: str,
+    event_name: str,
+    runners: list[BetfairRunner],
+    market_status: str = "OPEN",
+    inplay: bool = False,
+    total_matched: float | None = 1234.5,
+    market_start_time: datetime | None = None,
+) -> BetfairBook:
+    return BetfairBook(
+        market_id=market_id,
+        betfair_event_id=event_id,
+        betfair_event_name=event_name,
+        market_start_time=market_start_time or datetime(2026, 4, 25, 14, 0, tzinfo=UTC),
+        market_status=market_status,
+        inplay=inplay,
+        total_matched=total_matched,
+        runners=runners,
+    )
+
+
+class TestStripPitcherAnnotation:
+    def test_tbd_suffix_removed(self) -> None:
+        assert _strip_pitcher_annotation("Colorado Rockies (TBD)") == "Colorado Rockies"
+
+    def test_pitcher_name_suffix_removed(self) -> None:
+        assert _strip_pitcher_annotation("New York Yankees (Cole)") == "New York Yankees"
+
+    def test_no_paren_unchanged(self) -> None:
+        assert _strip_pitcher_annotation("Boston Red Sox") == "Boston Red Sox"
+
+    def test_paren_in_middle_preserved(self) -> None:
+        # Defensive: only trailing parens are stripped
+        assert _strip_pitcher_annotation("Some (mid) Team") == "Some (mid) Team"
+
+
+class TestNormalizeRunnerName:
+    def test_betfair_alias_short_form(self) -> None:
+        assert _normalize_runner_name("Man Utd") == "Manchester Utd"
+
+    def test_betfair_alias_long_form(self) -> None:
+        assert _normalize_runner_name("Manchester United") == "Manchester Utd"
+
+    def test_betfair_short_mlb(self) -> None:
+        assert _normalize_runner_name("LA Angels") == "Los Angeles Angels"
+
+    def test_pitcher_annotation_then_alias(self) -> None:
+        assert _normalize_runner_name("NY Yankees (TBD)") == "New York Yankees"
+
+    def test_canonical_passthrough(self) -> None:
+        assert _normalize_runner_name("Liverpool") == "Liverpool"
+
+    def test_athletics_canonical(self) -> None:
+        # Athletics is a single-word canonical name that maps from "Oakland Athletics".
+        assert _normalize_runner_name("Oakland Athletics") == "Athletics"
+
+
+class TestIsDraw:
+    @pytest.mark.parametrize("name", ["The Draw", "draw", "DRAW", "the draw"])
+    def test_draw_variants(self, name: str) -> None:
+        assert _is_draw(name)
+
+    def test_team_name_is_not_draw(self) -> None:
+        assert not _is_draw("Liverpool")
+
+
+class TestResolveTeamsSoccer:
+    def test_epl_home_first(self) -> None:
+        cfg = SPORT_CONFIG["soccer_epl"]
+        book = _book(
+            market_id="1.1",
+            event_id="35480901",
+            event_name="Liverpool v Crystal Palace",
+            runners=[],
+        )
+        assert resolve_teams(book, cfg) == ("Liverpool", "Crystal Palace")
+
+    def test_epl_short_name(self) -> None:
+        cfg = SPORT_CONFIG["soccer_epl"]
+        book = _book(
+            market_id="1.2",
+            event_id="x",
+            event_name="Man Utd v Spurs",
+            runners=[],
+        )
+        assert resolve_teams(book, cfg) == ("Manchester Utd", "Tottenham")
+
+    def test_epl_unparseable(self) -> None:
+        cfg = SPORT_CONFIG["soccer_epl"]
+        book = _book(
+            market_id="1.3",
+            event_id="x",
+            event_name="Some Friendly Match",
+            runners=[],
+        )
+        assert resolve_teams(book, cfg) is None
+
+
+class TestResolveTeamsBaseball:
+    def test_mlb_away_first_swap(self) -> None:
+        cfg = SPORT_CONFIG["baseball_mlb"]
+        book = _book(
+            market_id="1.4",
+            event_id="x",
+            event_name="Boston Red Sox @ Baltimore Orioles",
+            runners=[],
+        )
+        # Betfair: Away @ Home → home first in returned tuple
+        assert resolve_teams(book, cfg) == ("Baltimore Orioles", "Boston Red Sox")
+
+    def test_mlb_with_pitchers(self) -> None:
+        cfg = SPORT_CONFIG["baseball_mlb"]
+        book = _book(
+            market_id="1.5",
+            event_id="x",
+            event_name="Colorado Rockies (TBD) @ New York Mets (TBD)",
+            runners=[],
+        )
+        assert resolve_teams(book, cfg) == ("New York Mets", "Colorado Rockies")
+
+
+class TestBookToBookmakerEntry:
+    @pytest.fixture
+    def epl_book(self) -> BetfairBook:
+        return _book(
+            market_id="1.123",
+            event_id="35480901",
+            event_name="Liverpool v Crystal Palace",
+            runners=[
+                _runner(1, "Liverpool", back=1.64, lay=1.65, back_size=292, lay_size=314, ltp=1.64),
+                _runner(
+                    2, "Crystal Palace", back=5.7, lay=5.9, back_size=243, lay_size=165, ltp=5.8
+                ),
+                _runner(3, "The Draw", back=4.5, lay=4.6, back_size=32, lay_size=214, ltp=4.6),
+            ],
+            total_matched=385702.0,
+        )
+
+    @pytest.fixture
+    def mlb_book(self) -> BetfairBook:
+        return _book(
+            market_id="1.456",
+            event_id="35529928",
+            event_name="Boston Red Sox @ Baltimore Orioles",
+            runners=[
+                _runner(10, "Boston Red Sox", back=2.0, lay=2.05),
+                _runner(11, "Baltimore Orioles", back=1.95, lay=1.97),
+            ],
+            total_matched=3500.0,
+        )
+
+    def test_epl_entry_shape(self, epl_book: BetfairBook) -> None:
+        cfg = SPORT_CONFIG["soccer_epl"]
+        snap = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+        entry = betfair_book_to_bookmaker_entry(
+            epl_book, cfg, home_team="Liverpool", away_team="Crystal Palace", snapshot_time=snap
+        )
+        assert entry is not None
+        assert entry["key"] == "betfair_exchange"
+        assert entry["title"] == "Betfair Exchange"
+        assert entry["last_update"] == snap.isoformat()
+        markets = entry["markets"]
+        assert len(markets) == 1
+        assert markets[0]["key"] == "1x2"
+        outcome_names = [o["name"] for o in markets[0]["outcomes"]]
+        assert sorted(outcome_names) == ["Crystal Palace", "Draw", "Liverpool"]
+
+    def test_epl_prices_are_american(self, epl_book: BetfairBook) -> None:
+        cfg = SPORT_CONFIG["soccer_epl"]
+        entry = betfair_book_to_bookmaker_entry(
+            epl_book, cfg, home_team="Liverpool", away_team="Crystal Palace"
+        )
+        assert entry is not None
+        prices = {o["name"]: o["price"] for o in entry["markets"][0]["outcomes"]}
+        # 1.64 decimal -> -156 American (under 2.0 → negative line)
+        assert prices["Liverpool"] == pytest.approx(-156, abs=1)
+        # 5.7 decimal -> +470 American
+        assert prices["Crystal Palace"] == pytest.approx(470, abs=1)
+        # 4.5 decimal -> +350 American
+        assert prices["Draw"] == pytest.approx(350, abs=1)
+
+    def test_epl_betfair_meta_preserved(self, epl_book: BetfairBook) -> None:
+        cfg = SPORT_CONFIG["soccer_epl"]
+        entry = betfair_book_to_bookmaker_entry(
+            epl_book, cfg, home_team="Liverpool", away_team="Crystal Palace"
+        )
+        assert entry is not None
+        meta = entry["betfair_meta"]
+        assert meta["market_id"] == "1.123"
+        assert meta["market_status"] == "OPEN"
+        assert meta["inplay"] is False
+        assert meta["total_matched"] == pytest.approx(385702.0)
+        assert len(meta["runners"]) == 3
+
+    def test_mlb_entry_shape(self, mlb_book: BetfairBook) -> None:
+        cfg = SPORT_CONFIG["baseball_mlb"]
+        entry = betfair_book_to_bookmaker_entry(
+            mlb_book,
+            cfg,
+            home_team="Baltimore Orioles",
+            away_team="Boston Red Sox",
+        )
+        assert entry is not None
+        assert entry["markets"][0]["key"] == "h2h"
+        outcomes = entry["markets"][0]["outcomes"]
+        names = [o["name"] for o in outcomes]
+        assert sorted(names) == ["Baltimore Orioles", "Boston Red Sox"]
+
+    def test_returns_none_when_outcomes_missing(self) -> None:
+        cfg = SPORT_CONFIG["soccer_epl"]
+        # Only one of three outcomes has a back price
+        book = _book(
+            market_id="1.x",
+            event_id="x",
+            event_name="A v B",
+            runners=[
+                _runner(1, "A", back=2.0),
+                _runner(2, "B", back=None),
+                _runner(3, "The Draw", back=None),
+            ],
+        )
+        entry = betfair_book_to_bookmaker_entry(book, cfg, home_team="A", away_team="B")
+        assert entry is None

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -42,6 +42,7 @@ class TestSettings:
                 "fetch-oddsportal-results",
                 "daily-digest",
                 "fetch-espn-fixtures",
+                "fetch-betfair-exchange",
             ]
             assert settings.data_quality.enable_validation is True
             assert settings.data_quality.reject_invalid_odds is False
@@ -158,3 +159,44 @@ class TestSettings:
             assert settings.polymarket.orderbook_poll_interval == 900
             assert settings.polymarket.collect_player_props is True
             assert settings.polymarket.nba_series_id == "99999"
+
+    def test_betfair_defaults(self):
+        """Defaults: disabled, no creds, both EPL+MLB in scope."""
+        from odds_core.config import BetfairConfig
+
+        with patch.dict(os.environ, {}, clear=True):
+            cfg = BetfairConfig(_env_file=None)
+            assert cfg.enabled is False
+            assert cfg.username is None
+            assert cfg.password is None
+            assert cfg.app_key is None
+            assert cfg.cert_file is None
+            assert cfg.cert_key is None
+            assert cfg.sports == ["soccer_epl", "baseball_mlb"]
+            assert cfg.lookahead_hours == 168
+
+    def test_betfair_env_overrides(self):
+        """Env-driven overrides for credentials and toggles."""
+        from odds_core.config import BetfairConfig
+
+        with patch.dict(
+            os.environ,
+            {
+                "BETFAIR_ENABLED": "true",
+                "BETFAIR_USERNAME": "alice",
+                "BETFAIR_PASSWORD": "secret",
+                "BETFAIR_APP_KEY": "appkey123",
+                "BETFAIR_CERT_FILE": "/tmp/bf.crt",
+                "BETFAIR_CERT_KEY": "/tmp/bf.key",
+                "BETFAIR_LOOKAHEAD_HOURS": "72",
+            },
+            clear=True,
+        ):
+            cfg = BetfairConfig(_env_file=None)
+            assert cfg.enabled is True
+            assert cfg.username == "alice"
+            assert cfg.password == "secret"
+            assert cfg.app_key == "appkey123"
+            assert cfg.cert_file == "/tmp/bf.crt"
+            assert cfg.cert_key == "/tmp/bf.key"
+            assert cfg.lookahead_hours == 72

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -161,7 +161,7 @@ class TestSettings:
             assert settings.polymarket.nba_series_id == "99999"
 
     def test_betfair_defaults(self):
-        """Defaults: disabled, no creds, both EPL+MLB in scope."""
+        """Defaults: disabled, no creds, sports=None (resolved from SPORT_CONFIG at runtime)."""
         from odds_core.config import BetfairConfig
 
         with patch.dict(os.environ, {}, clear=True):
@@ -172,7 +172,7 @@ class TestSettings:
             assert cfg.app_key is None
             assert cfg.cert_file is None
             assert cfg.cert_key is None
-            assert cfg.sports == ["soccer_epl", "baseball_mlb"]
+            assert cfg.sports is None
             assert cfg.lookahead_hours == 168
 
     def test_betfair_env_overrides(self):
@@ -200,3 +200,28 @@ class TestSettings:
             assert cfg.cert_file == "/tmp/bf.crt"
             assert cfg.cert_key == "/tmp/bf.key"
             assert cfg.lookahead_hours == 72
+
+    def test_betfair_enabled_requires_credentials(self):
+        """enabled=True with missing creds must fail at config load, not at runtime."""
+        import pytest
+        from odds_core.config import BetfairConfig
+        from pydantic import ValidationError
+
+        with patch.dict(
+            os.environ,
+            {"BETFAIR_ENABLED": "true", "BETFAIR_APP_KEY": "appkey123"},
+            clear=True,
+        ):
+            with pytest.raises(ValidationError) as exc_info:
+                BetfairConfig(_env_file=None)
+            msg = str(exc_info.value)
+            assert "BETFAIR_USERNAME" in msg
+            assert "BETFAIR_PASSWORD" in msg
+
+    def test_betfair_disabled_skips_credential_check(self):
+        """enabled=False with no creds is valid (default state)."""
+        from odds_core.config import BetfairConfig
+
+        with patch.dict(os.environ, {"BETFAIR_ENABLED": "false"}, clear=True):
+            cfg = BetfairConfig(_env_file=None)
+            assert cfg.enabled is False

--- a/tests/unit/test_fetch_betfair_exchange.py
+++ b/tests/unit/test_fetch_betfair_exchange.py
@@ -7,13 +7,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from odds_lambda.betfair.client import BetfairBook
 from odds_lambda.betfair.constants import SPORT_CONFIG
-from odds_lambda.jobs.fetch_betfair_exchange import (
-    CLOSING_INTERVAL_HOURS,
-    FAR_INTERVAL_HOURS,
-    PREGAME_INTERVAL_HOURS,
-    _interval_for_kickoff,
-    _should_skip_book,
-)
+from odds_lambda.jobs.fetch_betfair_exchange import SCHEDULE, _should_skip_book
 
 
 def _book(
@@ -48,24 +42,26 @@ def _book(
     )
 
 
-class TestIntervalForKickoff:
+class TestBetfairSchedule:
+    """Validate the BFE-specific ProximitySchedule values."""
+
     def test_no_kickoff_returns_far(self) -> None:
-        assert _interval_for_kickoff(None) == FAR_INTERVAL_HOURS
+        assert SCHEDULE.interval_for(None) == SCHEDULE.far
 
     def test_imminent_kickoff_returns_closing(self) -> None:
         now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
         ko = now + timedelta(hours=2)  # < 3h => CLOSING
-        assert _interval_for_kickoff(ko, now=now) == CLOSING_INTERVAL_HOURS
+        assert SCHEDULE.interval_for(ko, now=now) == SCHEDULE.closing
 
     def test_pregame_window(self) -> None:
         now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
         ko = now + timedelta(hours=6)
-        assert _interval_for_kickoff(ko, now=now) == PREGAME_INTERVAL_HOURS
+        assert SCHEDULE.interval_for(ko, now=now) == SCHEDULE.pregame
 
     def test_far_out_kickoff(self) -> None:
         now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
         ko = now + timedelta(hours=24)
-        assert _interval_for_kickoff(ko, now=now) == FAR_INTERVAL_HOURS
+        assert SCHEDULE.interval_for(ko, now=now) == SCHEDULE.far
 
 
 class TestShouldSkipBook:

--- a/tests/unit/test_fetch_betfair_exchange.py
+++ b/tests/unit/test_fetch_betfair_exchange.py
@@ -1,0 +1,87 @@
+"""Tests for fetch_betfair_exchange job helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from odds_lambda.betfair.client import BetfairBook
+from odds_lambda.betfair.constants import SPORT_CONFIG
+from odds_lambda.jobs.fetch_betfair_exchange import (
+    CLOSING_INTERVAL_HOURS,
+    FAR_INTERVAL_HOURS,
+    PREGAME_INTERVAL_HOURS,
+    _interval_for_kickoff,
+    _should_skip_book,
+)
+
+
+def _book(
+    *,
+    inplay: bool = False,
+    status: str = "OPEN",
+    runners_count: int = 3,
+) -> BetfairBook:
+    from odds_lambda.betfair.client import BetfairRunner
+
+    runners = [
+        BetfairRunner(
+            selection_id=i,
+            runner_name=f"R{i}",
+            best_back=2.0,
+            best_lay=2.05,
+            back_size=10.0,
+            lay_size=10.0,
+            last_price_traded=2.0,
+        )
+        for i in range(runners_count)
+    ]
+    return BetfairBook(
+        market_id="1.x",
+        betfair_event_id="x",
+        betfair_event_name="A v B",
+        market_start_time=datetime(2026, 4, 25, 14, 0, tzinfo=UTC),
+        market_status=status,
+        inplay=inplay,
+        total_matched=1000.0,
+        runners=runners,
+    )
+
+
+class TestIntervalForKickoff:
+    def test_no_kickoff_returns_far(self) -> None:
+        assert _interval_for_kickoff(None) == FAR_INTERVAL_HOURS
+
+    def test_imminent_kickoff_returns_closing(self) -> None:
+        now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+        ko = now + timedelta(hours=2)  # < 3h => CLOSING
+        assert _interval_for_kickoff(ko, now=now) == CLOSING_INTERVAL_HOURS
+
+    def test_pregame_window(self) -> None:
+        now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+        ko = now + timedelta(hours=6)
+        assert _interval_for_kickoff(ko, now=now) == PREGAME_INTERVAL_HOURS
+
+    def test_far_out_kickoff(self) -> None:
+        now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+        ko = now + timedelta(hours=24)
+        assert _interval_for_kickoff(ko, now=now) == FAR_INTERVAL_HOURS
+
+
+class TestShouldSkipBook:
+    def test_inplay_skipped(self) -> None:
+        assert _should_skip_book(_book(inplay=True), SPORT_CONFIG["soccer_epl"])
+
+    @pytest.mark.parametrize("status", ["CLOSED", "INACTIVE", "closed"])
+    def test_closed_skipped(self, status: str) -> None:
+        assert _should_skip_book(_book(status=status), SPORT_CONFIG["soccer_epl"])
+
+    def test_open_3way_kept(self) -> None:
+        assert not _should_skip_book(_book(runners_count=3), SPORT_CONFIG["soccer_epl"])
+
+    def test_2way_for_3way_market_skipped(self) -> None:
+        # EPL is 3-way h2h, but only 2 runners → skip (corrupt)
+        assert _should_skip_book(_book(runners_count=2), SPORT_CONFIG["soccer_epl"])
+
+    def test_2way_for_2way_market_kept(self) -> None:
+        assert not _should_skip_book(_book(runners_count=2), SPORT_CONFIG["baseball_mlb"])

--- a/tests/unit/test_fetch_oddsportal_scheduling.py
+++ b/tests/unit/test_fetch_oddsportal_scheduling.py
@@ -9,59 +9,52 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from odds_lambda.fetch_tier import FetchTier
-from odds_lambda.jobs.fetch_oddsportal import (
-    CLOSING_INTERVAL_HOURS,
-    DB_FALLBACK_INTERVAL_HOURS,
-    FAR_INTERVAL_HOURS,
-    PREGAME_INTERVAL_HOURS,
-    _interval_for_kickoff,
-    main,
-)
+from odds_lambda.jobs.fetch_oddsportal import SCHEDULE, main
 from odds_lambda.scheduling.jobs import JobContext
 
 
 class TestIntervalForKickoff:
-    """Tests for _interval_for_kickoff proximity logic."""
+    """Tests for the OddsPortal SCHEDULE proximity bands."""
 
     def test_no_upcoming_games_returns_far_interval(self) -> None:
-        assert _interval_for_kickoff(None) == FAR_INTERVAL_HOURS
+        assert SCHEDULE.interval_for(None) == SCHEDULE.far
 
     def test_game_within_closing_window(self) -> None:
         now = datetime(2026, 4, 7, 14, 0, tzinfo=UTC)
         kickoff = now + timedelta(hours=1)
-        assert _interval_for_kickoff(kickoff, now=now) == CLOSING_INTERVAL_HOURS
+        assert SCHEDULE.interval_for(kickoff, now=now) == SCHEDULE.closing
 
     def test_game_at_closing_boundary(self) -> None:
         now = datetime(2026, 4, 7, 14, 0, tzinfo=UTC)
-        # Exactly at 3h boundary — should be closing (< 3h is false, so pregame)
+        # Exactly at 3h boundary — should be pregame (< 3h is false)
         kickoff = now + timedelta(hours=FetchTier.CLOSING.max_hours)
-        assert _interval_for_kickoff(kickoff, now=now) == PREGAME_INTERVAL_HOURS
+        assert SCHEDULE.interval_for(kickoff, now=now) == SCHEDULE.pregame
 
     def test_game_just_under_closing_threshold(self) -> None:
         now = datetime(2026, 4, 7, 14, 0, tzinfo=UTC)
         kickoff = now + timedelta(hours=2.99)
-        assert _interval_for_kickoff(kickoff, now=now) == CLOSING_INTERVAL_HOURS
+        assert SCHEDULE.interval_for(kickoff, now=now) == SCHEDULE.closing
 
     def test_game_in_pregame_window(self) -> None:
         now = datetime(2026, 4, 7, 14, 0, tzinfo=UTC)
         kickoff = now + timedelta(hours=6)
-        assert _interval_for_kickoff(kickoff, now=now) == PREGAME_INTERVAL_HOURS
+        assert SCHEDULE.interval_for(kickoff, now=now) == SCHEDULE.pregame
 
     def test_game_at_pregame_boundary(self) -> None:
         now = datetime(2026, 4, 7, 14, 0, tzinfo=UTC)
         kickoff = now + timedelta(hours=FetchTier.PREGAME.max_hours)
-        assert _interval_for_kickoff(kickoff, now=now) == FAR_INTERVAL_HOURS
+        assert SCHEDULE.interval_for(kickoff, now=now) == SCHEDULE.far
 
     def test_game_far_away(self) -> None:
         now = datetime(2026, 4, 7, 14, 0, tzinfo=UTC)
         kickoff = now + timedelta(hours=24)
-        assert _interval_for_kickoff(kickoff, now=now) == FAR_INTERVAL_HOURS
+        assert SCHEDULE.interval_for(kickoff, now=now) == SCHEDULE.far
 
     def test_game_already_started(self) -> None:
         now = datetime(2026, 4, 7, 14, 0, tzinfo=UTC)
         kickoff = now - timedelta(hours=1)
         # Negative hours_until — should still return closing interval
-        assert _interval_for_kickoff(kickoff, now=now) == CLOSING_INTERVAL_HOURS
+        assert SCHEDULE.interval_for(kickoff, now=now) == SCHEDULE.closing
 
 
 class TestProximityScheduling:
@@ -255,7 +248,7 @@ class TestProximityScheduling:
         first_call = mock_backend.schedule_next_execution.call_args_list[0]
         scheduled_time = first_call.kwargs["next_time"]
         delta_hours = (scheduled_time - now).total_seconds() / 3600
-        assert 0.9 <= delta_hours <= DB_FALLBACK_INTERVAL_HOURS + 0.1
+        assert 0.9 <= delta_hours <= SCHEDULE.db_fallback + 0.1
 
     @pytest.mark.asyncio
     async def test_closing_game_schedules_30min(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -357,6 +357,18 @@ wheels = [
 ]
 
 [[package]]
+name = "betfairlightweight"
+version = "2.23.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/9b/1a259af561f0dc86937ceca339a1a3b9d06f9a859c140318f6a2d3001cd9/betfairlightweight-2.23.2.tar.gz", hash = "sha256:44439f5bb67a9f6344ef70d7a14af2e4886b39a113e6295fbf734c6384eb1c3c", size = 219835, upload-time = "2026-03-16T09:38:47.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/41/de88d8f194c5219be408d450a472e28f53fb97f2d06e748ebf7a30b3d9b6/betfairlightweight-2.23.2-py3-none-any.whl", hash = "sha256:5411f64c0e6f72c882bc7723c1d52661d60ef87053a07dd949fe8e4e9982c5eb", size = 69529, upload-time = "2026-03-16T09:38:45.666Z" },
+]
+
+[[package]]
 name = "betting-odds-pipeline"
 version = "0.1.0"
 source = { virtual = "." }
@@ -3071,6 +3083,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "alembic" },
     { name = "apscheduler" },
+    { name = "betfairlightweight" },
     { name = "boto3" },
     { name = "fake-useragent" },
     { name = "nba-api" },
@@ -3086,6 +3099,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "apscheduler", specifier = "==4.0.0a6" },
+    { name = "betfairlightweight", specifier = ">=2.23.2" },
     { name = "boto3", specifier = ">=1.34.0" },
     { name = "fake-useragent", specifier = ">=2.2.0" },
     { name = "nba-api", specifier = ">=1.1.0" },


### PR DESCRIPTION
## Summary

- Restores `betfair_exchange` as a sharp benchmark by ingesting Match Odds directly via the Betfair Exchange API for both EPL (1x2) and MLB (h2h), replacing the indirect-via-OddsPortal path that broke 2026-04-21 when OP moved exchange odds to a separate encrypted endpoint.
- New `odds_lambda.betfair` package (cert-based auth, sport-parameterised event/market-book discovery, adapter into the canonical `bookmakers[].key=\"betfair_exchange\"` shape) plus a self-scheduling `fetch_betfair_exchange` job wired into the per-sport scheduler for `soccer_epl` and `baseball_mlb`.
- Existing consumers (`find_retail_edges`, hybrid Pinnacle+BFE sharp fallback) pick up the new rows unchanged via the canonical bookmaker key.

## Architecture notes

- **Auth**: cert-based non-interactive login (`identitysso-cert.betfair.com`) when `BETFAIR_CERT_FILE`/`BETFAIR_CERT_KEY` are set; falls back to `login_interactive` otherwise (dev only — prompts 2FA). `.gitignore` excludes `.betfair/` and `secrets/` so the cert pair can never be committed.
- **Cadence**: `*/30 * * * *` safety-floor cron, with proximity-based self-scheduling (15min closing tier `<3h` to KO, 30min pregame tier 3–12h, 2h far tier). Pre-schedules **before** fetching so a crash mid-run can't break the chain.
- **Storage**: writes a single `bookmakers[]` entry with `key=\"betfair_exchange\"`, `markets[0].key=\"1x2\"` for EPL or `\"h2h\"` for MLB, American prices via `decimal_to_american`, plus a `betfair_meta` block (`market_id`, `total_matched`, per-runner LTP+sizes). `raw_data.source=\"betfair_api\"` for provenance. Uses `find_or_create_event(home, away, commence_time)` against existing `op_live_*` events.
- **Bootstrap default updated**: `fetch-betfair-exchange` added to `SchedulerConfig.bootstrap_jobs` so the local scheduler installs both per-sport cron entries on start.

## Verified end-to-end against local DB

- **Cert login**: works against the live API with the kwargs corrected (`cert_files=(crt, key)`; the `betfairlightweight` `certs=` kwarg is a directory, not a tuple).
- **EPL**: 6/6 upcoming events ingested, 3-way prices (e.g. `Man Utd −112 / Brentford +330 / Draw +300`, `total_matched=£24,728`).
- **MLB**: 13/13 today's games ingested, 2-way h2h with home/away swapped to canonical order. Pitcher `(TBD)` annotations stripped.
- **In-play / closed** markets correctly skipped. **SUSPENDED** markets are kept (BFE state during brief trading pauses; price still valid pre-match).
- Self-scheduling tightened to 15min for MLB (games <2h away) and 2h for EPL (next fixture Mon Apr 27 19:00).

## Test plan

- [x] Unit tests: 43/44 pass (the single failure is the pre-existing `test_settings_defaults` Discord webhook leak documented in memory; my bootstrap assertion update passes).
- [x] Live cert login + listEvents/listMarketBook against the Betfair API (EPL+MLB).
- [x] Job `main()` invoked end-to-end against local Postgres for both sports; `odds_snapshots` rows verified for shape, prices, `total_matched`, and `betfair_meta`.
- [x] `ruff check` + `ruff format` clean.
- [ ] After merge: set `BETFAIR_CERT_FILE`/`BETFAIR_CERT_KEY` to **absolute** paths in the prod env (Lambda cwd is `/var/task`, the local dev `.betfair/...` relative path won't resolve).
- [ ] After merge: confirm `betfair_login_cert` (not `betfair_login_interactive`) appears in CloudWatch on the first prod run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)