### PR TITLE
Fix MCP scheduler tools: sport filter + JobLookupError handling

### DIFF
--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -456,28 +456,39 @@ async def get_scrape_status(
 
             job_result: dict[str, Any] | None = None
             if job_id is not None and not pending_jobs:
-                result = await scheduler.get_job_result(UUID(job_id), wait=False)
-                if result is not None:
-                    stats = result.return_value
-                    job_result = {
-                        "job_id": job_id,
-                        "state": "completed",
-                        "outcome": result.outcome.name,
-                        "started_at": result.started_at.isoformat() if result.started_at else None,
-                        "finished_at": result.finished_at.isoformat(),
-                        "stats": dataclasses.asdict(stats)
-                        if dataclasses.is_dataclass(stats)
-                        else None,
-                        "exception": repr(result.exception) if result.exception else None,
-                    }
+                from apscheduler import JobLookupError
+
+                try:
+                    result = await scheduler.get_job_result(UUID(job_id), wait=False)
+                except* JobLookupError:
+                    # Result-retention window has elapsed since the job completed.
+                    # Treat as a clean state — agent should fall back to
+                    # get_current_odds / get_odds_history to verify ingestion.
+                    job_result = {"job_id": job_id, "state": "expired"}
                 else:
-                    job_result = {"job_id": job_id, "state": "unknown"}
+                    if result is not None:
+                        stats = result.return_value
+                        job_result = {
+                            "job_id": job_id,
+                            "state": "completed",
+                            "outcome": result.outcome.name,
+                            "started_at": result.started_at.isoformat()
+                            if result.started_at
+                            else None,
+                            "finished_at": result.finished_at.isoformat(),
+                            "stats": dataclasses.asdict(stats)
+                            if dataclasses.is_dataclass(stats)
+                            else None,
+                            "exception": repr(result.exception) if result.exception else None,
+                        }
+                    else:
+                        job_result = {"job_id": job_id, "state": "unknown"}
 
     except Exception as e:
-        logger.warning("get_scrape_status_failed", error=str(e))
+        logger.warning("get_scrape_status_failed", error=repr(e))
         return {
             "status": "unavailable",
-            "message": f"Could not query scheduler: {e}",
+            "message": f"Could not query scheduler: {e!r}",
             "jobs": [],
         }
 
@@ -1153,14 +1164,14 @@ async def get_scheduled_jobs(
     """List all currently scheduled jobs from the scheduler backend.
 
     Returns job name, next run time, and status for each job. Optionally
-    filter by sport key (substring match on job name).
+    filter by sport key — matches the registered sport suffix (e.g.
+    ``soccer_epl`` matches ``...-epl`` job ids).
 
     If the scheduler backend is not running (e.g. local APScheduler not
     started), returns an informative message rather than an error.
 
     Args:
         sport: Optional sport key to filter jobs (e.g. "soccer_epl").
-               Matches as substring against job names.
 
     Returns:
         Dict with list of scheduled jobs or an informative message.
@@ -1172,10 +1183,10 @@ async def get_scheduled_jobs(
         async with build_scheduler(role=SchedulerRole.scheduler) as scheduler:
             schedules = await scheduler.get_schedules()
     except Exception as e:
-        logger.warning("get_scheduled_jobs_failed", error=str(e))
+        logger.warning("get_scheduled_jobs_failed", error=repr(e))
         return {
             "jobs": [],
-            "message": f"Could not query scheduler: {e}",
+            "message": f"Could not query scheduler: {e!r}",
         }
 
     jobs = [
@@ -1188,7 +1199,10 @@ async def get_scheduled_jobs(
     ]
 
     if sport:
-        jobs = [j for j in jobs if sport in j["job_name"]]
+        from odds_lambda.scheduling.jobs import sport_key_to_suffix
+
+        suffix = sport_key_to_suffix(sport) or sport
+        jobs = [j for j in jobs if j["job_name"].endswith(f"-{suffix}")]
 
     return {
         "job_count": len(jobs),

--- a/tests/unit/test_agent_wakeup.py
+++ b/tests/unit/test_agent_wakeup.py
@@ -174,9 +174,9 @@ class TestGetScheduledJobs:
 
         now = datetime.now(UTC)
         schedules = [
-            _make_schedule("fetch_odds_soccer_epl", now),
-            _make_schedule("fetch_odds_baseball_mlb", now),
-            _make_schedule("agent_run_soccer_epl", now),
+            _make_schedule("fetch-odds-epl", now),
+            _make_schedule("fetch-odds-mlb", now),
+            _make_schedule("agent-run-epl", now),
         ]
 
         with _patch_build_scheduler(schedules=schedules):
@@ -184,9 +184,9 @@ class TestGetScheduledJobs:
 
         assert result["job_count"] == 2
         job_names = [j["job_name"] for j in result["jobs"]]
-        assert "fetch_odds_soccer_epl" in job_names
-        assert "agent_run_soccer_epl" in job_names
-        assert "fetch_odds_baseball_mlb" not in job_names
+        assert "fetch-odds-epl" in job_names
+        assert "agent-run-epl" in job_names
+        assert "fetch-odds-mlb" not in job_names
 
     @pytest.mark.asyncio
     async def test_no_filter_returns_all(self) -> None:
@@ -194,8 +194,8 @@ class TestGetScheduledJobs:
 
         now = datetime.now(UTC)
         schedules = [
-            _make_schedule("fetch_odds_soccer_epl", now),
-            _make_schedule("fetch_odds_baseball_mlb", now),
+            _make_schedule("fetch-odds-epl", now),
+            _make_schedule("fetch-odds-mlb", now),
         ]
 
         with _patch_build_scheduler(schedules=schedules):


### PR DESCRIPTION
## Summary

- **`get_scheduled_jobs` sport filter:** the substring filter compared the `SportKey` enum value (`"baseball_mlb"`) against job ids registered with the short suffix (`fetch-oddsportal-mlb`, `agent-run-mlb`, …) and stripped every match, returning `job_count: 0`. The MLB agent observations file records this as a "zombie scheduler" pattern across 10 consecutive sessions even though the schedules are healthy and ingesting. Replace with `sport_key_to_suffix(sport)` + `endswith` match.
- **`get_scrape_status` TaskGroup error:** `scheduler.get_job_result(UUID, wait=False)` raises `JobLookupError` once APScheduler's result-retention window has elapsed. The error is wrapped in nested `ExceptionGroup`s and the catch-all `f"...: {e}"` formatter drops the sub-exception, so the agent saw a meaningless `"unhandled errors in a TaskGroup (1 sub-exception)"` (~3–9 hits per session, every session since 2026-04-17). Catch `JobLookupError` via `except*` and surface `{"state": "expired"}`. Switch the generic catch-all to `repr(e)` so future failures are diagnosable.

## Root-cause repro

Calling `get_job_result(uuid4(), wait=False)` on a UUID that isn't in the data store reliably reproduces the double-wrapped `ExceptionGroup → ExceptionGroup → JobLookupError`. Verified against the latest MLB session (`baseball_mlb_20260426T113529Z`): `refresh_scrape` returned a job_id, scrape completed, two later `get_scrape_status` calls with that id both hit the path.

## Test plan

- [x] `get_scheduled_jobs(sport="baseball_mlb")` returns 5 jobs (was 0)
- [x] `get_scheduled_jobs(sport="soccer_epl")` returns 6 jobs (was 0)
- [x] `get_scheduled_jobs()` (no filter) still returns all 11
- [x] `get_scrape_status(job_id=<stale UUID>)` returns `{"state": "expired"}` (was TaskGroup error)
- [x] `get_scrape_status()` (no job_id) still returns `status: ok`
- [ ] Next MLB agent session shows non-zero `get_scheduled_jobs(sport="baseball_mlb")` and clean `expired` instead of TaskGroup payload
- [ ] Update `packages/odds-mcp/agents/mlb/observations.md` (gitignored) to retire the "zombie scheduler" and "TaskGroup is cosmetic" entries once the next session confirms

🤖 Generated with [Claude Code](https://claude.com/claude-code)