### PR TITLE
Add live job-table printing and stale-schedule pruning to local scheduler

### DIFF
--- a/packages/odds-cli/odds_cli/commands/scheduler.py
+++ b/packages/odds-cli/odds_cli/commands/scheduler.py
@@ -1,6 +1,9 @@
 """Scheduler management CLI commands."""
 
+from __future__ import annotations
+
 import asyncio
+from typing import TYPE_CHECKING
 
 import structlog
 import typer
@@ -8,12 +11,15 @@ from odds_core.config import get_settings
 from rich.console import Console
 from rich.table import Table
 
+if TYPE_CHECKING:
+    from odds_lambda.scheduling.backends.base import ScheduledJob
+
 app = typer.Typer()
 console = Console()
 logger = structlog.get_logger()
 
 
-def _print_scheduled_jobs(con: Console, jobs: list) -> None:
+def _print_scheduled_jobs(con: Console, jobs: list[ScheduledJob]) -> None:
     if not jobs:
         con.print("[yellow]No jobs currently scheduled[/yellow]")
         return
@@ -107,36 +113,16 @@ def start_local(
         """Run scheduler using async context manager."""
         from odds_lambda.scheduling.jobs import (
             JobContext,
+            expected_compound_job_names,
             get_bootstrap_function,
             get_job_cron,
-            get_job_cron_sports,
             is_per_sport_job,
             make_compound_job_name,
+            resolve_target_sports,
         )
 
         bootstrap_jobs = app_settings.scheduler.bootstrap_jobs if effective_bootstrap else []
-
-        def _expected_compound_names() -> set[str]:
-            """Compute the full set of compound job names the current config expects."""
-            expected: set[str] = set()
-            for job_name in bootstrap_jobs:
-                per_sport = is_per_sport_job(job_name)
-                cron_expr = get_job_cron(job_name)
-                if per_sport:
-                    allowed_sports = (
-                        get_job_cron_sports(job_name) if cron_expr is not None else None
-                    )
-                    configured_sports = app_settings.data_collection.sports
-                    target_sports = (
-                        list(allowed_sports)
-                        if allowed_sports is not None
-                        else list(configured_sports)
-                    )
-                    for sport_key in target_sports:
-                        expected.add(make_compound_job_name(job_name, sport_key))
-                else:
-                    expected.add(job_name)
-            return expected
+        configured_sports = app_settings.data_collection.sports
 
         # Start scheduler first so bootstrap jobs can schedule via the backend
         async with LocalSchedulerBackend() as _backend:
@@ -145,7 +131,8 @@ def start_local(
             async def _on_job_released(_event: Event) -> None:
                 try:
                     jobs = await _backend.get_scheduled_jobs()
-                except Exception:
+                except Exception as e:
+                    logger.debug("job_released_refresh_failed", error=str(e))
                     return
                 console.print()
                 _print_scheduled_jobs(console, jobs)
@@ -156,7 +143,7 @@ def start_local(
             # self-scheduling jobs removed from the config persist indefinitely in
             # the Postgres data store and keep firing after restart.
             if effective_bootstrap:
-                expected = _expected_compound_names()
+                expected = expected_compound_job_names(bootstrap_jobs, configured_sports)
                 existing_jobs = await _backend.get_scheduled_jobs()
                 stale = [j for j in existing_jobs if j.job_name not in expected]
                 if stale:
@@ -224,18 +211,8 @@ def start_local(
 
                 if cron_expr is not None:
                     if per_sport:
-                        allowed_sports = get_job_cron_sports(job_name)
-                        configured_sports = app_settings.data_collection.sports
-                        target_sports = (
-                            list(allowed_sports)
-                            if allowed_sports is not None
-                            else list(configured_sports)
-                        )
-                        skipped_sports = (
-                            [s for s in configured_sports if s not in target_sports]
-                            if allowed_sports is not None
-                            else []
-                        )
+                        target_sports = resolve_target_sports(job_name, configured_sports)
+                        skipped_sports = [s for s in configured_sports if s not in target_sports]
                         for skipped in skipped_sports:
                             skipped_compound = make_compound_job_name(job_name, skipped)
                             console.print(
@@ -253,7 +230,7 @@ def start_local(
                 bootstrap_fn = get_bootstrap_function(job_name)
 
                 if per_sport:
-                    for sport_key in app_settings.data_collection.sports:
+                    for sport_key in configured_sports:
                         await _bootstrap_dynamic(
                             make_compound_job_name(job_name, sport_key),
                             JobContext(sport=sport_key),

--- a/packages/odds-cli/odds_cli/commands/scheduler.py
+++ b/packages/odds-cli/odds_cli/commands/scheduler.py
@@ -13,6 +13,26 @@ console = Console()
 logger = structlog.get_logger()
 
 
+def _print_scheduled_jobs(con: Console, jobs: list) -> None:
+    if not jobs:
+        con.print("[yellow]No jobs currently scheduled[/yellow]")
+        return
+    jobs = sorted(jobs, key=lambda j: (j.next_run_time is None, j.next_run_time))
+    table = Table(show_header=True, header_style="bold cyan")
+    table.add_column("Job Name", style="white")
+    table.add_column("Next Run Time", style="yellow")
+    table.add_column("Status", style="green")
+    for job in jobs:
+        next_run = (
+            job.next_run_time.strftime("%Y-%m-%d %H:%M:%S UTC")
+            if job.next_run_time
+            else "[dim]Not scheduled[/dim]"
+        )
+        table.add_row(job.job_name, next_run, job.status.value)
+    con.print(table)
+    con.print(f"[dim]Total: {len(jobs)} jobs[/dim]")
+
+
 @app.command("start")
 def start_local(
     db: str | None = typer.Option(
@@ -96,8 +116,58 @@ def start_local(
 
         bootstrap_jobs = app_settings.scheduler.bootstrap_jobs if effective_bootstrap else []
 
+        def _expected_compound_names() -> set[str]:
+            """Compute the full set of compound job names the current config expects."""
+            expected: set[str] = set()
+            for job_name in bootstrap_jobs:
+                per_sport = is_per_sport_job(job_name)
+                cron_expr = get_job_cron(job_name)
+                if per_sport:
+                    allowed_sports = (
+                        get_job_cron_sports(job_name) if cron_expr is not None else None
+                    )
+                    configured_sports = app_settings.data_collection.sports
+                    target_sports = (
+                        list(allowed_sports)
+                        if allowed_sports is not None
+                        else list(configured_sports)
+                    )
+                    for sport_key in target_sports:
+                        expected.add(make_compound_job_name(job_name, sport_key))
+                else:
+                    expected.add(job_name)
+            return expected
+
         # Start scheduler first so bootstrap jobs can schedule via the backend
         async with LocalSchedulerBackend() as _backend:
+            from apscheduler import Event, JobReleased
+
+            async def _on_job_released(_event: Event) -> None:
+                try:
+                    jobs = await _backend.get_scheduled_jobs()
+                except Exception:
+                    return
+                console.print()
+                _print_scheduled_jobs(console, jobs)
+
+            _backend.subscribe(_on_job_released, {JobReleased})
+
+            # Prune schedules that are no longer in bootstrap_jobs. Without this,
+            # self-scheduling jobs removed from the config persist indefinitely in
+            # the Postgres data store and keep firing after restart.
+            if effective_bootstrap:
+                expected = _expected_compound_names()
+                existing_jobs = await _backend.get_scheduled_jobs()
+                stale = [j for j in existing_jobs if j.job_name not in expected]
+                if stale:
+                    console.print("[yellow]Removing stale schedules...[/yellow]")
+                    for job in stale:
+                        try:
+                            await _backend.cancel_scheduled_execution(job.job_name)
+                            console.print(f"[dim]  {job.job_name} removed[/dim]")
+                        except Exception as e:
+                            console.print(f"[yellow]  {job.job_name} removal failed: {e}[/yellow]")
+                    console.print()
 
             async def _bootstrap_cron(compound: str, cron_expr: str) -> None:
                 """Install a recurring CronTrigger, re-applying on every start.
@@ -198,6 +268,10 @@ def start_local(
             console.print("[bold green]Scheduler started![/bold green]")
             console.print("[dim]Jobs will self-schedule based on game proximity[/dim]")
             console.print("[dim]Press Ctrl+C to stop[/dim]\n")
+
+            jobs = await _backend.get_scheduled_jobs()
+            _print_scheduled_jobs(console, jobs)
+            console.print()
 
             try:
                 logger.info("local_scheduler_running", message="Press Ctrl+C to stop")
@@ -350,26 +424,7 @@ def list_jobs():
 
         jobs = asyncio.run(get_jobs())
 
-        if not jobs:
-            console.print("[yellow]No jobs currently scheduled[/yellow]")
-            return
-
-        # Create jobs table
-        table = Table(show_header=True, header_style="bold cyan")
-        table.add_column("Job Name", style="white")
-        table.add_column("Next Run Time", style="yellow")
-        table.add_column("Status", style="green")
-
-        for job in jobs:
-            next_run = (
-                job.next_run_time.strftime("%Y-%m-%d %H:%M:%S UTC")
-                if job.next_run_time
-                else "[dim]Not scheduled[/dim]"
-            )
-            table.add_row(job.job_name, next_run, job.status.value)
-
-        console.print(table)
-        console.print(f"\n[dim]Total: {len(jobs)} jobs[/dim]")
+        _print_scheduled_jobs(console, jobs)
 
     except BackendUnavailableError as e:
         console.print(f"[yellow]⚠ Not supported:[/yellow] {e}")

--- a/packages/odds-lambda/odds_lambda/scheduling/backends/local.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/backends/local.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from datetime import datetime
 from types import TracebackType
 from typing import TYPE_CHECKING
 
 import structlog
-from apscheduler import AsyncScheduler, ConflictPolicy, SchedulerRole
+from apscheduler import AsyncScheduler, ConflictPolicy, Event, SchedulerRole
 from apscheduler.datastores.sqlalchemy import SQLAlchemyDataStore
 from apscheduler.eventbrokers.asyncpg import AsyncpgEventBroker
 from apscheduler.triggers.cron import CronTrigger
@@ -375,6 +375,16 @@ class LocalSchedulerBackend(SchedulerBackend):
             args=[ctx],
             conflict_policy=ConflictPolicy.replace,
         )
+
+    def subscribe(
+        self,
+        callback: Callable[[Event], object],
+        event_types: type[Event] | Iterable[type[Event]] | None = None,
+    ) -> None:
+        """Subscribe a listener to scheduler events on the running scheduler."""
+        if self._scheduler is None:
+            raise BackendUnavailableError("Scheduler not started")
+        self._scheduler.subscribe(callback, event_types)
 
     async def cancel_scheduled_execution(self, job_name: str) -> None:
         if self.dry_run:

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable, Sequence
 from dataclasses import dataclass, fields
 from importlib import import_module
 
@@ -251,6 +251,34 @@ def get_job_function(job_name: str) -> Callable[[JobContext], Awaitable[None]]:
 def is_per_sport_job(job_name: str) -> bool:
     """Check whether a job accepts a sport parameter."""
     return job_name in _PER_SPORT_JOBS
+
+
+def resolve_target_sports(job_name: str, configured_sports: Sequence[SportKey]) -> list[SportKey]:
+    """Sports a per-sport job actually schedules for, honoring any cron allowlist.
+
+    A cron job may restrict itself to a subset of sports via ``_JOB_CRON_MAP``;
+    event-driven and unrestricted jobs run for every configured sport.
+    """
+    allowed = get_job_cron_sports(job_name) if get_job_cron(job_name) is not None else None
+    return list(allowed) if allowed is not None else list(configured_sports)
+
+
+def expected_compound_job_names(
+    bootstrap_jobs: Iterable[str], configured_sports: Sequence[SportKey]
+) -> set[str]:
+    """Compute the full set of compound job names a config is expected to schedule.
+
+    Mirrors the bootstrap loop's naming so callers (e.g. stale-schedule pruning)
+    can compare against what is actually in the data store.
+    """
+    expected: set[str] = set()
+    for job_name in bootstrap_jobs:
+        if is_per_sport_job(job_name):
+            for sport_key in resolve_target_sports(job_name, configured_sports):
+                expected.add(make_compound_job_name(job_name, sport_key))
+        else:
+            expected.add(job_name)
+    return expected
 
 
 def get_bootstrap_function(job_name: str) -> Callable[[JobContext], Awaitable[None]]:

--- a/tests/unit/test_job_routing.py
+++ b/tests/unit/test_job_routing.py
@@ -7,11 +7,13 @@ from odds_lambda.scheduling.jobs import (
     _JOB_CRON_MAP,
     _JOB_MODULE_MAP,
     JobContext,
+    expected_compound_job_names,
     get_bootstrap_function,
     get_job_cron,
     get_job_cron_sports,
     make_compound_job_name,
     resolve_job_name,
+    resolve_target_sports,
     sport_key_to_suffix,
 )
 
@@ -228,3 +230,49 @@ class TestJobCronRegistry:
         assertion in ``jobs.py`` guards this, but the test pins the contract.
         """
         assert set(_JOB_CRON_MAP) <= set(_JOB_MODULE_MAP)
+
+
+class TestResolveTargetSports:
+    """Tests for resolve_target_sports()."""
+
+    def test_event_driven_job_targets_all_configured_sports(self) -> None:
+        assert resolve_target_sports("fetch-odds", ["soccer_epl", "baseball_mlb"]) == [
+            "soccer_epl",
+            "baseball_mlb",
+        ]
+
+    def test_cron_job_with_allowlist_ignores_unlisted_sports(self) -> None:
+        # daily-digest is restricted to EPL even when MLB is configured.
+        assert resolve_target_sports("daily-digest", ["soccer_epl", "baseball_mlb"]) == [
+            "soccer_epl"
+        ]
+
+    def test_empty_configured_sports_yields_empty(self) -> None:
+        assert resolve_target_sports("fetch-odds", []) == []
+
+
+class TestExpectedCompoundJobNames:
+    """Tests for expected_compound_job_names() — drives stale-schedule pruning."""
+
+    def test_expands_per_sport_and_keeps_global_jobs(self) -> None:
+        expected = expected_compound_job_names(
+            ["fetch-odds", "daily-digest", "check-health"],
+            ["soccer_epl", "baseball_mlb"],
+        )
+        assert expected == {
+            "fetch-odds-epl",
+            "fetch-odds-mlb",
+            "daily-digest-epl",  # cron allowlist drops MLB
+            "check-health",  # global job kept as-is
+        }
+
+    def test_prune_drops_compound_for_unconfigured_sport(self) -> None:
+        # When MLB is removed from config, its compound becomes stale while
+        # the configured EPL schedule is preserved.
+        expected = expected_compound_job_names(["fetch-odds"], ["soccer_epl"])
+        existing = ["fetch-odds-epl", "fetch-odds-mlb"]
+        stale = [name for name in existing if name not in expected]
+        assert stale == ["fetch-odds-mlb"]
+
+    def test_no_bootstrap_jobs_yields_empty(self) -> None:
+        assert expected_compound_job_names([], ["soccer_epl"]) == set()


### PR DESCRIPTION
## Summary
- Print the scheduled-job table at startup and on every `JobReleased` event, via a new `LocalSchedulerBackend.subscribe()` method that registers a listener on the running scheduler.
- Prune schedules that are no longer in `bootstrap_jobs` on start, so self-scheduling jobs removed from config stop firing after a restart (they otherwise persist indefinitely in the Postgres data store).
- Refactor the job-table rendering into a shared `_print_scheduled_jobs` helper reused by `scheduler list`.

## Testing
- `ruff check` / `ruff format` clean (pre-commit passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)