### PR TITLE
Add reporting-system audit doc and agent-run summary viewer

### DIFF
--- a/docs/REPORTING.md
+++ b/docs/REPORTING.md
@@ -1,0 +1,349 @@
+# Reporting System
+
+This document maps the reporting surfaces of the pipeline — Discord alerts, digests, health monitoring, CLI status, MCP state queries, and agent-run traces — and the storage tables that back them. It also lists sharp edges and possible redesign directions.
+
+"Reporting" here means: everything the system emits *about itself* (operationally) or *about its outputs* (predictions, paper trades, agent briefs) so that a human or the betting agent can know what is happening.
+
+---
+
+## 1. System map
+
+```
+                       ┌───────────────────────────────────────────────┐
+                       │             Producers (jobs, services)        │
+                       │                                               │
+                       │ fetch_odds, fetch_*, score_predictions,       │
+                       │ agent_run, daily_digest, check_health, …      │
+                       └──────────┬────────────────────────────┬───────┘
+                                  │                            │
+                wrap with         │                            │ writes to
+       async with job_alert_      │                            │ FetchLog, DataQualityLog,
+       context(name)              │                            │ Prediction, MatchBrief,
+                                  │                            │ PaperTrade, AgentWakeup
+                                  ▼                            ▼
+                       ┌─────────────────────┐        ┌────────────────────┐
+                       │   alerts.py         │        │   Storage tables    │
+                       │   (odds-core)       │        │   (Postgres)        │
+                       │                     │        │                     │
+                       │  AlertManager       │◄──────►│  AlertHistory       │
+                       │  DiscordAlert       │ rate   │  FetchLog           │
+                       │  job_alert_context  │ limit  │  DataQualityLog     │
+                       │  send_job_warning   │ heart- │  Prediction         │
+                       │  send_critical/…    │ beat   │  MatchBrief         │
+                       │                     │        │  PaperTrade         │
+                       └─────────┬───────────┘        │  AgentWakeup        │
+                                 │ POST embed         └─────────┬──────────┘
+                                 ▼                              │
+                       ┌────────────────────┐   reads           │
+                       │  Discord webhook   │                   │
+                       └────────────────────┘                   │
+                                                                ▼
+            ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐
+            │  HealthMonitor   │  │  daily_digest    │  │  CLI / MCP       │
+            │  (poll-based)    │  │  (poll-based)    │  │  (on-demand)     │
+            │                  │  │                  │  │                  │
+            │  stale data,     │  │  results +       │  │  odds status,    │
+            │  failure streaks,│  │  upcoming preds  │  │  odds scheduler, │
+            │  quota, quality, │  │  → embed         │  │  MCP tools       │
+            │  heartbeats      │  │                  │  │  (get_portfolio, │
+            │  → alerts        │  │                  │  │   get_scrape_… ) │
+            └──────────────────┘  └──────────────────┘  └──────────────────┘
+```
+
+Three reporting *modes* coexist:
+
+1. **Event-driven**: jobs emit alerts at the moment something happens (job crash, low quota, soft scrape failure). Output: Discord. Storage: `AlertHistory` (used for rate-limit + heartbeat).
+2. **Poll-driven**: scheduled jobs (`check_health`, `daily_digest`) walk recent state and emit a summary alert. Output: Discord. Storage: reads from `FetchLog`, `OddsSnapshot`, `DataQualityLog`, `Prediction`, `AlertHistory`.
+3. **On-demand**: CLI commands and MCP tools serve current state to a human/agent. Output: terminal table or JSON. Storage: reads from everything.
+
+---
+
+## 2. Alert primitives — `packages/odds-core/odds_core/alerts.py`
+
+Everything that ends up in Discord goes through this module.
+
+### Class hierarchy
+
+| Class / function | Role |
+|---|---|
+| `AlertBase` (alerts.py:18) | Abstract channel: `send(message, severity)`, `send_embed(embed)` |
+| `DiscordAlert` (alerts.py:38) | Webhook-backed implementation; colors by severity (info=blue, warning=yellow, error=red, critical=dark red) |
+| `AlertManager` (alerts.py:91) | Fan-out router. Reads `settings.alerts`, populates `self.channels` from configured channels, broadcasts to all. Disabled when `alert_enabled=False` or no channels configured. |
+| `alert_manager` (alerts.py:157) | Module-level singleton |
+
+Only one channel class exists today (Discord). The interface is set up for additional channels (Slack, email) but there are no other implementations.
+
+### Module-level helpers
+
+- `send_info`, `send_warning`, `send_error`, `send_critical` (alerts.py:161–178): one-shot delivery, *not* rate-limited, *not* recorded.
+- `check_rate_limit(alert_type, rate_limit_minutes=30)` (alerts.py:188): returns `True` if no `AlertHistory` row with that `alert_type` exists inside the window. **Severity is not part of the key** — a `warning` and a `critical` with the same alert_type block each other.
+- `record_to_alert_history(alert_type, severity, message)` (alerts.py:211): inserts row with `sent_at = now(UTC)`.
+- `job_alert_context(job_name)` (alerts.py:232): async context manager every job wraps its body in. On exception → rate-limited `critical` alert + raise. On clean exit → writes a `heartbeat:{job_name}` row to `AlertHistory` (no Discord — heartbeats are silent unless missing).
+- `send_job_warning(alert_type, message)` (alerts.py:266): rate-limited warning, returns `True` if sent.
+
+### Alert-type taxonomy
+
+`alert_type` strings double as rate-limit keys and as keys in heartbeat expectations. The current vocabulary:
+
+| Type | Source | Severity | Notes |
+|---|---|---|---|
+| `job_failure:{job_name}` | `job_alert_context` | critical | Fired on exception |
+| `heartbeat:{job_name}` | `job_alert_context` | info | DB-only; no Discord |
+| `quota_low`, `quota_critical` | `fetch_odds`, `HealthMonitor` | warning/critical | Tiered |
+| `consecutive_failures` | `HealthMonitor` | error | ≥3 consecutive fetch failures |
+| `stale_data` | `HealthMonitor` | warning | No new snapshots within `stale_data_hours` |
+| `data_quality_errors` | `HealthMonitor` | warning | error+critical count > threshold |
+| `missing_heartbeat:{job_name}` | `HealthMonitor` | warning | Job did not complete inside expected window |
+| `health_check_failure` | `HealthMonitor` | critical | Health check itself crashed |
+| Ad-hoc job warnings (e.g. empty scrape) | various jobs | warning | Free-form via `send_job_warning` |
+
+---
+
+## 3. Health monitoring — `packages/odds-lambda/odds_lambda/health_monitor.py`
+
+Polled by the `check_health` job. Single class: `HealthMonitor(session, settings)`. Entry point: `check_system_health()` (health_monitor.py:368) runs five checks and returns a `HealthStatus`.
+
+### Checks
+
+1. **`check_stale_data`** (health_monitor.py:163): hours since `max(OddsSnapshot.snapshot_time)`. Threshold: `settings.alerts.stale_data_hours`.
+2. **`check_consecutive_failures`** (health_monitor.py:185): counts the leading run of `success=False` rows in the last 10 `FetchLog` entries. Threshold: `consecutive_failures_threshold`.
+3. **`check_api_quota`** (health_monitor.py:215): pulls `api_quota_remaining` from latest fetch log via `OddsReader.get_database_stats()`. Tiered: `quota_critical_threshold` (10%) → critical, `quota_warning_threshold` (20%) → warning.
+4. **`check_data_quality`** (health_monitor.py:240): counts `error` + `critical` rows in `DataQualityLog` over last 24h. Threshold: `data_quality_error_threshold`.
+5. **`check_job_heartbeats`** (health_monitor.py:305): for each `(job_name, max_hours)` in `settings.alerts.heartbeat_expectations`, looks up `max(sent_at)` where `alert_type = heartbeat:{job_name}`. If older than `max_hours`, fires `missing_heartbeat:{job_name}` warning.
+
+After the checks, `purge_old_heartbeats()` deletes heartbeat rows older than `heartbeat_retention_days` (default 7). This is the only retention sweep in the system.
+
+### Internals
+
+`HealthMonitor` has its own `_should_send_alert` / `_record_alert` / `_send_alert` triplet (health_monitor.py:66–152) that duplicates the `check_rate_limit` / `record_to_alert_history` flow in `alerts.py`. The duplication exists because `HealthMonitor` carries an `AsyncSession` and an explicit `Settings`; the alerts.py helpers create their own session per call.
+
+### Metrics object
+
+`HealthMetrics` (health_monitor.py:29) is a Pydantic model bundling the numbers that the health check computed: fetch success rate 24h, hours since last fetch, quota, consecutive failures, data quality errors, scheduled/live/final event counts. It is returned inside `HealthStatus` but **never emitted to Discord** — it exists only as a return value for the job invoker. No human consumer reads it.
+
+---
+
+## 4. Daily digest — `packages/odds-lambda/odds_lambda/jobs/daily_digest.py`
+
+The only "human-facing summary of model outputs" report. Run on a schedule per sport.
+
+### Flow
+
+1. `main(ctx)` (line 344) wraps in `job_alert_context("daily-digest-{sport}")`.
+2. `send_digest()` (line 290) does two queries:
+   - **Completed** events (`status=FINAL`, `completed_at >= now - lookback_hours`) joined with latest `Prediction` per event for the configured `model_name`.
+   - **Upcoming** events (`status=SCHEDULED`, `commence_time in (now, now+lookahead_hours]`) joined with latest `Prediction`, ordered by `|predicted_clv|` DESC.
+3. `build_digest_embed()` (line 251) assembles a green Discord embed with two fields:
+   - `Post-Match Results (last {window})` — each line: ✅/❌ icon, teams, score, predicted side + CLV%, and a footer `X events | Y/X correct side`.
+   - `Upcoming Predictions (next {window})` — teams, kickoff, predicted side, CLV%.
+4. Sends via `alert_manager.send_embed(embed)`. Skips silently if both sections are empty.
+
+### Domain logic
+
+- `_value_side(predicted_clv)` (line 173): positive CLV → home undervalued, negative → away. This is the home-outcome predicted-CLV convention — the digest assumes a home-side model. There is no support for a draw side or a multi-model digest.
+- `_result_hit(...)` (line 184): hit if `home_score > away_score` matches the predicted side. Draws count as a miss either way.
+- `MAX_FIELD_CHARS = 1024`: Discord field-value limit. Long fields are truncated with `...`.
+
+### Coupling
+
+- Hard-coded `model_name` default: `settings.model.name or "epl-clv-home"`.
+- Hard-coded sport display names (`_SPORT_DISPLAY_NAMES`): EPL, NBA, MLB.
+- No paper-trade integration. The digest reports model predictions but not actual paper bets placed or P&L — those are MCP-side only.
+
+---
+
+## 5. CLI status surfaces
+
+### `packages/odds-cli/odds_cli/commands/status.py`
+
+| Command | Reads | Displays |
+|---|---|---|
+| `odds status show` | `OddsReader.get_database_stats()`, latest FetchLog | Single table: last fetch (mins ago, ✓/✗), event counts by status, API quota (color-coded), 24h success rate (color-coded) |
+| `odds status show --verbose` | + `get_data_quality_logs(last 24h, limit 10)` | + event status breakdown + recent quality issues, severity-colored |
+| `odds status quota` | Last 10 FetchLog rows | Totals (used/remaining, %) + trend table with delta |
+| `odds status events --days N --team T` | Events table | List of events, status-colored, scores |
+
+These are *Rich*-printed terminal tables — no machine-readable output. The same data is also surfaced via MCP for the agent.
+
+### `packages/odds-cli/odds_cli/commands/scheduler.py`
+
+- `odds scheduler list` (line 400): calls the active scheduler backend's job listing; renders a job table. Catches `BackendUnavailableError` for backends that don't support listing (Railway).
+- `odds scheduler health` (line 439): calls `backend.health_check()` → `HealthCheckResult`; renders a green/red overall + per-check breakdown.
+
+---
+
+## 6. MCP reporting tools — `packages/odds-mcp/odds_mcp/server.py`
+
+The agent gets state through tools. Reporting-relevant ones (others fetch raw odds/fixtures):
+
+| Tool | Returns | Notes |
+|---|---|---|
+| `get_scrape_status(job_id?)` (server.py:411) | Pending+running scrape jobs; per-job state, outcome, stats, exception | Pulls from APScheduler backend |
+| `get_scheduled_jobs(sport?)` (server.py:1150) | All scheduled jobs, next_run_time, status | Substring sport filter on job name |
+| `get_predictions(event_id, limit=5, since_hours?)` (server.py:495) | Most-recent predictions for an event | |
+| `get_portfolio(initial_bankroll=1000)` (server.py:621) | Portfolio summary: bankroll, P&L, ROI, W/L/P record, open trades | Pure derivation from `PaperTrade` table |
+| `settle_bets()` (server.py:652) | Settles open trades against `FINAL` events; returns settlements | Writes to `PaperTrade` |
+| `save_match_brief(event_id, market, decision, summary, brief_text)` (server.py:676) | Creates `MatchBrief` row; snapshots sharp prices at write time | |
+| `get_slate_briefs(league, days_ahead)` (server.py:795) | Latest brief per upcoming event | Truncates to most recent brief per event |
+| `schedule_next_wakeup(sport, delay_hours, reason)` (server.py:1200) | Upserts `AgentWakeup` row (one active per sport) | Read+consumed by `agent_run` |
+
+The portfolio path is the only place "results from agent bets" surface. The daily digest doesn't read paper trades; the CLI has its own `odds paper` group that mirrors the MCP helpers.
+
+---
+
+## 7. Agent-run logs — `packages/odds-lambda/odds_lambda/jobs/agent_run.py`
+
+Not a "report" in the alerting sense — the agent's own output is captured as a JSONL trace and consumed offline.
+
+### Producer
+
+`_run_claude_agent(sport)` (agent_run.py:165) spawns:
+
+```
+claude -p "/agent {sport}" --model claude-sonnet-4-6 \
+       --output-format stream-json --verbose \
+       --dangerously-skip-permissions
+```
+
+Stream lines are:
+
+1. Always written to `logs/agent_runs/{sport}_{timestamp}_{pid}.jsonl`, with an 8 MiB per-line limit to avoid `LimitOverrunError` from `asyncio.StreamReader`.
+2. Selectively tee'd to structlog via `_log_stream_message` (agent_run.py:110):
+   - `type=assistant` blocks with `tool_use` → `agent_tool_use` (tool name + input preview).
+   - `type=result` → `agent_run_summary` (result text, num_turns, duration_ms, cost_usd).
+
+Trace files older than the 50-newest-per-sport cap are pruned each run (`AGENT_RUN_LOG_KEEP = 50`). The subprocess runs under `AGENT_DATABASE_URL` (read-only role) if set, otherwise falls back to the parent DSN with a warning.
+
+### Consumer
+
+`experiments/scripts/show_agent_summaries.py` reads the JSONL files, filters by `--sport`, `--since`, `--limit`, and prints the `result` summaries. The filename encodes `sport`, `timestamp`, `pid`; one file can contain multiple sessions (the script tracks `session_idx`).
+
+### Coupling
+
+- Filename format (`SPORT_YYYYMMDDTHHMMSSZ_PID.jsonl`) is the only schema connecting producer (`agent_run`) and consumer (`show_agent_summaries`). No DB.
+- The agent's *own* memory of its runs is `MatchBrief` rows it writes via `save_match_brief()`. The JSONL trace is for humans.
+
+---
+
+## 8. Storage backing reports
+
+All Postgres. Models live in `packages/odds-core/odds_core/models.py` unless noted.
+
+| Table | Purpose | Writers | Readers |
+|---|---|---|---|
+| `alert_history` (models.py:203) | Alert dedup + heartbeat ledger | `record_to_alert_history`, `HealthMonitor._record_alert` | `check_rate_limit`, `HealthMonitor.check_job_heartbeats`, `purge_old_heartbeats` |
+| `fetch_logs` (models.py:177) | Per-fetch result + quota snapshot | `OddsIngestionService` | `odds status` CLI, `HealthMonitor.check_consecutive_failures`, `HealthMonitor.check_api_quota` |
+| `data_quality_logs` (models.py:157) | Ingestion warnings/errors | `OddsIngestionService` | `odds status show --verbose`, `HealthMonitor.check_data_quality` |
+| `predictions` (`prediction_models.py`) | Scored predictions | `score_predictions` job | `daily_digest`, MCP `get_predictions` |
+| `match_briefs` (`match_brief_models.py`) | Agent brief log (append-only) | MCP `save_match_brief` | MCP `get_slate_briefs`, `get_match_brief` |
+| `agent_wakeups` (`agent_wakeup_models.py`) | Agent → scheduler override | MCP `schedule_next_wakeup` | `agent_run._check_agent_requested_wakeup` |
+| `paper_trades` (`paper_trade_models.py`) | Paper bets + settlements | MCP `paper_bet`, `settle_bets`; CLI mirrors | MCP `get_portfolio`, CLI `odds paper *` |
+
+Index notes:
+- `alert_history.ix_alert_type_sent_at` — composite, supports rate-limit lookup and heartbeat lookup in one shape.
+- `fetch_logs.fetch_time` — used by status CLI and HealthMonitor.
+- `paper_trades.ix_paper_trades_unsettled` — partial on `settled_at IS NULL`.
+
+---
+
+## 9. Sharp edges and quirks
+
+These are the friction points to know about before touching this code.
+
+1. **Two rate-limit implementations.** `alerts.py::check_rate_limit` (opens its own session) and `HealthMonitor._should_send_alert` (uses injected session) duplicate logic and config reading. Drifting them is easy.
+2. **Severity-blind rate limiting.** `alert_type` is the entire rate-limit key. A `warning` followed by a `critical` of the same alert_type is suppressed for `rate_limit_minutes`. For the quota chain (`quota_low` then `quota_critical`) this works only because the alert types differ — anyone adding tiered alerts must remember to pick distinct alert_types.
+3. **Heartbeat history conflated with alert history.** Heartbeats live in the same table as Discord-sent alerts, distinguished only by `alert_type` prefix (`heartbeat:`). `purge_old_heartbeats` filters on this string prefix. The schema invariant "heartbeat rows are silent, alert rows were sent" is not enforced anywhere.
+4. **Heartbeat expectations are config-only.** `settings.alerts.heartbeat_expectations` is a dict of `{job_name: max_hours}`. If a job is renamed, its heartbeat key drifts silently and the missing-heartbeat alert never fires. The same string also has to match what `job_alert_context` is called with — there is no central registry.
+5. **`HealthMetrics` is collected but never displayed.** Health-check runs gather a snapshot of the system, return it to the job, and it disappears. Discord only receives the issue strings, not the metrics object.
+6. **Daily digest is single-model and single-side.** Hard-coded home-side CLV convention; one `model_name` per run. No support for multi-model contrast, draw side, or aggregating multiple sports in one embed.
+7. **Daily digest ignores paper trades.** "What did the model say" is reported; "what did we actually bet, and how did it do" lives in a separate MCP-only surface. No Discord-side P&L summary exists.
+8. **Discord-only.** `AlertBase` is set up for plug-in channels but only `DiscordAlert` exists. Single point of failure: if the webhook URL is rotated or the Discord webhook breaks, all alerting silently no-ops (errors are logged but not surfaced anywhere else).
+9. **Webhook failure is not itself an alert.** `DiscordAlert._post` logs `discord_alert_error` on exception. There is no secondary channel and no DB-side "alert delivery failed" marker — `record_to_alert_history` is called regardless of whether the Discord POST succeeded, so a failed delivery still counts toward rate-limiting.
+10. **Rate-limit query is read-then-write without a transaction.** Two concurrent jobs can both observe "no recent alert", both send, both record. In practice jobs don't overlap on alert-type but it isn't enforced.
+11. **`alert_manager` is module-level**, instantiated at import time from global settings. Re-reading settings (e.g. flipping `alert_enabled` at runtime) requires re-importing or constructing a new manager. Tests have to monkey-patch it.
+12. **Agent-run reporting has no DB component.** The only durable record is the JSONL file. If the disk is wiped (Lambda ephemeral storage, container restart on Railway), traces are lost — `MatchBrief` is the only persistent agent record.
+13. **Sport-aware naming is ad-hoc.** Daily digest uses `make_compound_job_name("daily-digest", sport)` → `daily-digest-epl`. Other places use the sport key directly (`soccer_epl`). Heartbeat keys, CloudWatch metrics, Discord embed titles, and CLI display names each have their own translation table.
+
+---
+
+## 10. Potential improvements (low-risk, within current shape)
+
+Ranked roughly by ROI.
+
+1. **Single rate-limit/record helper.** Collapse `alerts.py::check_rate_limit + record_to_alert_history` and `HealthMonitor._should_send_alert + _record_alert + _send_alert` into one helper that takes a session if provided, or opens one if not. Eliminates a class of "fixed one, missed the other" bugs.
+2. **Separate heartbeat ledger from alert ledger.** Either a dedicated `job_heartbeats` table or a column `is_heartbeat` on `AlertHistory`. Lets `purge_old_heartbeats` stop pattern-matching on alert_type, and prevents heartbeat rows from accidentally being counted in rate-limit windows that share keys.
+3. **Job registry as the source of truth.** A single declaration of every job with `(name, sport, heartbeat_max_hours, alert_types_emitted)`. Use it to (a) wire the scheduler, (b) populate `heartbeat_expectations`, (c) validate at startup that every job emits alert_types the system knows about, (d) generate the sport-aware naming consistently.
+4. **Surface `HealthMetrics` somewhere.** Either persist `HealthStatus` per check, or post a daily metrics embed (a "system status" digest alongside the predictions digest). Currently the most useful output of the health check is thrown away.
+5. **Combined performance digest.** Have `daily_digest` also pull settled paper trades from the lookback window and append a P&L line. Closes the loop: "model said X; we bet Y; outcome was Z."
+6. **Webhook delivery feedback.** Have `DiscordAlert._post` raise on non-204 responses, let the caller decide whether to record. Optionally retry once with backoff for 5xx. Adds a `delivery_failed` boolean to AlertHistory or a separate failure table.
+7. **Severity-aware rate limiting.** Compound the rate-limit key with severity, or define an escalation rule ("a critical breaks the warning lock for the same alert_type"). Today's pattern is "pick distinct alert_types per tier", which is fragile and untyped.
+8. **Per-sport alert routing.** Send EPL alerts to one webhook, MLB to another. `AlertManager` could carry a per-channel filter (`channels: list[tuple[AlertBase, predicate]]`). The infrastructure is there; only the predicate is missing.
+9. **MCP `get_alert_history` tool.** Lets the agent see its own job context: "did fetching break for my sport in the last 6 hours?" Currently the agent has no visibility into operational health.
+10. **Trace JSONL → DB.** Write a row per session with `{sport, started_at, duration_ms, num_turns, cost_usd, result_text, file_path}` so `show_agent_summaries` can become an MCP tool / CLI query and traces stop being filesystem-only.
+
+---
+
+## 11. Alternative directions (bigger shape changes)
+
+These are not "fixes" — they're different ways the reporting layer could have been built. Useful for sketching where the system could evolve.
+
+### Bus-based instead of point-to-point
+
+Today every job pushes alerts directly through `AlertManager`. An alternative: jobs publish typed events (`JobFailed`, `QuotaLow`, `HeartbeatRecorded`, `BriefSaved`) to an internal bus; alert formatting, persistence, and channel fan-out are subscribers. Pros: decouples job logic from channel choice; trivially adds a "log all events" sink for audit. Cons: more indirection for a system with one channel and ~15 alert types.
+
+### Pull-based reporting (Prometheus-shaped)
+
+Instead of jobs pushing alerts to Discord, jobs would write metrics to a metrics store (CloudWatch, Prometheus). Discord becomes a destination for *alarm rules* over those metrics. Pros: standard tooling, dashboards for free, alerting becomes declarative ("alert when fetch_success_rate_24h < 0.95"). Cons: requires a metrics backend; loses the rich per-event context that the current digests carry.
+
+### Single "control plane" surface
+
+Replace Discord webhook + CLI + MCP with one HTTP service that:
+- Serves status, alerts, predictions, briefs, paper trades as JSON.
+- Hosts a tiny web UI for humans.
+- Discord becomes a thin push-notification channel that links back to the UI.
+
+Today the same information is rendered three ways (terminal table, Discord embed, MCP dict). A unified API would centralize the "what is the current state" query.
+
+### Briefs as event-sourced agent log
+
+Right now `MatchBrief` is append-only but each brief is a snapshot of the agent's whole reasoning. An event-sourced log of `(decision_event, prior_observations, prior_pre_market_read, …)` would let downstream tooling diff agent reasoning across briefs, score calibration over time, and replay agent state without re-running the agent. The current schema treats every brief as a fresh dump; events would expose the *delta*.
+
+### CloudWatch-native alerting
+
+The codebase already uses CloudWatch. The hand-rolled `HealthMonitor` checks (stale data, quota, consecutive failures, data quality) are exactly the kind of thing CloudWatch metric alarms handle natively. The pipeline could:
+- Emit one metric per check via PutMetricData.
+- Define CloudWatch alarms (with SNS → Discord webhook lambda).
+- Delete `HealthMonitor`.
+
+The cost: AWS-only, harder to test locally. The benefit: no custom rate-limit code, no custom heartbeat table, alarms get history and graphs for free.
+
+### Separation of "tooling alerts" and "trading alerts"
+
+Two separate Discord destinations:
+- **#odds-ops** (job failures, quota, stale data, heartbeats) — operational, mostly silent.
+- **#odds-trades** (paper trades placed, daily digest, agent run summaries) — substantive, daily traffic.
+
+Today they're collapsed into one webhook and one channel. The signal-to-noise tradeoff differs sharply between the two; they probably want different rate limits, retention, and audiences.
+
+---
+
+## 12. Reference: where each piece lives
+
+- Alert core: `packages/odds-core/odds_core/alerts.py`
+- Alert table: `packages/odds-core/odds_core/models.py:203-227` (`AlertHistory`)
+- Fetch log table: `packages/odds-core/odds_core/models.py:177-201` (`FetchLog`)
+- Data quality table: `packages/odds-core/odds_core/models.py:157-174` (`DataQualityLog`)
+- Health monitor: `packages/odds-lambda/odds_lambda/health_monitor.py`
+- Health-check job: `packages/odds-lambda/odds_lambda/jobs/check_health.py`
+- Daily digest job: `packages/odds-lambda/odds_lambda/jobs/daily_digest.py`
+- Agent-run job: `packages/odds-lambda/odds_lambda/jobs/agent_run.py`
+- Agent-run viewer: `experiments/scripts/show_agent_summaries.py`
+- Status CLI: `packages/odds-cli/odds_cli/commands/status.py`
+- Scheduler CLI: `packages/odds-cli/odds_cli/commands/scheduler.py`
+- Paper CLI: `packages/odds-cli/odds_cli/commands/paper.py`
+- MCP server: `packages/odds-mcp/odds_mcp/server.py`
+- Paper trading core: `packages/odds-core/odds_core/paper_trading.py` (helpers `place_trade`, `settle_trades`, `get_portfolio_summary`)
+- Match brief models: `packages/odds-core/odds_core/match_brief_models.py`
+- Agent wakeup models: `packages/odds-core/odds_core/agent_wakeup_models.py`
+- Paper trade models: `packages/odds-core/odds_core/paper_trade_models.py`
+- Alert config: `packages/odds-core/odds_core/config.py::AlertConfig`

--- a/experiments/scripts/show_agent_summaries.py
+++ b/experiments/scripts/show_agent_summaries.py
@@ -1,0 +1,208 @@
+"""Print agent run `.result` summaries from logs/agent_runs/ JSONL traces.
+
+Usage examples:
+    uv run python experiments/scripts/show_agent_summaries.py
+    uv run python experiments/scripts/show_agent_summaries.py --sport epl --since 24h
+    uv run python experiments/scripts/show_agent_summaries.py --sport mlb --limit 3
+    uv run python experiments/scripts/show_agent_summaries.py --file logs/agent_runs/soccer_epl_20260424T101044Z_1259597.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+LOG_DIR = Path(__file__).resolve().parents[2] / "logs" / "agent_runs"
+
+SPORT_KEYS = {
+    "epl": "soccer_epl",
+    "mlb": "baseball_mlb",
+}
+
+FILENAME_RE = re.compile(r"^(?P<sport>[a-z_]+)_(?P<ts>\d{8}T\d{6}Z)_(?P<pid>\d+)\.jsonl$")
+
+
+@dataclass
+class SessionSummary:
+    path: Path
+    sport: str
+    file_start: datetime
+    session_idx: int  # 0-based position within the file
+    duration_ms: int | None
+    num_turns: int | None
+    total_cost_usd: float | None
+    subtype: str | None
+    is_error: bool | None
+    result: str
+
+
+def parse_filename(path: Path) -> tuple[str, datetime] | None:
+    m = FILENAME_RE.match(path.name)
+    if not m:
+        return None
+    sport = m.group("sport")
+    ts = datetime.strptime(m.group("ts"), "%Y%m%dT%H%M%SZ").replace(tzinfo=UTC)
+    return sport, ts
+
+
+def parse_since(raw: str) -> datetime:
+    """Accepts `24h`, `7d`, or an ISO date/datetime. Returns an aware UTC datetime."""
+    raw = raw.strip()
+    m = re.fullmatch(r"(\d+)([hd])", raw)
+    if m:
+        value, unit = int(m.group(1)), m.group(2)
+        delta = timedelta(hours=value) if unit == "h" else timedelta(days=value)
+        return datetime.now(UTC) - delta
+    # ISO date or datetime
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError as e:
+        raise SystemExit(f"Could not parse --since {raw!r}: {e}") from e
+    return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+
+
+def iter_result_entries(path: Path):
+    with path.open() as fh:
+        for idx, line in enumerate(fh):
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if entry.get("type") == "result":
+                yield idx, entry
+
+
+def load_summaries(
+    sport_filter: str | None,
+    since: datetime | None,
+    log_dir: Path,
+    explicit_file: Path | None,
+) -> list[SessionSummary]:
+    if explicit_file is not None:
+        files = [explicit_file]
+    else:
+        files = sorted(log_dir.glob("*.jsonl"))
+
+    summaries: list[SessionSummary] = []
+    for path in files:
+        parsed = parse_filename(path)
+        if parsed is None:
+            continue
+        sport, file_start = parsed
+        if sport_filter is not None and sport != sport_filter:
+            continue
+        if since is not None and file_start < since:
+            # Filename = first session start. Later sessions in a multi-session
+            # file could still fall after `since`; walk the file anyway.
+            pass
+
+        session_idx = 0
+        for _line_no, entry in iter_result_entries(path):
+            result_text = entry.get("result") or ""
+            if not result_text:
+                session_idx += 1
+                continue
+            # Time-filter by file start when no per-session timestamp is available.
+            if since is not None and file_start < since:
+                session_idx += 1
+                continue
+            summaries.append(
+                SessionSummary(
+                    path=path,
+                    sport=sport,
+                    file_start=file_start,
+                    session_idx=session_idx,
+                    duration_ms=entry.get("duration_ms"),
+                    num_turns=entry.get("num_turns"),
+                    total_cost_usd=entry.get("total_cost_usd"),
+                    subtype=entry.get("subtype"),
+                    is_error=entry.get("is_error"),
+                    result=result_text,
+                )
+            )
+            session_idx += 1
+
+    summaries.sort(key=lambda s: (s.file_start, s.session_idx), reverse=True)
+    return summaries
+
+
+def fmt_duration(ms: int | None) -> str:
+    if ms is None:
+        return "?"
+    seconds = ms // 1000
+    m, s = divmod(seconds, 60)
+    return f"{m}m{s:02d}s"
+
+
+def fmt_cost(cost: float | None) -> str:
+    return f"${cost:.2f}" if cost is not None else "?"
+
+
+def print_summary(s: SessionSummary) -> None:
+    tag = f" session#{s.session_idx}" if s.session_idx > 0 else ""
+    header = (
+        f"[{s.file_start.strftime('%Y-%m-%d %H:%M UTC')}] {s.sport}{tag}  "
+        f"turns={s.num_turns}  {fmt_duration(s.duration_ms)}  {fmt_cost(s.total_cost_usd)}"
+    )
+    if s.is_error:
+        header += "  [ERROR]"
+    elif s.subtype and s.subtype != "success":
+        header += f"  [{s.subtype}]"
+    print(header)
+    print(f"  file: {s.path.name}")
+    body = s.result
+    indented = "\n".join(f"  {line}" for line in body.splitlines())
+    print(indented)
+    print()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sport", choices=sorted(SPORT_KEYS), help="Filter by sport")
+    parser.add_argument(
+        "--since",
+        help="Time filter: `24h`, `7d`, or ISO date (e.g. 2026-04-20).",
+    )
+    parser.add_argument("--limit", type=int, default=10, help="Max sessions to show (default 10).")
+    parser.add_argument("--full", action="store_true", help="Print the full result text.")
+    parser.add_argument("--file", type=Path, help="Target a specific JSONL file.")
+    parser.add_argument(
+        "--log-dir",
+        type=Path,
+        default=LOG_DIR,
+        help=f"Agent-run log directory (default {LOG_DIR}).",
+    )
+    args = parser.parse_args(argv)
+
+    sport_filter = SPORT_KEYS.get(args.sport) if args.sport else None
+    since = parse_since(args.since) if args.since else None
+
+    summaries = load_summaries(
+        sport_filter=sport_filter,
+        since=since,
+        log_dir=args.log_dir,
+        explicit_file=args.file,
+    )
+
+    if not summaries:
+        print("No sessions matched.", file=sys.stderr)
+        return 1
+
+    total = len(summaries)
+    shown = min(total, args.limit)
+    if total > shown:
+        print(f"Showing last {shown} of {total} — raise --limit to see more\n")
+
+    for s in reversed(summaries[: args.limit]):
+        print_summary(s)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- `docs/REPORTING.md` — maps the pipeline's reporting surfaces (Discord alerts, health monitoring, daily digest, CLI status, MCP state tools, agent-run traces) and the Postgres tables backing them, with a section on known sharp edges/quirks and a ranked list of low-risk improvements plus bigger alternative directions.
- `experiments/scripts/show_agent_summaries.py` — prints agent-run `result` summaries from `logs/agent_runs/` JSONL traces, with `--sport`, `--since`, `--limit`, `--full`, `--file` filters.

## Notes
- `REPORTING.md` is not yet wired into the doc index table in `CLAUDE.md` — happy to add it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)