### PR TITLE
Skip score_events when model doesn't serve the sport

### DIFF
--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
@@ -326,11 +326,7 @@ async def main(ctx: JobContext) -> None:
                 message=f"⚠️ OddsPortal scrape empty ({detail})",
             )
 
-    # Score predictions for newly arrived snapshots. Wrapped in its own
-    # try/except (outside the scrape alert context) so scoring failures
-    # don't surface as scrape alerts — they're logged independently.
-    # Guarded with model_supports_sport so per-sport scrapes for sports
-    # without a published model don't trigger noisy sport_mismatch errors.
+    # Outside job_alert_context so scoring failures don't fire scrape alerts.
     try:
         from odds_lambda.model_loader import model_supports_sport
 

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
@@ -329,11 +329,18 @@ async def main(ctx: JobContext) -> None:
     # Score predictions for newly arrived snapshots. Wrapped in its own
     # try/except (outside the scrape alert context) so scoring failures
     # don't surface as scrape alerts — they're logged independently.
+    # Guarded with model_supports_sport so per-sport scrapes for sports
+    # without a published model don't trigger noisy sport_mismatch errors.
     try:
-        from odds_lambda.jobs.score_predictions import score_events
+        from odds_lambda.model_loader import model_supports_sport
 
-        score_stats = await score_events(sport=ctx.sport)
-        logger.info("fetch_oddsportal_scoring_complete", **score_stats)
+        if model_supports_sport(ctx.sport):
+            from odds_lambda.jobs.score_predictions import score_events
+
+            score_stats = await score_events(sport=ctx.sport)
+            logger.info("fetch_oddsportal_scoring_complete", **score_stats)
+        else:
+            logger.info("fetch_oddsportal_scoring_skipped", sport=sport)
     except Exception as e:
         logger.error(
             "fetch_oddsportal_scoring_failed",

--- a/packages/odds-lambda/odds_lambda/model_loader.py
+++ b/packages/odds-lambda/odds_lambda/model_loader.py
@@ -148,17 +148,7 @@ def load_model(
 
 
 def model_supports_sport(sport: SportKey | None) -> bool:
-    """Whether the configured model serves the given sport.
-
-    Returns ``True`` when ``sport`` is ``None`` (caller defers to the
-    model's own ``sport_key``). Returns ``False`` when no model is
-    configured, the model artifact has no bundled config, or its
-    ``sport_key`` differs from the requested sport.
-
-    Lets pre-sport callers (e.g. ``fetch-oddsportal-mlb``) skip
-    speculative scoring without raising the ``sport_mismatch`` error in
-    ``score_events``.
-    """
+    """Whether the configured model serves ``sport`` (``None`` ⇒ no preference)."""
     if sport is None:
         return True
     try:

--- a/packages/odds-lambda/odds_lambda/model_loader.py
+++ b/packages/odds-lambda/odds_lambda/model_loader.py
@@ -10,6 +10,7 @@ import structlog
 import yaml
 from odds_analytics.training.config import FeatureConfig
 from odds_core.config import get_settings
+from odds_core.sports import SportKey
 
 logger = structlog.get_logger(__name__)
 
@@ -144,6 +145,30 @@ def load_model(
     _cached_model_key = key
 
     return model_data
+
+
+def model_supports_sport(sport: SportKey | None) -> bool:
+    """Whether the configured model serves the given sport.
+
+    Returns ``True`` when ``sport`` is ``None`` (caller defers to the
+    model's own ``sport_key``). Returns ``False`` when no model is
+    configured, the model artifact has no bundled config, or its
+    ``sport_key`` differs from the requested sport.
+
+    Lets pre-sport callers (e.g. ``fetch-oddsportal-mlb``) skip
+    speculative scoring without raising the ``sport_mismatch`` error in
+    ``score_events``.
+    """
+    if sport is None:
+        return True
+    try:
+        model_data = load_model()
+    except (ValueError, FileNotFoundError):
+        return False
+    config: FeatureConfig | None = model_data.get("feature_config")
+    if config is None or not config.sport_key:
+        return False
+    return config.sport_key == sport
 
 
 def get_cached_version() -> str | None:


### PR DESCRIPTION
## Summary

Every ``fetch-oddsportal-mlb`` scrape calls ``score_events(sport="baseball_mlb")``, which loads the configured model (currently ``epl-clv-home``, EPL-only) and bails out at the ``sport_mismatch`` error path. The bailout is correct — there is no MLB model published — but the error-level log fires on every scrape, polluting alert channels.

Add a small ``model_supports_sport(sport)`` helper next to ``load_model`` that returns whether the configured model's bundled ``feature_config.sport_key`` matches the requested sport. Gate the speculative ``score_events`` call in ``fetch_oddsportal`` on it.

## Why this shape, not a per-sport model registry

A per-sport ``ModelConfig`` would solve the same problem but designs the schema before there's a second model to validate against. This change introduces the right *interface* — caller asks the model layer "do you serve sport X?" — without committing to an artifact layout. When an MLB model lands, the helper's implementation swaps to a dict lookup; the callsite doesn't change.

## Test plan

- [x] Unit cases verified: matching sport → True, mismatched sport → False, sport=None → True, missing config → False, unconfigured (load raises ValueError) → False
- [x] ``tests/unit/test_model_loader.py``, ``test_fetch_oddsportal.py``, ``test_fetch_oddsportal_scheduling.py``, ``test_score_predictions.py`` all pass (46 tests)
- [ ] Next ``fetch-oddsportal-mlb`` run logs ``fetch_oddsportal_scoring_skipped`` at info instead of ``sport_mismatch`` at error

🤖 Generated with [Claude Code](https://claude.com/claude-code)