### PR TITLE
Pin OddsHarvester dependency to tag odds-fork-2026.05.29

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ odds-lambda = { workspace = true }
 odds-analytics = { workspace = true }
 odds-cli = { workspace = true }
 odds-mcp = { workspace = true }
-oddsharvester = { git = "https://github.com/Acusick1/OddsHarvester.git", branch = "fix/fractional-odds-and-unknown-bookmaker" }
+oddsharvester = { git = "https://github.com/Acusick1/OddsHarvester.git", tag = "odds-fork-2026.05.29" }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -418,7 +418,7 @@ dev = [
     { name = "jupyter", specifier = ">=1.1.1" },
     { name = "matplotlib", specifier = ">=3.10.7" },
     { name = "numpy", specifier = ">=1.24.0" },
-    { name = "oddsharvester", git = "https://github.com/Acusick1/OddsHarvester.git?branch=fix%2Ffractional-odds-and-unknown-bookmaker" },
+    { name = "oddsharvester", git = "https://github.com/Acusick1/OddsHarvester.git?tag=odds-fork-2026.05.29" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "plotly", specifier = ">=6.3.1" },
     { name = "pre-commit", specifier = ">=3.5.0" },
@@ -3131,8 +3131,8 @@ requires-dist = [
 
 [[package]]
 name = "oddsharvester"
-version = "0.1.0"
-source = { git = "https://github.com/Acusick1/OddsHarvester.git?branch=fix%2Ffractional-odds-and-unknown-bookmaker#ffb64c47c4b389fbfda3b0e8b2fbb2c740e7fbf3" }
+version = "0.3.0"
+source = { git = "https://github.com/Acusick1/OddsHarvester.git?tag=odds-fork-2026.05.29#9343f8f0deebdc869e474c30606d0a0b260accf9" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "boto3" },


### PR DESCRIPTION
Re-pin the `oddsharvester` git dependency from the
`fix/fractional-odds-and-unknown-bookmaker` branch to the immutable tag
`odds-fork-2026.05.29`.

The fork was rebased onto upstream and tag-pinned so the dependency no
longer tracks a moving branch. The scraper was live-verified working
against this tag.

- `pyproject.toml`: source `branch=…` → `tag=odds-fork-2026.05.29`
- `uv.lock`: resolved to tag commit `9343f8f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)