### PR TITLE
Split EPL-specific MCP tools into a mounted sub-server

### DIFF
--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -4,6 +4,7 @@ Thin wrappers over existing DB queries, jobs, and paper trading logic.
 All tools are stateless and use async_session_maker() for DB access.
 """
 
+import asyncio
 import json
 import math
 import statistics
@@ -1253,5 +1254,17 @@ async def schedule_next_wakeup(
 mcp.mount(epl_mcp)
 
 
+async def _assert_unique_tool_names() -> None:
+    # Unprefixed mounts mean a child server can silently shadow a parent tool
+    # of the same name — FastMCP returns both entries from ``list_tools`` with
+    # no warning. Fail loudly at startup instead.
+    tools = await mcp.list_tools()
+    names = [t.name for t in tools]
+    duplicates = sorted({n for n in names if names.count(n) > 1})
+    if duplicates:
+        raise RuntimeError(f"Duplicate MCP tool names across mounted servers: {duplicates}")
+
+
 if __name__ == "__main__":
+    asyncio.run(_assert_unique_tool_names())
     mcp.run()

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -15,7 +15,6 @@ from fastmcp import FastMCP
 from odds_analytics.utils import per_book_market_holds
 from odds_core.agent_wakeup_models import AgentWakeup
 from odds_core.database import async_session_maker
-from odds_core.epl_data_models import EspnFixture
 from odds_core.match_brief_models import BriefDecision, MatchBrief, SharpPriceMap
 from odds_core.models import Event, EventStatus, Odds, OddsSnapshot
 from odds_core.odds_math import calculate_implied_probability
@@ -23,8 +22,6 @@ from odds_core.paper_trade_models import PaperTrade
 from odds_core.prediction_models import Prediction
 from odds_core.snapshot_utils import extract_odds_from_snapshot
 from odds_core.sports import SportKey
-from odds_core.team import normalize_team_name
-from odds_lambda.espn_fixture_fetcher import current_season, season_label
 from odds_lambda.jobs.fetch_oddsportal import LEAGUE_SPEC_BY_NAME
 from odds_lambda.paper_trading import (
     get_open_trades,
@@ -35,6 +32,8 @@ from odds_lambda.paper_trading import (
 from odds_lambda.storage.readers import BookPriceEntry, OddsReader
 from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from odds_mcp.tools.epl import epl_mcp
 
 logger = structlog.get_logger()
 
@@ -1249,300 +1248,9 @@ async def schedule_next_wakeup(
     }
 
 
-# ---------------------------------------------------------------------------
-# ESPN fixture context helpers (used by ``get_team_context``)
-# ---------------------------------------------------------------------------
-
-
-# ESPN's canonical match-state enum (``status.type.state``). Used for
-# categorising fixtures as past/live/upcoming.
-_ESPN_STATE_POST = "post"  # completed match (any kind: FT, AET, after pens)
-_ESPN_STATE_IN = "in"  # live match (any in-play status)
-
-# Fallback set for rows written before the ``state`` column was introduced
-# (``state is None``). Values are ESPN's ``status.type.description`` strings
-# that indicate a completed match. Kept narrow — only strings confirmed in
-# live ESPN responses. Matches are intentionally exact; partial matches
-# (e.g. "Final Score") would risk false positives.
-_ESPN_FINAL_STATUS_FALLBACK: frozenset[str] = frozenset(
-    {
-        "Full Time",
-        "Final Score - After Penalties",
-        "Final Score - After Extra Time",
-        "Final",
-    }
-)
-
-_PREMIER_LEAGUE = "Premier League"
-
-
-def _is_final(row: EspnFixture) -> bool:
-    """Return True if ``row`` represents a completed match.
-
-    Prefers ``state == "post"`` when available; falls back to a curated set of
-    ``status`` description strings for rows written before the migration.
-    """
-    if row.state is not None:
-        return row.state == _ESPN_STATE_POST
-    return row.status in _ESPN_FINAL_STATUS_FALLBACK
-
-
-def _is_in_progress(row: EspnFixture) -> bool:
-    """Return True if ``row`` is currently live.
-
-    Only the ``state`` column can distinguish "in" vs "pre" reliably, so rows
-    with ``state is None`` are treated as not-in-progress (the old "In
-    Progress" status string was never persisted on historical rows anyway).
-    """
-    return row.state == _ESPN_STATE_IN
-
-
-def _parse_score(value: str) -> int | None:
-    """Parse an ESPN score string (may be blank or non-numeric).
-
-    Returns ``None`` when the value cannot be interpreted as a non-negative int.
-    """
-    if not value:
-        return None
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError):
-        return None
-    if parsed < 0:
-        return None
-    return parsed
-
-
-def _outcome_for_score(score_team: int, score_opponent: int) -> str:
-    if score_team > score_opponent:
-        return "W"
-    if score_team < score_opponent:
-        return "L"
-    return "D"
-
-
-def _fixture_to_dict(fixture: EspnFixture, *, as_of: datetime) -> dict[str, Any]:
-    """Serialise an EspnFixture for the upcoming-fixtures view."""
-    days_until = (fixture.date - as_of).total_seconds() / 86400.0
-    return {
-        "date": fixture.date.isoformat(),
-        "opponent": fixture.opponent,
-        "home_away": fixture.home_away,
-        "competition": fixture.competition,
-        "status": fixture.status,
-        "days_until_ko": round(days_until, 3),
-    }
-
-
-def _result_to_dict(fixture: EspnFixture) -> dict[str, Any] | None:
-    """Serialise an EspnFixture into a last-results entry.
-
-    Returns ``None`` when the row does not have parseable integer scores (e.g.
-    status is Final but scores are blank/malformed — an ESPN quirk).
-    """
-    score_team = _parse_score(fixture.score_team)
-    score_opponent = _parse_score(fixture.score_opponent)
-    if score_team is None or score_opponent is None:
-        return None
-    return {
-        "date": fixture.date.isoformat(),
-        "opponent": fixture.opponent,
-        "home_away": fixture.home_away,
-        "score_team": score_team,
-        "score_opponent": score_opponent,
-        "outcome": _outcome_for_score(score_team, score_opponent),
-        "competition": fixture.competition,
-    }
-
-
-def _derive_standings(fixtures: list[EspnFixture]) -> dict[str, dict[str, Any]]:
-    """Build a points table keyed by team from a season's Premier League rows.
-
-    The input is the set of EspnFixture rows for the target season. Only rows
-    where ``competition == "Premier League"`` and state is ``"post"`` (or, for
-    legacy rows with no state, a matching fallback status) with parseable
-    scores count. Position is assigned by sorting the team-indexed table by
-    (points desc, goal_diff desc, goals_for desc) — the standard EPL tiebreak
-    chain. Each match contributes to both teams' rows (rows are per team in
-    ``espn_fixtures``).
-    """
-    table: dict[str, dict[str, Any]] = {}
-
-    for fixture in fixtures:
-        if fixture.competition != _PREMIER_LEAGUE:
-            continue
-        if not _is_final(fixture):
-            continue
-        score_team = _parse_score(fixture.score_team)
-        score_opponent = _parse_score(fixture.score_opponent)
-        if score_team is None or score_opponent is None:
-            continue
-
-        row = table.setdefault(
-            fixture.team,
-            {
-                "played": 0,
-                "wins": 0,
-                "draws": 0,
-                "losses": 0,
-                "goals_for": 0,
-                "goals_against": 0,
-            },
-        )
-        row["played"] += 1
-        row["goals_for"] += score_team
-        row["goals_against"] += score_opponent
-        if score_team > score_opponent:
-            row["wins"] += 1
-        elif score_team < score_opponent:
-            row["losses"] += 1
-        else:
-            row["draws"] += 1
-
-    # Finalise derived fields and assign positions.
-    for row in table.values():
-        row["goal_diff"] = row["goals_for"] - row["goals_against"]
-        row["points"] = row["wins"] * 3 + row["draws"]
-
-    ordered = sorted(
-        table.items(),
-        key=lambda item: (
-            -item[1]["points"],
-            -item[1]["goal_diff"],
-            -item[1]["goals_for"],
-            item[0],
-        ),
-    )
-    for position, (team, row) in enumerate(ordered, start=1):
-        row["position"] = position
-        # Duplicate the team name into the row so callers can flatten via
-        # ``sorted(table.values(), ...)`` without losing the dict key.
-        row["team"] = team
-
-    return table
-
-
-@mcp.tool()
-async def get_team_context(
-    team: str,
-    as_of: str | None = None,
-    last_n: int = 5,
-    next_n: int = 5,
-    include_standings: bool = True,
-) -> dict[str, Any]:
-    """Fetch form, upcoming fixtures, and league table position for an EPL team.
-
-    Draws from the ``espn_fixtures`` table (refreshed daily by the
-    ``fetch-espn-fixtures`` job). Returns:
-
-    - ``last_results``: up to ``last_n`` most recent Premier-League-only
-      completed fixtures before ``as_of``, each with score, outcome (W/D/L),
-      home/away. PL-only to keep "form" meaningful — cup results sit in
-      upcoming_fixtures via rotation risk, not form.
-    - ``upcoming_fixtures``: next ``next_n`` fixtures after ``as_of`` across
-      all competitions (PL, FA Cup, League Cup, European) with
-      ``days_until_ko``. This is the rotation-risk signal.
-    - ``standings`` (when ``include_standings=True``): derived on the fly from
-      Premier League completed rows in the current season. Position assigned
-      by a simplified tiebreak chain: points, goal diff, goals for, team name.
-      This omits the official EPL head-to-head step, so ``position`` on a
-      tight 3-way tie at the threshold is approximate — do not over-trust it.
-
-    Live (``state="in"``) rows are skipped from both last_results and
-    upcoming_fixtures; they neither count as form nor as upcoming rotation.
-
-    Args:
-        team: Canonical team name (matches the output of
-            ``odds_core.team.normalize_team_name`` — e.g. "Manchester Utd",
-            "Tottenham", "Wolves"). Common variants are also accepted.
-        as_of: ISO datetime cutoff. Defaults to now. Used to split fixtures
-            into past vs upcoming; also used to compute ``days_until_ko``.
-        last_n: Max last-results entries to return. Clamped to >= 1.
-        next_n: Max upcoming-fixtures entries to return. Clamped to >= 1.
-        include_standings: When True, include the derived table. The returned
-            ``standings.team_row`` is the target team's row; ``standings.table``
-            is the full 20-team ordering.
-
-    Returns:
-        Dict with ``team``, ``as_of``, ``season``, ``last_results``,
-        ``upcoming_fixtures``, and (optionally) ``standings``.
-    """
-    canonical_team = normalize_team_name(team)
-
-    if as_of is None:
-        resolved_as_of = datetime.now(UTC)
-    else:
-        parsed = datetime.fromisoformat(as_of.replace("Z", "+00:00"))
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=UTC)
-        resolved_as_of = parsed
-
-    last_n = max(1, last_n)
-    next_n = max(1, next_n)
-
-    season = current_season(resolved_as_of)
-    season_lbl = season_label(season)
-
-    async with async_session_maker() as session:
-        # Team-scoped rows: drive last_results + upcoming_fixtures.
-        team_query = (
-            select(EspnFixture).where(EspnFixture.team == canonical_team).order_by(EspnFixture.date)
-        )
-        team_result = await session.execute(team_query)
-        team_rows = list(team_result.scalars().all())
-
-        # Season-scoped rows for all teams: drive standings derivation.
-        standings_rows: list[EspnFixture] = []
-        if include_standings:
-            standings_query = (
-                select(EspnFixture)
-                .where(EspnFixture.season == season_lbl)
-                .order_by(EspnFixture.date)
-            )
-            standings_result = await session.execute(standings_query)
-            standings_rows = list(standings_result.scalars().all())
-
-    # Split team_rows into past (final, PL only) and upcoming (any competition,
-    # not started). Live matches ("in") are skipped on both sides.
-    last_results: list[dict[str, Any]] = []
-    upcoming: list[dict[str, Any]] = []
-    for row in team_rows:
-        if _is_in_progress(row):
-            continue
-        if _is_final(row):
-            if row.competition != _PREMIER_LEAGUE:
-                continue
-            if row.date >= resolved_as_of:
-                continue
-            entry = _result_to_dict(row)
-            if entry is not None:
-                last_results.append(entry)
-        elif row.date >= resolved_as_of:
-            # "pre" rows and unknown-state future-dated rows.
-            upcoming.append(_fixture_to_dict(row, as_of=resolved_as_of))
-
-    # Newest-first on last_results; already date-asc on upcoming.
-    last_results.reverse()
-    last_results = last_results[:last_n]
-    upcoming_fixtures = upcoming[:next_n]
-
-    response: dict[str, Any] = {
-        "team": canonical_team,
-        "as_of": resolved_as_of.isoformat(),
-        "season": season_lbl,
-        "last_results": last_results,
-        "upcoming_fixtures": upcoming_fixtures,
-    }
-
-    if include_standings:
-        table = _derive_standings(standings_rows)
-        team_row = table.get(canonical_team)
-        response["standings"] = {
-            "team_row": team_row,
-            "table": sorted(table.values(), key=lambda r: r["position"]),
-        }
-
-    return response
+# Mount sport-specific sub-servers without a namespace so tool names are
+# preserved verbatim (``get_team_context`` stays ``get_team_context``).
+mcp.mount(epl_mcp)
 
 
 if __name__ == "__main__":

--- a/packages/odds-mcp/odds_mcp/tools/__init__.py
+++ b/packages/odds-mcp/odds_mcp/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Sport-specific MCP sub-servers mounted onto the parent ``odds-mcp`` server."""

--- a/packages/odds-mcp/odds_mcp/tools/epl.py
+++ b/packages/odds-mcp/odds_mcp/tools/epl.py
@@ -1,0 +1,313 @@
+"""EPL-specific MCP tools.
+
+Mounted onto the parent ``odds-mcp`` server in :mod:`odds_mcp.server` without a
+namespace, so tool names are exposed verbatim to clients.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+from fastmcp import FastMCP
+from odds_core.database import async_session_maker
+from odds_core.epl_data_models import EspnFixture
+from odds_core.team import normalize_team_name
+from odds_lambda.espn_fixture_fetcher import current_season, season_label
+from sqlalchemy import select
+
+epl_mcp = FastMCP("odds-mcp-epl")
+
+
+# ---------------------------------------------------------------------------
+# ESPN fixture context helpers (used by ``get_team_context``)
+# ---------------------------------------------------------------------------
+
+
+# ESPN's canonical match-state enum (``status.type.state``). Used for
+# categorising fixtures as past/live/upcoming.
+_ESPN_STATE_POST = "post"  # completed match (any kind: FT, AET, after pens)
+_ESPN_STATE_IN = "in"  # live match (any in-play status)
+
+# Fallback set for rows written before the ``state`` column was introduced
+# (``state is None``). Values are ESPN's ``status.type.description`` strings
+# that indicate a completed match. Kept narrow — only strings confirmed in
+# live ESPN responses. Matches are intentionally exact; partial matches
+# (e.g. "Final Score") would risk false positives.
+_ESPN_FINAL_STATUS_FALLBACK: frozenset[str] = frozenset(
+    {
+        "Full Time",
+        "Final Score - After Penalties",
+        "Final Score - After Extra Time",
+        "Final",
+    }
+)
+
+_PREMIER_LEAGUE = "Premier League"
+
+
+def _is_final(row: EspnFixture) -> bool:
+    """Return True if ``row`` represents a completed match.
+
+    Prefers ``state == "post"`` when available; falls back to a curated set of
+    ``status`` description strings for rows written before the migration.
+    """
+    if row.state is not None:
+        return row.state == _ESPN_STATE_POST
+    return row.status in _ESPN_FINAL_STATUS_FALLBACK
+
+
+def _is_in_progress(row: EspnFixture) -> bool:
+    """Return True if ``row`` is currently live.
+
+    Only the ``state`` column can distinguish "in" vs "pre" reliably, so rows
+    with ``state is None`` are treated as not-in-progress (the old "In
+    Progress" status string was never persisted on historical rows anyway).
+    """
+    return row.state == _ESPN_STATE_IN
+
+
+def _parse_score(value: str) -> int | None:
+    """Parse an ESPN score string (may be blank or non-numeric).
+
+    Returns ``None`` when the value cannot be interpreted as a non-negative int.
+    """
+    if not value:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed < 0:
+        return None
+    return parsed
+
+
+def _outcome_for_score(score_team: int, score_opponent: int) -> str:
+    if score_team > score_opponent:
+        return "W"
+    if score_team < score_opponent:
+        return "L"
+    return "D"
+
+
+def _fixture_to_dict(fixture: EspnFixture, *, as_of: datetime) -> dict[str, Any]:
+    """Serialise an EspnFixture for the upcoming-fixtures view."""
+    days_until = (fixture.date - as_of).total_seconds() / 86400.0
+    return {
+        "date": fixture.date.isoformat(),
+        "opponent": fixture.opponent,
+        "home_away": fixture.home_away,
+        "competition": fixture.competition,
+        "status": fixture.status,
+        "days_until_ko": round(days_until, 3),
+    }
+
+
+def _result_to_dict(fixture: EspnFixture) -> dict[str, Any] | None:
+    """Serialise an EspnFixture into a last-results entry.
+
+    Returns ``None`` when the row does not have parseable integer scores (e.g.
+    status is Final but scores are blank/malformed — an ESPN quirk).
+    """
+    score_team = _parse_score(fixture.score_team)
+    score_opponent = _parse_score(fixture.score_opponent)
+    if score_team is None or score_opponent is None:
+        return None
+    return {
+        "date": fixture.date.isoformat(),
+        "opponent": fixture.opponent,
+        "home_away": fixture.home_away,
+        "score_team": score_team,
+        "score_opponent": score_opponent,
+        "outcome": _outcome_for_score(score_team, score_opponent),
+        "competition": fixture.competition,
+    }
+
+
+def _derive_standings(fixtures: list[EspnFixture]) -> dict[str, dict[str, Any]]:
+    """Build a points table keyed by team from a season's Premier League rows.
+
+    The input is the set of EspnFixture rows for the target season. Only rows
+    where ``competition == "Premier League"`` and state is ``"post"`` (or, for
+    legacy rows with no state, a matching fallback status) with parseable
+    scores count. Position is assigned by sorting the team-indexed table by
+    (points desc, goal_diff desc, goals_for desc) — the standard EPL tiebreak
+    chain. Each match contributes to both teams' rows (rows are per team in
+    ``espn_fixtures``).
+    """
+    table: dict[str, dict[str, Any]] = {}
+
+    for fixture in fixtures:
+        if fixture.competition != _PREMIER_LEAGUE:
+            continue
+        if not _is_final(fixture):
+            continue
+        score_team = _parse_score(fixture.score_team)
+        score_opponent = _parse_score(fixture.score_opponent)
+        if score_team is None or score_opponent is None:
+            continue
+
+        row = table.setdefault(
+            fixture.team,
+            {
+                "played": 0,
+                "wins": 0,
+                "draws": 0,
+                "losses": 0,
+                "goals_for": 0,
+                "goals_against": 0,
+            },
+        )
+        row["played"] += 1
+        row["goals_for"] += score_team
+        row["goals_against"] += score_opponent
+        if score_team > score_opponent:
+            row["wins"] += 1
+        elif score_team < score_opponent:
+            row["losses"] += 1
+        else:
+            row["draws"] += 1
+
+    # Finalise derived fields and assign positions.
+    for row in table.values():
+        row["goal_diff"] = row["goals_for"] - row["goals_against"]
+        row["points"] = row["wins"] * 3 + row["draws"]
+
+    ordered = sorted(
+        table.items(),
+        key=lambda item: (
+            -item[1]["points"],
+            -item[1]["goal_diff"],
+            -item[1]["goals_for"],
+            item[0],
+        ),
+    )
+    for position, (team, row) in enumerate(ordered, start=1):
+        row["position"] = position
+        # Duplicate the team name into the row so callers can flatten via
+        # ``sorted(table.values(), ...)`` without losing the dict key.
+        row["team"] = team
+
+    return table
+
+
+@epl_mcp.tool()
+async def get_team_context(
+    team: str,
+    as_of: str | None = None,
+    last_n: int = 5,
+    next_n: int = 5,
+    include_standings: bool = True,
+) -> dict[str, Any]:
+    """Fetch form, upcoming fixtures, and league table position for an EPL team.
+
+    Draws from the ``espn_fixtures`` table (refreshed daily by the
+    ``fetch-espn-fixtures`` job). Returns:
+
+    - ``last_results``: up to ``last_n`` most recent Premier-League-only
+      completed fixtures before ``as_of``, each with score, outcome (W/D/L),
+      home/away. PL-only to keep "form" meaningful — cup results sit in
+      upcoming_fixtures via rotation risk, not form.
+    - ``upcoming_fixtures``: next ``next_n`` fixtures after ``as_of`` across
+      all competitions (PL, FA Cup, League Cup, European) with
+      ``days_until_ko``. This is the rotation-risk signal.
+    - ``standings`` (when ``include_standings=True``): derived on the fly from
+      Premier League completed rows in the current season. Position assigned
+      by a simplified tiebreak chain: points, goal diff, goals for, team name.
+      This omits the official EPL head-to-head step, so ``position`` on a
+      tight 3-way tie at the threshold is approximate — do not over-trust it.
+
+    Live (``state="in"``) rows are skipped from both last_results and
+    upcoming_fixtures; they neither count as form nor as upcoming rotation.
+
+    Args:
+        team: Canonical team name (matches the output of
+            ``odds_core.team.normalize_team_name`` — e.g. "Manchester Utd",
+            "Tottenham", "Wolves"). Common variants are also accepted.
+        as_of: ISO datetime cutoff. Defaults to now. Used to split fixtures
+            into past vs upcoming; also used to compute ``days_until_ko``.
+        last_n: Max last-results entries to return. Clamped to >= 1.
+        next_n: Max upcoming-fixtures entries to return. Clamped to >= 1.
+        include_standings: When True, include the derived table. The returned
+            ``standings.team_row`` is the target team's row; ``standings.table``
+            is the full 20-team ordering.
+
+    Returns:
+        Dict with ``team``, ``as_of``, ``season``, ``last_results``,
+        ``upcoming_fixtures``, and (optionally) ``standings``.
+    """
+    canonical_team = normalize_team_name(team)
+
+    if as_of is None:
+        resolved_as_of = datetime.now(UTC)
+    else:
+        parsed = datetime.fromisoformat(as_of.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        resolved_as_of = parsed
+
+    last_n = max(1, last_n)
+    next_n = max(1, next_n)
+
+    season = current_season(resolved_as_of)
+    season_lbl = season_label(season)
+
+    async with async_session_maker() as session:
+        # Team-scoped rows: drive last_results + upcoming_fixtures.
+        team_query = (
+            select(EspnFixture).where(EspnFixture.team == canonical_team).order_by(EspnFixture.date)
+        )
+        team_result = await session.execute(team_query)
+        team_rows = list(team_result.scalars().all())
+
+        # Season-scoped rows for all teams: drive standings derivation.
+        standings_rows: list[EspnFixture] = []
+        if include_standings:
+            standings_query = (
+                select(EspnFixture)
+                .where(EspnFixture.season == season_lbl)
+                .order_by(EspnFixture.date)
+            )
+            standings_result = await session.execute(standings_query)
+            standings_rows = list(standings_result.scalars().all())
+
+    # Split team_rows into past (final, PL only) and upcoming (any competition,
+    # not started). Live matches ("in") are skipped on both sides.
+    last_results: list[dict[str, Any]] = []
+    upcoming: list[dict[str, Any]] = []
+    for row in team_rows:
+        if _is_in_progress(row):
+            continue
+        if _is_final(row):
+            if row.competition != _PREMIER_LEAGUE:
+                continue
+            if row.date >= resolved_as_of:
+                continue
+            entry = _result_to_dict(row)
+            if entry is not None:
+                last_results.append(entry)
+        elif row.date >= resolved_as_of:
+            # "pre" rows and unknown-state future-dated rows.
+            upcoming.append(_fixture_to_dict(row, as_of=resolved_as_of))
+
+    # Newest-first on last_results; already date-asc on upcoming.
+    last_results.reverse()
+    last_results = last_results[:last_n]
+    upcoming_fixtures = upcoming[:next_n]
+
+    response: dict[str, Any] = {
+        "team": canonical_team,
+        "as_of": resolved_as_of.isoformat(),
+        "season": season_lbl,
+        "last_results": last_results,
+        "upcoming_fixtures": upcoming_fixtures,
+    }
+
+    if include_standings:
+        table = _derive_standings(standings_rows)
+        team_row = table.get(canonical_team)
+        response["standings"] = {
+            "team_row": team_row,
+            "table": sorted(table.values(), key=lambda r: r["position"]),
+        }
+
+    return response

--- a/tests/unit/test_get_team_context.py
+++ b/tests/unit/test_get_team_context.py
@@ -100,7 +100,7 @@ class TestDeriveStandings:
         return rows
 
     def test_three_teams_round_robin(self) -> None:
-        from odds_mcp.server import _derive_standings
+        from odds_mcp.tools.epl import _derive_standings
 
         # A beats B 2-0, A draws C 1-1, B beats C 3-1
         records: list[EspnFixtureRecord] = []
@@ -165,7 +165,7 @@ class TestDeriveStandings:
         assert c["position"] == 3
 
     def test_position_tiebreak_by_goal_diff_then_gf(self) -> None:
-        from odds_mcp.server import _derive_standings
+        from odds_mcp.tools.epl import _derive_standings
 
         # Two matches chosen to tie X and Y on points (3) AND goal diff (+2),
         # with X ahead on goals-for — exercises the GF tiebreak branch.
@@ -201,7 +201,7 @@ class TestDeriveStandings:
         assert table["Y"]["position"] == 2
 
     def test_only_counts_premier_league(self) -> None:
-        from odds_mcp.server import _derive_standings
+        from odds_mcp.tools.epl import _derive_standings
 
         # An FA Cup win does NOT count toward the league table.
         records: list[EspnFixtureRecord] = []
@@ -219,7 +219,7 @@ class TestDeriveStandings:
         assert table == {}
 
     def test_only_counts_final_status(self) -> None:
-        from odds_mcp.server import _derive_standings
+        from odds_mcp.tools.epl import _derive_standings
 
         records: list[EspnFixtureRecord] = []
         records.extend(
@@ -237,7 +237,7 @@ class TestDeriveStandings:
         assert table == {}
 
     def test_skips_malformed_scores(self) -> None:
-        from odds_mcp.server import _derive_standings
+        from odds_mcp.tools.epl import _derive_standings
 
         # Final row with blank scores (ESPN quirk) is ignored.
         records: list[EspnFixtureRecord] = []
@@ -284,7 +284,7 @@ class TestGetTeamContextAsOf:
         self, pglite_async_session, test_engine
     ) -> None:
         """as_of must exclude fixtures strictly in the future (no look-ahead)."""
-        from odds_mcp import server as mcp_server
+        from odds_mcp.tools import epl as mcp_server
 
         writer = EspnFixtureWriter(pglite_async_session)
 
@@ -339,7 +339,7 @@ class TestGetTeamContextAsOf:
     async def test_in_progress_rows_skipped_from_both_sides(
         self, pglite_async_session, test_engine
     ) -> None:
-        from odds_mcp import server as mcp_server
+        from odds_mcp.tools import epl as mcp_server
         from sqlalchemy.ext.asyncio import async_sessionmaker
 
         writer = EspnFixtureWriter(pglite_async_session)
@@ -379,7 +379,7 @@ class TestGetTeamContextAsOf:
     @pytest.mark.asyncio
     async def test_normalises_team_alias(self, pglite_async_session, test_engine) -> None:
         """Inputs like 'Wolverhampton Wanderers' resolve to canonical 'Wolves'."""
-        from odds_mcp import server as mcp_server
+        from odds_mcp.tools import epl as mcp_server
         from sqlalchemy.ext.asyncio import async_sessionmaker
 
         writer = EspnFixtureWriter(pglite_async_session)
@@ -409,7 +409,7 @@ class TestGetTeamContextAsOf:
     async def test_upcoming_includes_cup_competitions(
         self, pglite_async_session, test_engine
     ) -> None:
-        from odds_mcp import server as mcp_server
+        from odds_mcp.tools import epl as mcp_server
         from sqlalchemy.ext.asyncio import async_sessionmaker
 
         writer = EspnFixtureWriter(pglite_async_session)
@@ -454,7 +454,7 @@ class TestGetTeamContextAsOf:
 
     @pytest.mark.asyncio
     async def test_standings_returned_from_db(self, pglite_async_session, test_engine) -> None:
-        from odds_mcp import server as mcp_server
+        from odds_mcp.tools import epl as mcp_server
         from sqlalchemy.ext.asyncio import async_sessionmaker
 
         writer = EspnFixtureWriter(pglite_async_session)
@@ -502,7 +502,7 @@ class TestGetTeamContextAsOf:
         self, pglite_async_session, test_engine
     ) -> None:
         """Legacy rows (state=None) are classified as final via the status fallback."""
-        from odds_mcp import server as mcp_server
+        from odds_mcp.tools import epl as mcp_server
         from sqlalchemy.ext.asyncio import async_sessionmaker
 
         writer = EspnFixtureWriter(pglite_async_session)
@@ -559,22 +559,22 @@ class TestGetTeamContextAsOf:
 
 class TestParseScore:
     def test_valid_integer(self) -> None:
-        from odds_mcp.server import _parse_score
+        from odds_mcp.tools.epl import _parse_score
 
         assert _parse_score("3") == 3
 
     def test_blank(self) -> None:
-        from odds_mcp.server import _parse_score
+        from odds_mcp.tools.epl import _parse_score
 
         assert _parse_score("") is None
 
     def test_malformed(self) -> None:
-        from odds_mcp.server import _parse_score
+        from odds_mcp.tools.epl import _parse_score
 
         assert _parse_score("abc") is None
 
     def test_negative_rejected(self) -> None:
-        from odds_mcp.server import _parse_score
+        from odds_mcp.tools.epl import _parse_score
 
         assert _parse_score("-1") is None
 
@@ -584,14 +584,14 @@ class TestGetTeamContextMockedDB:
 
     @pytest.mark.asyncio
     async def test_default_as_of_returns_now(self) -> None:
-        from odds_mcp import server as mcp_server
+        from odds_mcp.tools import epl as mcp_server
 
         mock_session = AsyncMock()
         mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = []
         mock_session.execute = AsyncMock(return_value=mock_result)
 
-        with patch("odds_mcp.server.async_session_maker") as mock_session_maker:
+        with patch("odds_mcp.tools.epl.async_session_maker") as mock_session_maker:
             mock_session_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
             mock_session_maker.return_value.__aexit__ = AsyncMock()
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -8,6 +8,30 @@ from odds_core.models import Event, EventStatus, OddsSnapshot
 from odds_core.paper_trade_models import PaperTrade, TradeResult
 
 
+class TestToolNamespace:
+    """Guard against silent name shadowing across mounted sub-servers.
+
+    FastMCP's unprefixed mount surfaces both colliding tools through
+    ``list_tools`` without raising — see ``_assert_unique_tool_names``. This
+    test catches a duplicate before it ships.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_duplicate_tool_names(self) -> None:
+        from odds_mcp.server import mcp
+
+        tools = await mcp.list_tools()
+        names = [t.name for t in tools]
+        duplicates = sorted({n for n in names if names.count(n) > 1})
+        assert not duplicates, f"Duplicate MCP tool names: {duplicates}"
+
+    @pytest.mark.asyncio
+    async def test_assert_unique_tool_names_helper_passes(self) -> None:
+        from odds_mcp.server import _assert_unique_tool_names
+
+        await _assert_unique_tool_names()
+
+
 class TestCoerceBookmakerList:
     def test_none_passthrough(self) -> None:
         from odds_mcp.server import _coerce_bookmaker_list


### PR DESCRIPTION
## Summary

- Move `get_team_context` and its 7 helpers (`_is_final`, `_is_in_progress`, `_parse_score`, `_outcome_for_score`, `_fixture_to_dict`, `_result_to_dict`, `_derive_standings`) out of `packages/odds-mcp/odds_mcp/server.py` into a new `packages/odds-mcp/odds_mcp/tools/epl.py`.
- `tools/epl.py` owns its own `epl_mcp = FastMCP("odds-mcp-epl")` child instance; `server.py` imports `epl_mcp` and calls `mcp.mount(epl_mcp)` with no namespace argument so the tool name `get_team_context` is preserved verbatim for the agent.
- Update `tests/unit/test_get_team_context.py` import paths and patch targets to point at the new module.
- `server.py` shrinks from ~1549 → 1257 lines; the EPL submodule is 313 lines.
- Sets up the pattern for the upcoming MLB tools landing in `tools/mlb.py` without compounding the monolithic-server problem now.

## Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)