### PR TITLE
Resolve retail/sharp prices via per-bookmaker lookback (#364)

### DIFF
--- a/packages/odds-lambda/odds_lambda/storage/readers.py
+++ b/packages/odds-lambda/odds_lambda/storage/readers.py
@@ -828,10 +828,17 @@ class OddsReader:
 
             age_seconds = round((ref_time - snapshot.snapshot_time).total_seconds(), 1)
 
+            # Dedup is first-wins both across and within snapshots: snapshots
+            # are walked newest-first, so the first time a
+            # ``(bookmaker_key, outcome_name, point)`` tuple is seen its price
+            # is locked in. Within-snapshot duplicates (the same tuple
+            # repeated inside one bookmaker block) are not expected in
+            # well-formed ``raw_data``; if they ever occur the earlier entry
+            # in the iteration order wins.
             for o in odds:
                 key = (o.bookmaker_key, o.outcome_name, o.point)
                 if key in book_result.entries:
-                    continue  # already resolved from a newer snapshot
+                    continue
                 book_result.entries[key] = BookPriceEntry(
                     odds=o,
                     meta=BookPriceMeta(

--- a/packages/odds-lambda/odds_lambda/storage/readers.py
+++ b/packages/odds-lambda/odds_lambda/storage/readers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 
 import structlog
@@ -16,6 +17,40 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from odds_lambda.fetch_tier import FetchTier
 
 logger = structlog.get_logger()
+
+
+@dataclass
+class BookPriceMeta:
+    """Metadata about a per-bookmaker price found via lookback search.
+
+    Mirrors :class:`SharpPriceMeta` so consumers can handle staleness
+    uniformly across sharp and retail prices.
+    """
+
+    snapshot_id: int
+    snapshot_time: datetime
+    age_seconds: float
+
+
+@dataclass
+class BookPriceEntry:
+    """A single per-bookmaker price with its provenance."""
+
+    odds: Odds
+    meta: BookPriceMeta
+
+
+@dataclass
+class BookPriceResult:
+    """Per-bookmaker prices resolved across a time window of snapshots.
+
+    ``entries`` maps ``(bookmaker_key, outcome_name, point)`` to the newest
+    price for that tuple within the lookback window, along with provenance
+    metadata. Tuples for which no snapshot in the window contained the book
+    are absent from the mapping.
+    """
+
+    entries: dict[tuple[str, str, float | None], BookPriceEntry] = field(default_factory=dict)
 
 
 class OddsReader:
@@ -726,6 +761,87 @@ class OddsReader:
                 break
 
         return sharp_result
+
+    async def get_latest_book_prices(
+        self,
+        event_id: str,
+        market: str,
+        lookback_hours: float = 2.0,
+        *,
+        now: datetime | None = None,
+    ) -> BookPriceResult:
+        """Return the newest price per bookmaker within a lookback window.
+
+        Scans snapshots within ``[now - lookback_hours, now]`` newest-first.
+        For each unique ``(bookmaker_key, outcome_name, point)`` tuple, keeps
+        the first (newest) price seen. Books absent from every snapshot in
+        the window do not appear in the result.
+
+        Robust to multiple writer streams — when one stream produces a
+        snapshot containing only a subset of books (e.g. a Betfair Exchange
+        direct-ingestion row) and another, slightly older stream produced a
+        snapshot with the broader retail book set, both contribute their
+        most recent prices.
+
+        Args:
+            event_id: Event identifier.
+            market: Market key (e.g. ``"h2h"``, ``"1x2"``).
+            lookback_hours: How far back to search (default 2 h).
+            now: Reference time for the lookback window. Defaults to
+                ``datetime.now(UTC)``. Exposed for testing and for
+                data-relative anchoring (e.g. anchor on the latest snapshot
+                time so the window is independent of clock drift).
+
+        Returns:
+            A :class:`BookPriceResult` mapping each
+            ``(bookmaker_key, outcome_name, point)`` tuple to its newest
+            ``Odds`` row in the window plus :class:`BookPriceMeta`
+            (``snapshot_id``, ``snapshot_time``, ``age_seconds``).
+        """
+        ref_time = now or datetime.now(UTC)
+        window_start = ref_time - timedelta(hours=lookback_hours)
+
+        query = (
+            select(OddsSnapshot)
+            .where(
+                and_(
+                    OddsSnapshot.event_id == event_id,
+                    OddsSnapshot.snapshot_time >= window_start,
+                    OddsSnapshot.snapshot_time <= ref_time,
+                )
+            )
+            .order_by(OddsSnapshot.snapshot_time.desc())
+        )
+
+        result = await self.session.execute(query)
+        snapshots = list(result.scalars().all())
+
+        book_result = BookPriceResult()
+
+        for snapshot in snapshots:
+            if not raw_data_has_market(snapshot.raw_data, market):
+                continue
+
+            odds = extract_odds_from_snapshot(snapshot, event_id, market=market)
+            if not odds:
+                continue
+
+            age_seconds = round((ref_time - snapshot.snapshot_time).total_seconds(), 1)
+
+            for o in odds:
+                key = (o.bookmaker_key, o.outcome_name, o.point)
+                if key in book_result.entries:
+                    continue  # already resolved from a newer snapshot
+                book_result.entries[key] = BookPriceEntry(
+                    odds=o,
+                    meta=BookPriceMeta(
+                        snapshot_id=snapshot.id,
+                        snapshot_time=snapshot.snapshot_time,
+                        age_seconds=age_seconds,
+                    ),
+                )
+
+        return book_result
 
     async def get_games_by_date(
         self, target_date: datetime, status: EventStatus | None = EventStatus.FINAL

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -96,7 +96,12 @@ def _event_to_dict(event: Event) -> dict[str, Any]:
 
 
 def _odds_to_dict(odds: Odds) -> dict[str, Any]:
-    """Serialize an Odds object to a JSON-safe dict."""
+    """Serialize an Odds object to a JSON-safe dict.
+
+    Includes ``last_update`` (the bookmaker's self-reported update time from
+    ``raw_data``) so callers can judge per-book freshness independently of
+    the contributing snapshot's wall-clock time.
+    """
     return {
         "bookmaker_key": odds.bookmaker_key,
         "bookmaker_title": odds.bookmaker_title,
@@ -104,6 +109,7 @@ def _odds_to_dict(odds: Odds) -> dict[str, Any]:
         "outcome_name": odds.outcome_name,
         "price": odds.price,
         "point": odds.point,
+        "last_update": odds.last_update.isoformat() if odds.last_update else None,
     }
 
 
@@ -209,12 +215,20 @@ async def get_current_odds(
     alongside its ``last_update`` from ``raw_data`` so callers can judge
     per-book staleness.
 
+    Anchor metadata (``anchor_snapshot_id``, ``anchor_created_at``,
+    ``anchor_fetch_tier``, ``anchor_hours_until_commence``) describes the
+    latest snapshot used to anchor the lookback window. It is **not**
+    aggregated across surfaced rows — surfaced ``odds`` may span several
+    older snapshots. ``bookmaker_count`` is derived from the surfaced rows
+    (count of distinct ``bookmaker_key`` values) so it always matches what
+    the caller sees.
+
     Args:
         event_id: Event identifier.
         market: Market type — "h2h" (2-way moneyline), "1x2" (3-way with
             draw), "totals", or "spreads".
         include_raw_data: If True, also include the full raw_data JSON blob
-            of the newest contributing snapshot.
+            of the anchor (newest) snapshot.
         lookback_hours: How far back to search for per-bookmaker prices
             (default 2.0 h).
 
@@ -248,7 +262,6 @@ async def get_current_odds(
         # Capture all data we need from ORM objects while the session is open.
         anchor_snapshot_id = latest_snapshot.id
         anchor_snapshot_created_at = latest_snapshot.created_at
-        anchor_bookmaker_count = latest_snapshot.bookmaker_count
         anchor_fetch_tier = latest_snapshot.fetch_tier
         anchor_hours_until_commence = latest_snapshot.hours_until_commence
         anchor_raw_data = latest_snapshot.raw_data if include_raw_data else None
@@ -280,14 +293,19 @@ async def get_current_odds(
             }
         )
 
+    # Bookmaker count is derived from surfaced rows (distinct keys) so the
+    # field always agrees with the visible odds[] — not from the anchor
+    # snapshot, which can be misleading when retail rows span older snapshots.
+    bookmaker_count = len({o["bookmaker_key"] for o in odds_dicts})
+
     snapshot_dict: dict[str, Any] = {
-        "id": anchor_snapshot_id,
+        "anchor_snapshot_id": anchor_snapshot_id,
         "event_id": event_id,
         "snapshot_time": newest_snapshot_time.isoformat(),
-        "created_at": anchor_snapshot_created_at.isoformat(),
-        "bookmaker_count": anchor_bookmaker_count,
-        "fetch_tier": anchor_fetch_tier,
-        "hours_until_commence": anchor_hours_until_commence,
+        "anchor_created_at": anchor_snapshot_created_at.isoformat(),
+        "bookmaker_count": bookmaker_count,
+        "anchor_fetch_tier": anchor_fetch_tier,
+        "anchor_hours_until_commence": anchor_hours_until_commence,
         "lookback_hours": lookback_hours,
         "odds": odds_dicts,
     }
@@ -973,6 +991,7 @@ async def find_retail_edges(
             "sharp_bookmakers": sharp_bms,
             "per_outcome": [],
             "retail_edges": [],
+            "message": "No retail bookmakers in lookback window",
         }
 
     # Top-level snapshot_time = max across surfaced retail snapshot times.

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -32,7 +32,7 @@ from odds_lambda.paper_trading import (
     place_trade,
     settle_trades,
 )
-from odds_lambda.storage.readers import OddsReader
+from odds_lambda.storage.readers import BookPriceEntry, OddsReader
 from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
@@ -192,17 +192,35 @@ async def get_current_odds(
     event_id: str,
     market: MarketKey,
     include_raw_data: bool = False,
+    lookback_hours: float = 2.0,
 ) -> dict[str, Any]:
-    """Get the latest odds snapshot for an event, showing current bookmaker prices.
+    """Get the latest odds for an event, resolved per-bookmaker over a lookback window.
+
+    For each ``(bookmaker_key, outcome_name, point)`` tuple, returns the
+    newest price within ``[latest_snapshot_time - lookback_hours,
+    latest_snapshot_time]``. This is robust to multiple writer streams: when
+    a Betfair Exchange direct-ingestion snapshot wins the latest-snapshot
+    race but contains only BFE, retail prices from an older snapshot in the
+    window are still surfaced.
+
+    The top-level ``snapshot_time`` is the newest contributing snapshot in
+    the window (max of surfaced book snapshot times). Each bookmaker entry
+    additionally surfaces the contributing snapshot's ``snapshot_time``
+    alongside its ``last_update`` from ``raw_data`` so callers can judge
+    per-book staleness.
 
     Args:
         event_id: Event identifier.
         market: Market type — "h2h" (2-way moneyline), "1x2" (3-way with
             draw), "totals", or "spreads".
-        include_raw_data: If True, also include the full raw_data JSON blob.
+        include_raw_data: If True, also include the full raw_data JSON blob
+            of the newest contributing snapshot.
+        lookback_hours: How far back to search for per-bookmaker prices
+            (default 2.0 h).
 
     Returns:
-        Dict with event info and the latest snapshot with structured odds.
+        Dict with event info and the resolved snapshot view with structured
+        odds (per-book ``snapshot_time`` and ``book_age_seconds`` fields).
     """
     async with async_session_maker() as session:
         reader = OddsReader(session)
@@ -210,20 +228,75 @@ async def get_current_odds(
         if event is None:
             return {"error": f"Event '{event_id}' not found"}
 
-        snapshot = await reader.get_latest_snapshot(event_id, market=market)
-        if snapshot is None:
+        # Anchor the lookback window on the latest snapshot time so the
+        # window is data-relative, not clock-relative.
+        latest_snapshot = await reader.get_latest_snapshot(event_id, market=market)
+        if latest_snapshot is None:
             return {
                 "event": _event_to_dict(event),
                 "snapshot": None,
                 "message": "No odds snapshots available for this event",
             }
 
-    odds = extract_odds_from_snapshot(snapshot, event_id, market=market)
+        book_result = await reader.get_latest_book_prices(
+            event_id,
+            market=market,
+            lookback_hours=lookback_hours,
+            now=latest_snapshot.snapshot_time,
+        )
+
+        # Capture all data we need from ORM objects while the session is open.
+        anchor_snapshot_id = latest_snapshot.id
+        anchor_snapshot_created_at = latest_snapshot.created_at
+        anchor_bookmaker_count = latest_snapshot.bookmaker_count
+        anchor_fetch_tier = latest_snapshot.fetch_tier
+        anchor_hours_until_commence = latest_snapshot.hours_until_commence
+        anchor_raw_data = latest_snapshot.raw_data if include_raw_data else None
+        event_dict = _event_to_dict(event)
+
+    if not book_result.entries:
+        return {
+            "event": event_dict,
+            "snapshot": None,
+            "message": f"No {market} odds in lookback window",
+        }
+
+    # Determine the newest contributing snapshot in the window.
+    newest_snapshot_time = max(entry.meta.snapshot_time for entry in book_result.entries.values())
+
+    # Serialize per-bookmaker odds with provenance fields. Sorted by
+    # bookmaker key, outcome name, point (None last) for deterministic output.
+    odds_dicts: list[dict[str, Any]] = []
+    for key in sorted(
+        book_result.entries.keys(),
+        key=lambda k: (k[0], k[1], math.inf if k[2] is None else k[2]),
+    ):
+        entry = book_result.entries[key]
+        odds_dicts.append(
+            {
+                **_odds_to_dict(entry.odds),
+                "snapshot_time": entry.meta.snapshot_time.isoformat(),
+                "book_age_seconds": entry.meta.age_seconds,
+            }
+        )
+
+    snapshot_dict: dict[str, Any] = {
+        "id": anchor_snapshot_id,
+        "event_id": event_id,
+        "snapshot_time": newest_snapshot_time.isoformat(),
+        "created_at": anchor_snapshot_created_at.isoformat(),
+        "bookmaker_count": anchor_bookmaker_count,
+        "fetch_tier": anchor_fetch_tier,
+        "hours_until_commence": anchor_hours_until_commence,
+        "lookback_hours": lookback_hours,
+        "odds": odds_dicts,
+    }
+    if include_raw_data:
+        snapshot_dict["raw_data"] = anchor_raw_data
+
     return {
-        "event": _event_to_dict(event),
-        "snapshot": _snapshot_to_dict(
-            snapshot, include_raw_data=include_raw_data, extracted_odds=odds
-        ),
+        "event": event_dict,
+        "snapshot": snapshot_dict,
     }
 
 
@@ -769,6 +842,7 @@ async def find_retail_edges(
     market: MarketKey,
     sharp_bookmakers: str | list[str] | None = None,
     sharp_lookback_hours: float = 2.0,
+    lookback_hours: float = 2.0,
 ) -> dict[str, Any]:
     """Surface retail books pricing longer than sharp, with dispersion stats.
 
@@ -781,7 +855,23 @@ async def find_retail_edges(
 
     Sharp prices are resolved via a time-windowed lookback across recent
     snapshots so a missing sharp book in the latest scrape does not discard
-    a nearby valid price. Retail prices come from the single latest snapshot.
+    a nearby valid price. Retail prices are likewise resolved per-bookmaker
+    over a lookback window: for each ``(bookmaker_key, outcome, point)``,
+    the newest price within ``[latest_snapshot_time - lookback_hours,
+    latest_snapshot_time]`` is used. This means a Betfair Exchange-only
+    snapshot winning the latest-snapshot race does not hide retail prices
+    from an older snapshot in the same window.
+
+    Each retail row carries ``snapshot_time`` and ``book_age_seconds``
+    mirroring ``sharp_snapshot_time`` / ``sharp_age_seconds``. The top-level
+    ``snapshot_time`` is the newest contributing retail snapshot in the
+    window (max of surfaced book snapshot times). Because per-book prices
+    can come from different snapshots, dispersion stats
+    (``median_divergence``, ``dispersion_stddev``, ``z_score``) are computed
+    across non-co-temporal prices. The trade-off is acceptable for the
+    default 2 h pre-match window — line moves within that window are
+    typically small relative to retail dispersion — but consumers should
+    weight ``dispersion_stddev`` accordingly when the window is widened.
 
     ``z_score`` per retail entry is ``(divergence - median_divergence) /
     dispersion_stddev`` computed across that outcome's retail books; ``null``
@@ -795,16 +885,20 @@ async def find_retail_edges(
         market: Market type — "h2h", "1x2", "totals", or "spreads".
         sharp_bookmakers: Sharp bookmaker keys (default: ["pinnacle", "betfair_exchange"]).
         sharp_lookback_hours: How far back to search for sharp prices (default 2.0 h).
+        lookback_hours: How far back to search for retail prices, per
+            bookmaker (default 2.0 h).
 
     Returns:
-        Dict with ``event``, ``snapshot_time``, ``sharp_bookmakers`` (the
-        configured input list; per-outcome resolution under the hybrid
-        fallback is visible via ``sharp_snapshot_time`` / ``sharp_age_seconds``
-        on each ``per_outcome`` row), ``per_outcome`` (flat array keyed by
+        Dict with ``event``, ``snapshot_time`` (newest contributing retail
+        snapshot in the window), ``sharp_bookmakers`` (the configured input
+        list; per-outcome sharp resolution under the hybrid fallback is
+        visible via ``sharp_snapshot_time`` / ``sharp_age_seconds`` on each
+        ``per_outcome`` row), ``per_outcome`` (flat array keyed by
         ``(outcome, point)``), and ``retail_edges`` (flat array of
-        negative-divergence entries sorted ascending by divergence; ties
-        broken by ``z_score`` ascending — more-negative first — then
-        ``book``, ``outcome``, and ``point`` for full determinism).
+        negative-divergence entries with per-row ``snapshot_time`` /
+        ``book_age_seconds``, sorted ascending by divergence; ties broken
+        by ``z_score`` ascending — more-negative first — then ``book``,
+        ``outcome``, and ``point`` for full determinism).
     """
     sharp_bms = _coerce_bookmaker_list(sharp_bookmakers) or _DEFAULT_SHARP_BOOKMAKERS
 
@@ -814,9 +908,10 @@ async def find_retail_edges(
         if event is None:
             return {"error": f"Event '{event_id}' not found"}
 
-        # Retail prices: latest snapshot only
-        snapshot = await reader.get_latest_snapshot(event_id, market=market)
-        if snapshot is None:
+        # Anchor lookback windows on the latest snapshot time so they are
+        # data-relative, not clock-relative.
+        latest_snapshot = await reader.get_latest_snapshot(event_id, market=market)
+        if latest_snapshot is None:
             return {
                 "event": _event_to_dict(event),
                 "snapshot_time": None,
@@ -826,41 +921,68 @@ async def find_retail_edges(
                 "message": "No odds snapshots available for this event",
             }
 
-        # Sharp prices: lookback across recent snapshots, anchored on the
-        # latest snapshot time so the window is data-relative, not clock-relative.
+        # Sharp prices: lookback across recent snapshots.
         sharp_result = await reader.get_sharp_prices(
             event_id,
             market=market,
             sharp_bookmakers=sharp_bms,
             lookback_hours=sharp_lookback_hours,
-            now=snapshot.snapshot_time,
+            now=latest_snapshot.snapshot_time,
         )
 
-        # Extract retail odds and metadata while ORM objects are live
-        odds = extract_odds_from_snapshot(snapshot, event_id, market=market)
-        snapshot_time_iso = snapshot.snapshot_time.isoformat()
+        # Retail prices: per-bookmaker latest within the lookback window.
+        book_result = await reader.get_latest_book_prices(
+            event_id,
+            market=market,
+            lookback_hours=lookback_hours,
+            now=latest_snapshot.snapshot_time,
+        )
+
         event_dict = _event_to_dict(event)
 
-    if not odds:
+    sharp_set = set(sharp_bms)
+
+    # Build per-(outcome, point) buckets of retail odds, dropping sharp books.
+    # Each retail row carries provenance from its contributing snapshot.
+    buckets: dict[tuple[str, float | None], list[BookPriceEntry]] = {}
+    for (bookmaker_key, _outcome, _point), entry in book_result.entries.items():
+        if bookmaker_key in sharp_set:
+            continue
+        o = entry.odds
+        buckets.setdefault((o.outcome_name, o.point), []).append(entry)
+
+    if not buckets:
+        # Either no odds in the window, or every book in the window is sharp.
+        if not book_result.entries:
+            return {
+                "event": event_dict,
+                "snapshot_time": None,
+                "sharp_bookmakers": sharp_bms,
+                "per_outcome": [],
+                "retail_edges": [],
+                "message": f"No {market} odds in lookback window",
+            }
+        # All books were sharp — newest contributing snapshot is still
+        # informative for the response envelope.
+        snapshot_time_iso = max(
+            e.meta.snapshot_time for e in book_result.entries.values()
+        ).isoformat()
         return {
             "event": event_dict,
             "snapshot_time": snapshot_time_iso,
             "sharp_bookmakers": sharp_bms,
             "per_outcome": [],
             "retail_edges": [],
-            "message": f"No {market} odds in latest snapshot",
         }
 
-    sharp_by_outcome = sharp_result.prices
-    sharp_set = set(sharp_bms)
+    # Top-level snapshot_time = max across surfaced retail snapshot times.
+    retail_snapshot_times = [e.meta.snapshot_time for entries in buckets.values() for e in entries]
+    snapshot_time_iso = max(retail_snapshot_times).isoformat()
 
-    # Group retail odds by (outcome_name, point). Totals with multiple point
-    # values produce one bucket per (outcome, point); h2h / 1x2 have point=None.
-    buckets: dict[tuple[str, float | None], list[Odds]] = {}
-    for o in odds:
-        if o.bookmaker_key in sharp_set:
-            continue
-        buckets.setdefault((o.outcome_name, o.point), []).append(o)
+    sharp_by_outcome = sharp_result.prices
+
+    # Flat list of all retail odds (across buckets) for per-book hold calc.
+    odds: list[Odds] = [e.odds for entries in buckets.values() for e in entries]
 
     # Per-book market hold is only meaningful for single-line markets; totals /
     # spreads span multiple lines, so computing it event-wide would conflate them.
@@ -882,20 +1004,22 @@ async def find_retail_edges(
         outcome_name, point = key
         return (outcome_name, math.inf if point is None else point)
 
-    for (outcome_name, point), outcome_odds in sorted(buckets.items(), key=_bucket_sort_key):
+    for (outcome_name, point), outcome_entries in sorted(buckets.items(), key=_bucket_sort_key):
         sharp_entry = sharp_by_outcome.get(outcome_name)
         sharp_prob = sharp_entry["implied_prob"] if sharp_entry else None
         sharp_meta = sharp_result.meta.get(outcome_name) if sharp_entry else None
 
-        # Build per-book retail rows for this (outcome, point) bucket.
-        # Deduplicate on bookmaker_key (last entry wins — matches per_book_market_holds).
-        by_book: dict[str, Odds] = {}
-        for o in outcome_odds:
-            by_book[o.bookmaker_key] = o
+        # Build per-book retail rows for this (outcome, point) bucket. The
+        # reader already keyed by (bookmaker_key, outcome_name, point), so
+        # entries here are unique per book within this bucket.
+        by_book: dict[str, BookPriceEntry] = {}
+        for entry in outcome_entries:
+            by_book[entry.odds.bookmaker_key] = entry
 
         retail_rows: list[dict[str, Any]] = []
         for bm_key in sorted(by_book):
-            o = by_book[bm_key]
+            entry = by_book[bm_key]
+            o = entry.odds
             retail_prob = round(calculate_implied_probability(o.price), 6)
             divergence = round(retail_prob - sharp_prob, 6) if sharp_prob is not None else None
             market_hold = (
@@ -912,6 +1036,8 @@ async def find_retail_edges(
                     # z_score filled in below once dispersion is known
                     "z_score": None,
                     "market_hold": market_hold,
+                    "snapshot_time": entry.meta.snapshot_time.isoformat(),
+                    "book_age_seconds": entry.meta.age_seconds,
                 }
             )
 

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -890,6 +890,10 @@ async def find_retail_edges(
     default 2 h pre-match window — line moves within that window are
     typically small relative to retail dispersion — but consumers should
     weight ``dispersion_stddev`` accordingly when the window is widened.
+    Consumers should likewise weight ``book_age_seconds`` when sizing: a
+    retail row from an older snapshot (e.g. a 60-min-old OP scrape with a
+    newer BFE-only snapshot in between) may no longer be takeable because
+    the bookmaker has since moved its line.
 
     ``z_score`` per retail entry is ``(divergence - median_divergence) /
     dispersion_stddev`` computed across that outcome's retail books; ``null``
@@ -1028,17 +1032,15 @@ async def find_retail_edges(
         sharp_prob = sharp_entry["implied_prob"] if sharp_entry else None
         sharp_meta = sharp_result.meta.get(outcome_name) if sharp_entry else None
 
-        # Build per-book retail rows for this (outcome, point) bucket. The
-        # reader already keyed by (bookmaker_key, outcome_name, point), so
-        # entries here are unique per book within this bucket.
-        by_book: dict[str, BookPriceEntry] = {}
-        for entry in outcome_entries:
-            by_book[entry.odds.bookmaker_key] = entry
-
+        # Build per-book retail rows for this (outcome, point) bucket.
+        # ``book_result.entries`` is already keyed by
+        # ``(bookmaker_key, outcome_name, point)``, so each entry in this
+        # bucket has a unique ``bookmaker_key`` by construction — iterate
+        # directly in ``bookmaker_key`` order for deterministic output.
         retail_rows: list[dict[str, Any]] = []
-        for bm_key in sorted(by_book):
-            entry = by_book[bm_key]
+        for entry in sorted(outcome_entries, key=lambda e: e.odds.bookmaker_key):
             o = entry.odds
+            bm_key = o.bookmaker_key
             retail_prob = round(calculate_implied_probability(o.price), 6)
             divergence = round(retail_prob - sharp_prob, 6) if sharp_prob is not None else None
             market_hold = (

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -1292,6 +1292,29 @@ class TestFindRetailEdgesPerBookmakerLookback:
         # all retail came from snap_op so it equals snap_op.snapshot_time
         assert result["snapshot_time"] == snap_op.snapshot_time.isoformat()
 
+    @pytest.mark.asyncio
+    async def test_lookback_hours_override_excludes_older_snapshot(
+        self, patch_session_maker, bfe_newest_with_older_retail_event
+    ):
+        """A short ``lookback_hours`` override excludes the older OP snapshot.
+
+        The OP snapshot (pinnacle + 17 retail) is at T-90min and the BFE
+        anchor at T-30min. With ``lookback_hours=0.5`` (30 min) the window
+        is ``[T-60min, T-30min]`` — only BFE is in range, so no retail books
+        survive the sharp filter and ``retail_edges`` is empty.
+        """
+        from odds_mcp.server import find_retail_edges
+
+        event, _snap_op, _snap_bfe, _retail_books = bfe_newest_with_older_retail_event
+
+        result = await find_retail_edges(event_id=event.id, market="1x2", lookback_hours=0.5)
+
+        assert "error" not in result
+        assert result["per_outcome"] == []
+        assert result["retail_edges"] == []
+        # Only sharp (BFE) was in window, so the no-retail message is surfaced
+        assert result.get("message") == "No retail bookmakers in lookback window"
+
 
 class TestGetCurrentOddsPerBookmakerLookback:
     """get_current_odds resolves per-bookmaker prices over a lookback window."""

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -1332,3 +1332,170 @@ class TestGetCurrentOddsPerBookmakerLookback:
         # Top-level snapshot_time = newest contributing snapshot (BFE)
         assert snapshot["snapshot_time"] == snap_bfe.snapshot_time.isoformat()
         assert snapshot["lookback_hours"] == 2.0
+
+    @pytest.mark.asyncio
+    async def test_bookmaker_count_reflects_surfaced_rows(
+        self, patch_session_maker, bfe_newest_with_older_retail_event
+    ):
+        """``bookmaker_count`` is derived from surfaced rows, not the anchor
+        snapshot. In the BFE-newer scenario the response surfaces 19 books
+        (1 BFE + 1 pinnacle + 17 retail) even though the anchor snapshot has
+        only 1 book."""
+        from odds_mcp.server import get_current_odds
+
+        event, _snap_op, _snap_bfe, retail_books = bfe_newest_with_older_retail_event
+
+        result = await get_current_odds(event_id=event.id, market="1x2")
+        snapshot = result["snapshot"]
+        assert snapshot is not None
+
+        # 19 unique bookmakers: betfair_exchange (BFE) + pinnacle + 17 retail.
+        # The anchor BFE snapshot only has 1 book — the response field reflects
+        # the wider per-bookmaker lookback union, not the anchor.
+        unique_books = {o["bookmaker_key"] for o in snapshot["odds"]}
+        assert len(unique_books) == snapshot["bookmaker_count"]
+        assert snapshot["bookmaker_count"] == 1 + 1 + len(retail_books)
+
+    @pytest.mark.asyncio
+    async def test_anchor_fields_describe_anchor_snapshot(
+        self, patch_session_maker, bfe_newest_with_older_retail_event
+    ):
+        """``anchor_*`` fields describe the latest (BFE) snapshot — not
+        aggregated across surfaced rows."""
+        from odds_mcp.server import get_current_odds
+
+        event, _snap_op, snap_bfe, _retail_books = bfe_newest_with_older_retail_event
+
+        result = await get_current_odds(event_id=event.id, market="1x2")
+        snapshot = result["snapshot"]
+        assert snapshot is not None
+
+        assert snapshot["anchor_snapshot_id"] == snap_bfe.id
+        assert snapshot["anchor_created_at"] == snap_bfe.created_at.isoformat()
+        assert snapshot["anchor_fetch_tier"] == snap_bfe.fetch_tier
+        assert snapshot["anchor_hours_until_commence"] == snap_bfe.hours_until_commence
+
+    @pytest.mark.asyncio
+    async def test_lookback_hours_override_excludes_older_snapshot(
+        self, patch_session_maker, bfe_newest_with_older_retail_event
+    ):
+        """A short ``lookback_hours`` override excludes the older OP snapshot.
+
+        The OP snapshot is at T-90min and the BFE anchor at T-30min. With
+        ``lookback_hours=0.5`` (30 min) the window is
+        ``[T-60min, T-30min]`` — only BFE is in range, so the response
+        surfaces 1 book (just betfair_exchange) instead of 18.
+        """
+        from odds_mcp.server import get_current_odds
+
+        event, _snap_op, snap_bfe, _retail_books = bfe_newest_with_older_retail_event
+
+        result = await get_current_odds(event_id=event.id, market="1x2", lookback_hours=0.5)
+        snapshot = result["snapshot"]
+        assert snapshot is not None
+
+        books_surfaced = {o["bookmaker_key"] for o in snapshot["odds"]}
+        assert books_surfaced == {"betfair_exchange"}
+        assert snapshot["lookback_hours"] == 0.5
+        # Newest contributing snapshot is BFE
+        assert snapshot["snapshot_time"] == snap_bfe.snapshot_time.isoformat()
+
+    @pytest.mark.asyncio
+    async def test_per_book_last_update_surfaced(
+        self, patch_session_maker, bfe_newest_with_older_retail_event
+    ):
+        """Each surfaced row carries ``last_update`` from ``raw_data``."""
+        from odds_mcp.server import get_current_odds
+
+        event, _snap_op, _snap_bfe, _retail_books = bfe_newest_with_older_retail_event
+
+        result = await get_current_odds(event_id=event.id, market="1x2")
+        snapshot = result["snapshot"]
+        assert snapshot is not None
+
+        for row in snapshot["odds"]:
+            assert "last_update" in row
+            assert row["last_update"] is not None
+
+    @pytest.mark.asyncio
+    async def test_totals_multiple_points_produce_distinct_entries(
+        self, patch_session_maker, pglite_async_session
+    ):
+        """A totals snapshot where one book has Over@2.5 and Over@3.0 produces
+        two surfaced entries for that book (keyed by point)."""
+        from odds_mcp.server import get_current_odds
+
+        commence_time = datetime(2026, 4, 27, 15, 0, tzinfo=UTC)
+        event = Event(
+            id="totals_points_test_001",
+            sport_key="baseball_mlb",
+            sport_title="MLB",
+            commence_time=commence_time,
+            home_team="Yankees",
+            away_team="Red Sox",
+            status=EventStatus.SCHEDULED,
+        )
+        pglite_async_session.add(event)
+
+        snapshot_time = commence_time - timedelta(hours=3)
+        raw_data = {
+            "bookmakers": [
+                {
+                    "key": "bet365",
+                    "title": "Bet365",
+                    "last_update": snapshot_time.isoformat(),
+                    "markets": [
+                        {
+                            "key": "totals",
+                            "outcomes": [
+                                {"name": "Over", "price": -110, "point": 2.5},
+                                {"name": "Under", "price": -110, "point": 2.5},
+                                {"name": "Over", "price": +120, "point": 3.0},
+                                {"name": "Under", "price": -140, "point": 3.0},
+                            ],
+                        }
+                    ],
+                },
+            ]
+        }
+        snapshot = OddsSnapshot(
+            event_id=event.id,
+            snapshot_time=snapshot_time,
+            raw_data=raw_data,
+            bookmaker_count=1,
+            fetch_tier="pregame",
+            hours_until_commence=3.0,
+        )
+        pglite_async_session.add(snapshot)
+        await pglite_async_session.commit()
+        await pglite_async_session.refresh(event)
+
+        result = await get_current_odds(event_id=event.id, market="totals")
+        odds = result["snapshot"]["odds"]
+
+        bet365_over = [
+            o for o in odds if o["bookmaker_key"] == "bet365" and o["outcome_name"] == "Over"
+        ]
+        bet365_under = [
+            o for o in odds if o["bookmaker_key"] == "bet365" and o["outcome_name"] == "Under"
+        ]
+        assert {row["point"] for row in bet365_over} == {2.5, 3.0}
+        assert {row["point"] for row in bet365_under} == {2.5, 3.0}
+
+    @pytest.mark.asyncio
+    async def test_include_raw_data_returns_anchor_raw_data(
+        self, patch_session_maker, bfe_newest_with_older_retail_event
+    ):
+        """``include_raw_data=True`` returns the anchor (BFE) snapshot's raw_data."""
+        from odds_mcp.server import get_current_odds
+
+        event, _snap_op, snap_bfe, _retail_books = bfe_newest_with_older_retail_event
+
+        result = await get_current_odds(event_id=event.id, market="1x2", include_raw_data=True)
+        snapshot = result["snapshot"]
+        assert snapshot is not None
+
+        assert "raw_data" in snapshot
+        assert snapshot["raw_data"] == snap_bfe.raw_data
+        # The anchor snapshot is BFE-only — raw_data has just one bookmaker
+        assert {bm["key"] for bm in snapshot["raw_data"]["bookmakers"]} == {"betfair_exchange"}

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -610,6 +610,8 @@ class TestFindRetailEdges:
                 "divergence",
                 "z_score",
                 "market_hold",
+                "snapshot_time",
+                "book_age_seconds",
             }
 
     @pytest.mark.asyncio
@@ -1132,3 +1134,201 @@ class TestFindRetailEdgesSharpLookback:
             # best_retail/worst_retail still populated but with null divergence/z_score
             assert entry["best_retail"]["divergence"] is None
             assert entry["best_retail"]["z_score"] is None
+
+
+@pytest.fixture
+async def bfe_newest_with_older_retail_event(pglite_async_session):
+    """Event where a BFE-only snapshot is newer than an OP retail+sharp snapshot.
+
+    Reproduces the production scenario from issue #364: ``fetch_betfair_exchange``
+    writes a Betfair-Exchange-only snapshot that wins the latest-snapshot race,
+    while the older OddsPortal snapshot containing 17 retail books would be
+    invisible without per-bookmaker lookback resolution.
+    """
+    commence_time = datetime(2026, 4, 26, 15, 0, tzinfo=UTC)
+    event = Event(
+        id="epl_bfe_newest_001",
+        sport_key="soccer_epl",
+        sport_title="EPL",
+        commence_time=commence_time,
+        home_team="Brighton",
+        away_team="Wolves",
+        status=EventStatus.SCHEDULED,
+    )
+    pglite_async_session.add(event)
+
+    # Older OP snapshot at T-90min: pinnacle + 17 retail books
+    op_time = commence_time - timedelta(minutes=90)
+    retail_books = [
+        "bet365",
+        "betway",
+        "betfred",
+        "betvictor",
+        "bwin",
+        "paddypower",
+        "skybet",
+        "williamhill",
+        "10bet",
+        "betmgm",
+        "888sport",
+        "midnite",
+        "betuk",
+        "spreadex",
+        "betano",
+        "unibet_uk",
+        "allbritishcasino",
+    ]
+    op_bookmakers = [
+        {
+            "key": "pinnacle",
+            "title": "Pinnacle",
+            "last_update": op_time.isoformat(),
+            "markets": [
+                {
+                    "key": "1x2",
+                    "outcomes": [
+                        {"name": "Brighton", "price": -140},
+                        {"name": "Draw", "price": 270},
+                        {"name": "Wolves", "price": 350},
+                    ],
+                }
+            ],
+        }
+    ]
+    for book in retail_books:
+        op_bookmakers.append(
+            {
+                "key": book,
+                "title": book.title(),
+                "last_update": op_time.isoformat(),
+                "markets": [
+                    {
+                        "key": "1x2",
+                        "outcomes": [
+                            {"name": "Brighton", "price": -130},
+                            {"name": "Draw", "price": 280},
+                            {"name": "Wolves", "price": 360},
+                        ],
+                    }
+                ],
+            }
+        )
+
+    snap_op = OddsSnapshot(
+        event_id=event.id,
+        snapshot_time=op_time,
+        raw_data={"bookmakers": op_bookmakers},
+        bookmaker_count=len(op_bookmakers),
+        fetch_tier="pregame",
+        hours_until_commence=1.5,
+    )
+    pglite_async_session.add(snap_op)
+
+    # Newer BFE-only snapshot at T-30min — wins latest-snapshot race
+    bfe_time = commence_time - timedelta(minutes=30)
+    snap_bfe = OddsSnapshot(
+        event_id=event.id,
+        snapshot_time=bfe_time,
+        raw_data={
+            "bookmakers": [
+                {
+                    "key": "betfair_exchange",
+                    "title": "Betfair Exchange",
+                    "last_update": bfe_time.isoformat(),
+                    "markets": [
+                        {
+                            "key": "1x2",
+                            "outcomes": [
+                                {"name": "Brighton", "price": -135},
+                                {"name": "Draw", "price": 275},
+                                {"name": "Wolves", "price": 355},
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
+        bookmaker_count=1,
+        fetch_tier="pregame",
+        hours_until_commence=0.5,
+    )
+    pglite_async_session.add(snap_bfe)
+
+    await pglite_async_session.commit()
+    await pglite_async_session.refresh(event)
+    await pglite_async_session.refresh(snap_op)
+    await pglite_async_session.refresh(snap_bfe)
+    return event, snap_op, snap_bfe, retail_books
+
+
+class TestFindRetailEdgesPerBookmakerLookback:
+    """Per-bookmaker lookback isolates retail data from BFE-only snapshot races."""
+
+    @pytest.mark.asyncio
+    async def test_bfe_newest_does_not_hide_older_retail(
+        self, patch_session_maker, bfe_newest_with_older_retail_event
+    ):
+        """A BFE-only newer snapshot must not hide 17 retail books from an
+        older OP snapshot in the lookback window."""
+        from odds_mcp.server import find_retail_edges
+
+        event, snap_op, _snap_bfe, retail_books = bfe_newest_with_older_retail_event
+
+        result = await find_retail_edges(event_id=event.id, market="1x2")
+
+        assert "error" not in result
+
+        # All 17 retail books surface on each outcome
+        for outcome_name in ("Brighton", "Draw", "Wolves"):
+            bucket = next(e for e in result["per_outcome"] if e["outcome"] == outcome_name)
+            assert bucket["n_books"] == 17
+
+        # Each retail row carries provenance to the OP snapshot
+        brighton = next(e for e in result["per_outcome"] if e["outcome"] == "Brighton")
+        assert brighton["best_retail"]["snapshot_time"] == snap_op.snapshot_time.isoformat()
+        assert brighton["best_retail"]["book_age_seconds"] is not None
+
+        # Top-level snapshot_time = newest contributing retail snapshot — here
+        # all retail came from snap_op so it equals snap_op.snapshot_time
+        assert result["snapshot_time"] == snap_op.snapshot_time.isoformat()
+
+
+class TestGetCurrentOddsPerBookmakerLookback:
+    """get_current_odds resolves per-bookmaker prices over a lookback window."""
+
+    @pytest.mark.asyncio
+    async def test_bfe_newest_does_not_hide_older_retail(
+        self, patch_session_maker, bfe_newest_with_older_retail_event
+    ):
+        """get_current_odds includes both BFE (newer) and the 17 retail books
+        (older) when both fall within the lookback window."""
+        from odds_mcp.server import get_current_odds
+
+        event, snap_op, snap_bfe, retail_books = bfe_newest_with_older_retail_event
+
+        result = await get_current_odds(event_id=event.id, market="1x2")
+
+        assert "error" not in result
+        snapshot = result["snapshot"]
+        assert snapshot is not None
+
+        odds = snapshot["odds"]
+        books_surfaced = {o["bookmaker_key"] for o in odds}
+
+        # All 17 retail books and BFE present
+        assert "betfair_exchange" in books_surfaced
+        for book in retail_books:
+            assert book in books_surfaced
+
+        # Per-row snapshot_time provenance: BFE from newer, retail from older
+        bfe_rows = [o for o in odds if o["bookmaker_key"] == "betfair_exchange"]
+        for row in bfe_rows:
+            assert row["snapshot_time"] == snap_bfe.snapshot_time.isoformat()
+
+        bet365_rows = [o for o in odds if o["bookmaker_key"] == "bet365"]
+        for row in bet365_rows:
+            assert row["snapshot_time"] == snap_op.snapshot_time.isoformat()
+
+        # Top-level snapshot_time = newest contributing snapshot (BFE)
+        assert snapshot["snapshot_time"] == snap_bfe.snapshot_time.isoformat()
+        assert snapshot["lookback_hours"] == 2.0

--- a/tests/unit/test_get_latest_book_prices.py
+++ b/tests/unit/test_get_latest_book_prices.py
@@ -1,0 +1,476 @@
+"""Tests for OddsReader.get_latest_book_prices per-bookmaker lookback resolution."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from odds_core.models import Event, EventStatus, OddsSnapshot
+from odds_lambda.storage.readers import BookPriceResult, OddsReader
+
+
+def _make_event(event_id: str = "evt-1") -> Event:
+    return Event(
+        id=event_id,
+        sport_key="soccer_epl",
+        sport_title="EPL",
+        commence_time=datetime(2026, 4, 25, 15, 0, tzinfo=UTC),
+        home_team="Brighton",
+        away_team="Wolves",
+        status=EventStatus.SCHEDULED,
+    )
+
+
+def _make_raw_data(
+    bookmakers: list[dict[str, object]],
+    snapshot_time: datetime,
+    market_key: str = "1x2",
+) -> dict:
+    """Build a raw_data blob from a compact bookmaker spec.
+
+    Each entry in *bookmakers* is ``{"key": str, "outcomes": list[dict]}``.
+    """
+    return {
+        "bookmakers": [
+            {
+                "key": bm["key"],
+                "title": str(bm["key"]).title(),
+                "last_update": snapshot_time.isoformat(),
+                "markets": [{"key": market_key, "outcomes": bm["outcomes"]}],
+            }
+            for bm in bookmakers
+        ]
+    }
+
+
+def _make_snapshot(
+    event_id: str,
+    snapshot_time: datetime,
+    bookmakers: list[dict[str, object]],
+) -> OddsSnapshot:
+    return OddsSnapshot(
+        event_id=event_id,
+        snapshot_time=snapshot_time,
+        raw_data=_make_raw_data(bookmakers, snapshot_time),
+        bookmaker_count=len(bookmakers),
+        fetch_tier="pregame",
+        hours_until_commence=2.0,
+    )
+
+
+# Standard 17-book retail panel mirroring the OddsPortal scrape coverage
+# documented in CLAUDE.md (~30 bookmakers per snapshot, including these 17).
+_RETAIL_BOOKS_17 = [
+    "bet365",
+    "betway",
+    "betfred",
+    "betvictor",
+    "bwin",
+    "paddypower",
+    "skybet",
+    "williamhill",
+    "10bet",
+    "betmgm",
+    "888sport",
+    "midnite",
+    "betuk",
+    "spreadex",
+    "betano",
+    "unibet_uk",
+    "allbritishcasino",
+]
+
+
+def _retail_panel(prices: dict[str, int]) -> list[dict[str, object]]:
+    """Build the 17-retail-book bookmaker spec sharing a common price set.
+
+    *prices* maps outcome name to American odds.
+    """
+    return [
+        {
+            "key": book,
+            "outcomes": [{"name": name, "price": price} for name, price in prices.items()],
+        }
+        for book in _RETAIL_BOOKS_17
+    ]
+
+
+class TestGetLatestBookPrices:
+    """Per-bookmaker latest-within-lookback resolution."""
+
+    @pytest.mark.asyncio
+    async def test_bfe_row_newer_than_op_row_surfaces_17_retail(self, test_session) -> None:
+        """When a Betfair-Exchange-only snapshot wins the latest-snapshot race,
+        the older OP snapshot's 17 retail books are still surfaced.
+        """
+        event = _make_event()
+        test_session.add(event)
+        await test_session.flush()
+
+        anchor = datetime(2026, 4, 25, 13, 0, tzinfo=UTC)
+
+        # Older OP snapshot: 17 retail books + pinnacle
+        op_time = anchor - timedelta(minutes=30)
+        op_snapshot = _make_snapshot(
+            event.id,
+            op_time,
+            [
+                {
+                    "key": "pinnacle",
+                    "outcomes": [
+                        {"name": "Brighton", "price": -140},
+                        {"name": "Draw", "price": 270},
+                        {"name": "Wolves", "price": 350},
+                    ],
+                },
+                *_retail_panel({"Brighton": -130, "Draw": 280, "Wolves": 360}),
+            ],
+        )
+
+        # Newer BFE-only snapshot
+        bfe_time = anchor - timedelta(minutes=5)
+        bfe_snapshot = _make_snapshot(
+            event.id,
+            bfe_time,
+            [
+                {
+                    "key": "betfair_exchange",
+                    "outcomes": [
+                        {"name": "Brighton", "price": -135},
+                        {"name": "Draw", "price": 275},
+                        {"name": "Wolves", "price": 355},
+                    ],
+                }
+            ],
+        )
+
+        test_session.add_all([op_snapshot, bfe_snapshot])
+        await test_session.flush()
+
+        reader = OddsReader(test_session)
+        result = await reader.get_latest_book_prices(
+            event.id, market="1x2", lookback_hours=2.0, now=anchor
+        )
+
+        assert isinstance(result, BookPriceResult)
+
+        # All 17 retail books surface, each with all 3 outcomes
+        retail_books_surfaced = {
+            bm
+            for (bm, _outcome, _point) in result.entries.keys()
+            if bm not in {"pinnacle", "betfair_exchange"}
+        }
+        assert retail_books_surfaced == set(_RETAIL_BOOKS_17)
+        assert len(retail_books_surfaced) == 17
+
+        # bet365 has all three outcomes from the older OP snapshot
+        for outcome in ("Brighton", "Draw", "Wolves"):
+            entry = result.entries[("bet365", outcome, None)]
+            assert entry.meta.snapshot_time == op_time
+
+        # BFE entries come from the newer snapshot
+        bfe_entry = result.entries[("betfair_exchange", "Brighton", None)]
+        assert bfe_entry.meta.snapshot_time == bfe_time
+
+    @pytest.mark.asyncio
+    async def test_book_a_only_in_older_book_b_only_in_newer_both_surfaced(
+        self, test_session
+    ) -> None:
+        """Book A only appears in the N-2 snapshot, book B only in N. Both
+        surface with provenance pointing to their respective snapshots.
+        """
+        event = _make_event()
+        test_session.add(event)
+        await test_session.flush()
+
+        anchor = datetime(2026, 4, 25, 13, 0, tzinfo=UTC)
+        old_time = anchor - timedelta(minutes=40)
+        new_time = anchor - timedelta(minutes=5)
+
+        old_snapshot = _make_snapshot(
+            event.id,
+            old_time,
+            [
+                {
+                    "key": "book_a",
+                    "outcomes": [
+                        {"name": "Brighton", "price": -150},
+                        {"name": "Draw", "price": 250},
+                        {"name": "Wolves", "price": 320},
+                    ],
+                }
+            ],
+        )
+
+        new_snapshot = _make_snapshot(
+            event.id,
+            new_time,
+            [
+                {
+                    "key": "book_b",
+                    "outcomes": [
+                        {"name": "Brighton", "price": -140},
+                        {"name": "Draw", "price": 260},
+                        {"name": "Wolves", "price": 340},
+                    ],
+                }
+            ],
+        )
+
+        test_session.add_all([old_snapshot, new_snapshot])
+        await test_session.flush()
+
+        reader = OddsReader(test_session)
+        result = await reader.get_latest_book_prices(
+            event.id, market="1x2", lookback_hours=2.0, now=anchor
+        )
+
+        # Both books present, with provenance to their respective snapshots
+        for outcome in ("Brighton", "Draw", "Wolves"):
+            assert result.entries[("book_a", outcome, None)].meta.snapshot_time == old_time
+            assert result.entries[("book_b", outcome, None)].meta.snapshot_time == new_time
+
+    @pytest.mark.asyncio
+    async def test_book_in_both_snapshots_only_newest_surfaced(self, test_session) -> None:
+        """When the same bookmaker appears in both N-2 and N, only the newer
+        price is surfaced (one row per (book, outcome, point))."""
+        event = _make_event()
+        test_session.add(event)
+        await test_session.flush()
+
+        anchor = datetime(2026, 4, 25, 13, 0, tzinfo=UTC)
+        old_time = anchor - timedelta(minutes=40)
+        new_time = anchor - timedelta(minutes=5)
+
+        # Same book, different prices in old vs new
+        old_snapshot = _make_snapshot(
+            event.id,
+            old_time,
+            [
+                {
+                    "key": "bet365",
+                    "outcomes": [
+                        {"name": "Brighton", "price": -150},
+                        {"name": "Draw", "price": 250},
+                        {"name": "Wolves", "price": 320},
+                    ],
+                }
+            ],
+        )
+
+        new_snapshot = _make_snapshot(
+            event.id,
+            new_time,
+            [
+                {
+                    "key": "bet365",
+                    "outcomes": [
+                        {"name": "Brighton", "price": -130},
+                        {"name": "Draw", "price": 280},
+                        {"name": "Wolves", "price": 360},
+                    ],
+                }
+            ],
+        )
+
+        test_session.add_all([old_snapshot, new_snapshot])
+        await test_session.flush()
+
+        reader = OddsReader(test_session)
+        result = await reader.get_latest_book_prices(
+            event.id, market="1x2", lookback_hours=2.0, now=anchor
+        )
+
+        # Only the newer price surfaces, with provenance to the newer snapshot
+        brighton = result.entries[("bet365", "Brighton", None)]
+        assert brighton.odds.price == -130
+        assert brighton.meta.snapshot_time == new_time
+
+        draw = result.entries[("bet365", "Draw", None)]
+        assert draw.odds.price == 280
+        assert draw.meta.snapshot_time == new_time
+
+        wolves = result.entries[("bet365", "Wolves", None)]
+        assert wolves.odds.price == 360
+        assert wolves.meta.snapshot_time == new_time
+
+        # Exactly 3 entries — one per outcome, no duplicates from the older snapshot
+        bet365_keys = [k for k in result.entries.keys() if k[0] == "bet365"]
+        assert len(bet365_keys) == 3
+
+    @pytest.mark.asyncio
+    async def test_book_absent_from_window_not_surfaced(self, test_session) -> None:
+        """A snapshot outside [now - lookback_hours, now] does not contribute."""
+        event = _make_event()
+        test_session.add(event)
+        await test_session.flush()
+
+        anchor = datetime(2026, 4, 25, 13, 0, tzinfo=UTC)
+
+        # In-window snapshot has bet365
+        in_window_time = anchor - timedelta(minutes=30)
+        in_window_snapshot = _make_snapshot(
+            event.id,
+            in_window_time,
+            [
+                {
+                    "key": "bet365",
+                    "outcomes": [
+                        {"name": "Brighton", "price": -130},
+                        {"name": "Draw", "price": 280},
+                        {"name": "Wolves", "price": 360},
+                    ],
+                }
+            ],
+        )
+
+        # Out-of-window snapshot (5 hours before anchor) has betway
+        out_of_window_time = anchor - timedelta(hours=5)
+        out_of_window_snapshot = _make_snapshot(
+            event.id,
+            out_of_window_time,
+            [
+                {
+                    "key": "betway",
+                    "outcomes": [
+                        {"name": "Brighton", "price": -120},
+                        {"name": "Draw", "price": 290},
+                        {"name": "Wolves", "price": 380},
+                    ],
+                }
+            ],
+        )
+
+        test_session.add_all([in_window_snapshot, out_of_window_snapshot])
+        await test_session.flush()
+
+        reader = OddsReader(test_session)
+        result = await reader.get_latest_book_prices(
+            event.id, market="1x2", lookback_hours=2.0, now=anchor
+        )
+
+        # bet365 (in-window) surfaces; betway (out-of-window) does not
+        books_surfaced = {bm for (bm, _outcome, _point) in result.entries.keys()}
+        assert "bet365" in books_surfaced
+        assert "betway" not in books_surfaced
+
+    @pytest.mark.asyncio
+    async def test_market_filter_skips_other_markets(self, test_session) -> None:
+        """Snapshots not containing the requested market key are skipped."""
+        event = _make_event()
+        test_session.add(event)
+        await test_session.flush()
+
+        anchor = datetime(2026, 4, 25, 13, 0, tzinfo=UTC)
+        snap_time = anchor - timedelta(minutes=30)
+
+        # Only totals data — no 1x2 market
+        snap = OddsSnapshot(
+            event_id=event.id,
+            snapshot_time=snap_time,
+            raw_data=_make_raw_data(
+                [
+                    {
+                        "key": "bet365",
+                        "outcomes": [
+                            {"name": "Over", "price": -110, "point": 2.5},
+                            {"name": "Under", "price": -110, "point": 2.5},
+                        ],
+                    }
+                ],
+                snap_time,
+                market_key="totals",
+            ),
+            bookmaker_count=1,
+            fetch_tier="pregame",
+            hours_until_commence=2.0,
+        )
+        test_session.add(snap)
+        await test_session.flush()
+
+        reader = OddsReader(test_session)
+        result = await reader.get_latest_book_prices(
+            event.id, market="1x2", lookback_hours=2.0, now=anchor
+        )
+
+        assert result.entries == {}
+
+    @pytest.mark.asyncio
+    async def test_age_seconds_anchored_on_now(self, test_session) -> None:
+        """age_seconds is computed from the supplied ``now`` argument."""
+        event = _make_event()
+        test_session.add(event)
+        await test_session.flush()
+
+        anchor = datetime(2026, 4, 25, 13, 0, tzinfo=UTC)
+        snap_time = anchor - timedelta(minutes=10)
+
+        snap = _make_snapshot(
+            event.id,
+            snap_time,
+            [
+                {
+                    "key": "bet365",
+                    "outcomes": [
+                        {"name": "Brighton", "price": -130},
+                    ],
+                }
+            ],
+        )
+        test_session.add(snap)
+        await test_session.flush()
+
+        reader = OddsReader(test_session)
+        result = await reader.get_latest_book_prices(
+            event.id, market="1x2", lookback_hours=2.0, now=anchor
+        )
+
+        entry = result.entries[("bet365", "Brighton", None)]
+        # 10 minutes = 600 seconds
+        assert entry.meta.age_seconds == pytest.approx(600.0, abs=0.5)
+
+    @pytest.mark.asyncio
+    async def test_totals_keyed_per_point(self, test_session) -> None:
+        """Same bookmaker on the same outcome but different points produces
+        separate entries."""
+        event = _make_event()
+        test_session.add(event)
+        await test_session.flush()
+
+        anchor = datetime(2026, 4, 25, 13, 0, tzinfo=UTC)
+        snap_time = anchor - timedelta(minutes=15)
+
+        snap = OddsSnapshot(
+            event_id=event.id,
+            snapshot_time=snap_time,
+            raw_data=_make_raw_data(
+                [
+                    {
+                        "key": "bet365",
+                        "outcomes": [
+                            {"name": "Over", "price": -110, "point": 2.5},
+                            {"name": "Over", "price": +120, "point": 3.5},
+                            {"name": "Under", "price": -110, "point": 2.5},
+                            {"name": "Under", "price": -140, "point": 3.5},
+                        ],
+                    }
+                ],
+                snap_time,
+                market_key="totals",
+            ),
+            bookmaker_count=1,
+            fetch_tier="pregame",
+            hours_until_commence=2.0,
+        )
+        test_session.add(snap)
+        await test_session.flush()
+
+        reader = OddsReader(test_session)
+        result = await reader.get_latest_book_prices(
+            event.id, market="totals", lookback_hours=2.0, now=anchor
+        )
+
+        # Distinct keys for each (bookmaker, outcome, point) tuple
+        assert ("bet365", "Over", 2.5) in result.entries
+        assert ("bet365", "Over", 3.5) in result.entries
+        assert ("bet365", "Under", 2.5) in result.entries
+        assert ("bet365", "Under", 3.5) in result.entries
+        assert len(result.entries) == 4

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -661,20 +661,53 @@ class TestFindRetailEdges:
         }
         return result
 
-    def _mock_reader(self, sharp_result: MagicMock | None = None) -> AsyncMock:
+    def _make_book_result(
+        self,
+        odds: list[MagicMock],
+        snapshot_time: datetime | None = None,
+    ) -> MagicMock:
+        """Build a BookPriceResult-like mock from a flat list of Odds mocks."""
+        from odds_lambda.storage.readers import BookPriceEntry, BookPriceMeta, BookPriceResult
+
+        snap_time = snapshot_time or datetime(2026, 4, 12, 10, 0, tzinfo=UTC)
+        entries: dict[tuple[str, str, float | None], BookPriceEntry] = {}
+        for o in odds:
+            key = (o.bookmaker_key, o.outcome_name, o.point)
+            # Newer entries (later in the list) win — matches reader semantics
+            entries[key] = BookPriceEntry(
+                odds=o,
+                meta=BookPriceMeta(
+                    snapshot_id=1,
+                    snapshot_time=snap_time,
+                    age_seconds=0.0,
+                ),
+            )
+        return BookPriceResult(entries=entries)
+
+    def _mock_reader(
+        self,
+        sharp_result: MagicMock | None = None,
+        book_result: object | None = None,
+    ) -> AsyncMock:
         reader = AsyncMock()
         reader.get_event_by_id = AsyncMock(return_value=self._make_event())
         reader.get_latest_snapshot = AsyncMock(return_value=self._make_snapshot())
         reader.get_sharp_prices = AsyncMock(return_value=sharp_result or self._make_sharp_result())
+        if book_result is not None:
+            reader.get_latest_book_prices = AsyncMock(return_value=book_result)
         return reader
 
     async def _call(self, odds: list, reader: AsyncMock, market: str = "h2h") -> dict:
         from odds_mcp.server import find_retail_edges
 
+        # Build a BookPriceResult from the supplied odds list to feed the
+        # reader's get_latest_book_prices mock — replaces the old
+        # extract_odds_from_snapshot patch.
+        reader.get_latest_book_prices = AsyncMock(return_value=self._make_book_result(odds))
+
         with (
             patch("odds_mcp.server.async_session_maker") as mock_session_maker,
             patch("odds_mcp.server.OddsReader", return_value=reader),
-            patch("odds_mcp.server.extract_odds_from_snapshot", return_value=odds),
         ):
             mock_session_maker.return_value.__aenter__ = AsyncMock()
             mock_session_maker.return_value.__aexit__ = AsyncMock()
@@ -727,6 +760,8 @@ class TestFindRetailEdges:
                     "divergence",
                     "z_score",
                     "market_hold",
+                    "snapshot_time",
+                    "book_age_seconds",
                 }
 
     @pytest.mark.asyncio

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -673,7 +673,11 @@ class TestFindRetailEdges:
         entries: dict[tuple[str, str, float | None], BookPriceEntry] = {}
         for o in odds:
             key = (o.bookmaker_key, o.outcome_name, o.point)
-            # Newer entries (later in the list) win — matches reader semantics
+            # First-wins: matches OddsReader.get_latest_book_prices, which walks
+            # snapshots newest-first and skips a key once already present
+            # (readers.py: ``if key in book_result.entries: continue``).
+            if key in entries:
+                continue
             entries[key] = BookPriceEntry(
                 odds=o,
                 meta=BookPriceMeta(


### PR DESCRIPTION
## Summary

- New `OddsReader.get_latest_book_prices(event_id, market, lookback_hours, *, now=None)` resolves prices per `(bookmaker_key, outcome_name, point)` from the newest snapshot containing each book within `[now − lookback_hours, now]`. Mirrors the structure of `get_sharp_prices` and reuses `extract_odds_from_snapshot` / `raw_data_has_market`. New dataclasses `BookPriceMeta`, `BookPriceEntry`, `BookPriceResult` carry per-book provenance (`snapshot_id`, `snapshot_time`, `age_seconds`).
- `find_retail_edges` and `get_current_odds` rewired to source rows from the new reader instead of `get_latest_snapshot()`. Each retail/bookmaker row now carries `snapshot_time` + `book_age_seconds` (mirroring existing sharp staleness fields), and the top-level `snapshot_time` is the max across surfaced book snapshot times. Both tools take a tunable `lookback_hours: float = 2.0` parameter.
- `get_current_odds` envelope: anchor-derived fields renamed to `anchor_snapshot_id`, `anchor_created_at`, `anchor_fetch_tier`, `anchor_hours_until_commence` to make scope explicit. `bookmaker_count` now derived from surfaced rows. `_odds_to_dict` exposes per-row `last_update` from `raw_data`.
- Sharp resolution via `get_sharp_prices` is unchanged; `find_retail_edges` keeps its sharp-set filter.
- Docstrings updated to describe new lookback semantics, per-row staleness, and the trade-off that dispersion stats are now computed across non-co-temporal prices (acceptable within a 2h pre-match window).

## Why

Before PR #363, OddsPortal scrapes wrote single snapshots containing both retail and sharp books, so reading the latest snapshot row surfaced everything. With direct Betfair Exchange ingestion (`fetch_betfair_exchange`), BFE-only snapshots can win the latest-snapshot race and silently hide the older OP snapshot's retail data from `find_retail_edges` and `get_current_odds`. Per-bookmaker lookback resolution makes both consumers robust to multiple writer streams.

## Tests

- New unit tests in `tests/unit/test_get_latest_book_prices.py` cover the four spec scenarios (BFE-newer surfaces 17 retail; books only in older/newer both surface; same book in both → newest only; out-of-window not surfaced) plus market filtering, age anchoring, and totals point keying.
- Integration tests in `tests/integration/test_mcp_tools.py` exercise BFE-newer end-to-end for both tools, plus `lookback_hours` override, totals multi-point, `last_update` propagation, anchor field semantics, `bookmaker_count` derivation, and `include_raw_data`.

## Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)