### PR TITLE
Bootstrap fetch-mlb-probables and pin agent model

### DIFF
--- a/packages/odds-core/odds_core/config.py
+++ b/packages/odds-core/odds_core/config.py
@@ -93,6 +93,7 @@ class SchedulerConfig(BaseSettings):
             "daily-digest",
             "fetch-espn-fixtures",
             "fetch-betfair-exchange",
+            "fetch-mlb-probables",
         ],
         description="Jobs to bootstrap when starting the local scheduler",
     )

--- a/packages/odds-lambda/odds_lambda/jobs/agent_run.py
+++ b/packages/odds-lambda/odds_lambda/jobs/agent_run.py
@@ -174,6 +174,8 @@ async def _run_claude_agent(sport: SportKey) -> int:
         "claude",
         "-p",
         f"/agent {sport}",
+        "--model",
+        "claude-sonnet-4-6",
         "--output-format",
         "stream-json",
         "--verbose",


### PR DESCRIPTION
## Summary
- **Bootstrap `fetch-mlb-probables`** — the job was registered (cron `0 6 * * *` for MLB) but never added to `bootstrap_jobs`, so it did not self-schedule on local scheduler start.
- **Pin the agent subprocess to `claude-sonnet-4-6`** — make the cron-driven agent run deterministic rather than inheriting the caller's default model.

## Follow-up
The hardcoded model is a known TODO to parametrize (config field + `AGENT_MODEL` env override); this PR just makes the current behaviour explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)