### PR TITLE
Make get_probable_pitchers MCP tool read-only

### DIFF
--- a/packages/odds-core/odds_core/mlb_data_models.py
+++ b/packages/odds-core/odds_core/mlb_data_models.py
@@ -34,6 +34,29 @@ class MlbProbablePitchersRecord:
     away_pitcher_id: int | None = None
 
 
+def select_latest_in_window(
+    records: list[MlbProbablePitchersRecord],
+    start: datetime,
+    end: datetime,
+) -> list[MlbProbablePitchersRecord]:
+    """Latest record per ``game_pk`` whose ``commence_time`` is in ``[start, end]``.
+
+    The single selection rule shared by the live read-through path (records
+    straight from MLBAM) and the cached read path (records mapped from persisted
+    snapshots), so both produce identically shaped results. Records outside the
+    window are dropped; among records for the same ``game_pk`` the newest
+    ``fetched_at`` wins. Ordered by ``commence_time`` ascending.
+    """
+    latest: dict[int, MlbProbablePitchersRecord] = {}
+    for record in records:
+        if not (start <= record.commence_time <= end):
+            continue
+        existing = latest.get(record.game_pk)
+        if existing is None or record.fetched_at > existing.fetched_at:
+            latest[record.game_pk] = record
+    return sorted(latest.values(), key=lambda r: r.commence_time)
+
+
 class MlbProbablePitchers(SQLModel, table=True):
     """Snapshot of MLBAM's probable-pitcher state for a single game.
 

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_mlb_probables.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_mlb_probables.py
@@ -1,4 +1,4 @@
-"""Fetch MLB probable-pitcher snapshots — backstop for days the agent doesn't run.
+"""Fetch MLB probable-pitcher snapshots — sole writer of ``mlb_probable_pitchers``.
 
 Flow:
 1. Hit MLB Stats API ``/schedule`` with the ``probablePitcher`` hydration for
@@ -7,10 +7,11 @@ Flow:
    (idempotent on ``(game_pk, fetched_at)``).
 3. Alerts on failure via ``job_alert_context``.
 
-The MCP ``get_probable_pitchers`` tool is the primary write path; this cron
-exists to keep the announcement-timing series populated on days the agent
-doesn't fire. The 3-day window matches MLBAM's empirical populate rate
-(D+0 fully populated, D+1..D+3 partial, D+4 onwards empty).
+This cron is the only write path for the snapshot table. The MCP
+``get_probable_pitchers`` tool is read-only — it read-throughs MLBAM live for
+agent freshness but never persists, so the agent's read-mostly DB role needs
+no write grant on the table. The 3-day window matches MLBAM's empirical
+populate rate (D+0 fully populated, D+1..D+3 partial, D+4 onwards empty).
 """
 
 from __future__ import annotations

--- a/packages/odds-lambda/odds_lambda/storage/mlb_pitcher_reader.py
+++ b/packages/odds-lambda/odds_lambda/storage/mlb_pitcher_reader.py
@@ -5,11 +5,35 @@ from __future__ import annotations
 from datetime import datetime
 
 import structlog
-from odds_core.mlb_data_models import MlbProbablePitchers
+from odds_core.mlb_data_models import (
+    MlbProbablePitchers,
+    MlbProbablePitchersRecord,
+    select_latest_in_window,
+)
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = structlog.get_logger(__name__)
+
+
+def _to_record(row: MlbProbablePitchers) -> MlbProbablePitchersRecord:
+    """Map a persisted snapshot row to the in-memory domain record.
+
+    Keeps the SQLModel persistence type from escaping the storage layer — the
+    reader speaks in domain records, the same type the fetcher produces.
+    """
+    return MlbProbablePitchersRecord(
+        game_pk=row.game_pk,
+        commence_time=row.commence_time,
+        fetched_at=row.fetched_at,
+        home_team=row.home_team,
+        away_team=row.away_team,
+        game_type=row.game_type,
+        home_pitcher_name=row.home_pitcher_name,
+        home_pitcher_id=row.home_pitcher_id,
+        away_pitcher_name=row.away_pitcher_name,
+        away_pitcher_id=row.away_pitcher_id,
+    )
 
 
 class MlbPitcherReader:
@@ -22,34 +46,30 @@ class MlbPitcherReader:
         self,
         start: datetime,
         end: datetime,
-    ) -> list[MlbProbablePitchers]:
-        """Return the latest snapshot per ``game_pk`` whose ``commence_time`` falls in ``[start, end]``.
+    ) -> list[MlbProbablePitchersRecord]:
+        """Return the latest snapshot per ``game_pk`` whose ``commence_time`` is in ``[start, end]``.
 
-        Uses ``DISTINCT ON (game_pk)`` against an ordering that picks the
-        newest ``fetched_at`` per ``game_pk``, then re-sorts by
-        ``commence_time`` ascending so the caller sees games in kickoff order.
+        SQL bounds the rows transferred to the commence-time window; the
+        latest-per-``game_pk`` selection and ordering are delegated to
+        :func:`select_latest_in_window` so the cached read path and the live
+        read-through path apply one identical rule. Returns domain records,
+        ordered by ``commence_time`` ascending.
         """
         if start > end:
             raise ValueError("start must be <= end")
 
-        # DISTINCT ON requires the leading ORDER BY column to match.
-        inner = (
+        stmt = (
             select(MlbProbablePitchers)
             .where(MlbProbablePitchers.commence_time >= start)
             .where(MlbProbablePitchers.commence_time <= end)
-            .distinct(MlbProbablePitchers.game_pk)
-            .order_by(
-                MlbProbablePitchers.game_pk,
-                MlbProbablePitchers.fetched_at.desc(),
-            )
         )
-        result = await self.session.execute(inner)
-        rows = list(result.scalars().all())
-        rows.sort(key=lambda r: r.commence_time)
+        result = await self.session.execute(stmt)
+        records = [_to_record(row) for row in result.scalars().all()]
+        selected = select_latest_in_window(records, start, end)
         logger.info(
             "mlb_probable_pitchers_loaded",
-            count=len(rows),
+            count=len(selected),
             start=start.isoformat(),
             end=end.isoformat(),
         )
-        return rows
+        return selected

--- a/packages/odds-mcp/agents/mlb/base.md
+++ b/packages/odds-mcp/agents/mlb/base.md
@@ -14,7 +14,7 @@ When calling MCP tools, use these MLB parameters:
 - `find_retail_edges`: `sharp_bookmakers=["betfair_exchange"]` (Pinnacle is absent for MLB; Betfair Exchange is the sole sharp reference)
 - `refresh_scrape`: `league="mlb"`, `market="home_away"`
 - `paper_bet`: `market="h2h"`, `selection="home"` or `selection="away"`
-- `get_probable_pitchers`: returns announced probable starting pitchers for the next `lookahead_hours` (default 48). Write-through: each call hits MLB Stats API live and appends a snapshot. Null pitcher fields mean "not yet announced" — a meaningful signal for upcoming-day games. The tool **cannot** flag opener / bulk-role; web-search if you suspect one.
+- `get_probable_pitchers`: returns announced probable starting pitchers for the next `lookahead_hours` (default 48). Read-only — by default (`refresh=True`) it read-throughs MLB Stats API live and returns the current state per game without persisting (falling back to the cached snapshot table on an MLBAM outage); `refresh=False` reads the cached snapshots only. `fetch_status` (`live` / `stale_db_only` / `db_only`) tells you which. Null pitcher fields mean "not yet announced" — a meaningful signal for upcoming-day games. The tool **cannot** flag opener / bulk-role; web-search if you suspect one.
 
 ## Data Sources
 

--- a/packages/odds-mcp/odds_mcp/tools/mlb.py
+++ b/packages/odds-mcp/odds_mcp/tools/mlb.py
@@ -14,11 +14,48 @@ from odds_core.database import async_session_maker
 from odds_core.mlb_data_models import MlbProbablePitchersRecord
 from odds_lambda.mlb_stats_fetcher import MlbStatsFetcher, dates_for_window
 from odds_lambda.storage.mlb_pitcher_reader import MlbPitcherReader
-from odds_lambda.storage.mlb_pitcher_writer import MlbPitcherWriter
 
 logger = structlog.get_logger()
 
 mlb_mcp = FastMCP("odds-mcp-mlb")
+
+
+def _game_dict(row: Any, now: datetime) -> dict[str, Any]:
+    """Format a probable-pitcher row (live record or DB row) for the response."""
+    hours_until = (row.commence_time - now).total_seconds() / 3600.0
+    return {
+        "game_pk": row.game_pk,
+        "commence_time": row.commence_time.isoformat(),
+        "home_team": row.home_team,
+        "away_team": row.away_team,
+        "home_pitcher_name": row.home_pitcher_name,
+        "home_pitcher_id": row.home_pitcher_id,
+        "away_pitcher_name": row.away_pitcher_name,
+        "away_pitcher_id": row.away_pitcher_id,
+        "fetched_at": row.fetched_at.isoformat(),
+        "hours_until_commence": round(hours_until, 3),
+    }
+
+
+def _latest_in_window(
+    records: list[MlbProbablePitchersRecord],
+    start: datetime,
+    end: datetime,
+) -> list[MlbProbablePitchersRecord]:
+    """Latest record per ``game_pk`` whose ``commence_time`` is in ``[start, end]``.
+
+    Mirrors :meth:`MlbPitcherReader.get_latest_in_window` so live (unpersisted)
+    records and cached DB rows are filtered identically. Ordered by
+    ``commence_time`` ascending.
+    """
+    latest: dict[int, MlbProbablePitchersRecord] = {}
+    for record in records:
+        if not (start <= record.commence_time <= end):
+            continue
+        existing = latest.get(record.game_pk)
+        if existing is None or record.fetched_at > existing.fetched_at:
+            latest[record.game_pk] = record
+    return sorted(latest.values(), key=lambda r: r.commence_time)
 
 
 @mlb_mcp.tool()
@@ -28,20 +65,22 @@ async def get_probable_pitchers(
 ) -> dict[str, Any]:
     """Return announced probable starting pitchers for upcoming MLB games.
 
-    By default (``refresh=True``), this is write-through-on-every-call: hits
-    the MLB Stats API for the dates covering ``[now, now + lookahead_hours]``,
-    appends a snapshot row per game to ``mlb_probable_pitchers``, then
-    returns the latest row per ``game_pk`` whose ``commence_time`` falls in
-    the lookahead window.
+    This tool is read-only: it never writes to ``mlb_probable_pitchers``. The
+    ``fetch-mlb-probables`` cron owns the snapshot table.
+
+    By default (``refresh=True``), it read-throughs live: hits the MLB Stats
+    API for the dates covering ``[now, now + lookahead_hours]`` and returns the
+    current state per game *without persisting it*. This keeps the agent
+    late-scratch-aware near game time. On HTTP failure it falls back to the
+    cached snapshot table so a transient MLBAM outage doesn't blank the slate.
 
     Pass ``refresh=False`` to skip the live fetch entirely and read straight
-    from the cached snapshot table. Useful when the agent only needs a
-    quick lookup and an earlier call (or the daily backstop cron) has
-    already populated the table.
+    from the cached snapshot table — useful for a quick lookup when the cron
+    (or a recent live call) has already populated current data.
 
     ``fetch_status`` distinguishes the three modes:
 
-    - ``"live"`` — successful live fetch, snapshot appended, latest read.
+    - ``"live"`` — successful live fetch; current state returned, nothing written.
     - ``"stale_db_only"`` — ``refresh=True`` but MLBAM HTTP failed; fell
       back to DB read so the agent can decide whether the cached data is
       fresh enough.
@@ -60,9 +99,9 @@ async def get_probable_pitchers(
     Args:
         lookahead_hours: Hours from now to include in the response. Clamped
             to ``[1, 168]``. Default 48h covers today + tomorrow's slate.
-        refresh: When True (default), live-fetch from MLBAM, append a
-            snapshot, and return the latest row per game. When False, skip
-            the fetch and return the latest cached snapshot per game.
+        refresh: When True (default), live-fetch from MLBAM and return the
+            current state per game without persisting. When False, skip the
+            fetch and return the latest cached snapshot per game.
 
     Returns:
         Dict with ``fetched_at``, ``lookahead_hours``, ``fetch_status``
@@ -74,13 +113,19 @@ async def get_probable_pitchers(
     now = datetime.now(UTC)
     end = now + timedelta(hours=lookahead_hours)
 
-    records: list[MlbProbablePitchersRecord] = []
     if refresh:
         target_dates = dates_for_window(now, lookahead_hours)
-        fetch_status = "live"
         try:
             async with MlbStatsFetcher() as fetcher:
                 records = await fetcher.fetch_dates(target_dates, fetched_at=now)
+            games = [_game_dict(r, now) for r in _latest_in_window(records, now, end)]
+            return {
+                "fetched_at": now.isoformat(),
+                "lookahead_hours": lookahead_hours,
+                "fetch_status": "live",
+                "game_count": len(games),
+                "games": games,
+            }
         except httpx.HTTPError as e:
             logger.warning(
                 "get_probable_pitchers_fetch_failed",
@@ -92,32 +137,10 @@ async def get_probable_pitchers(
         fetch_status = "db_only"
 
     async with async_session_maker() as session:
-        if records:
-            writer = MlbPitcherWriter(session)
-            await writer.insert_snapshots(records)
-            await session.commit()
-
         reader = MlbPitcherReader(session)
         rows = await reader.get_latest_in_window(now, end)
 
-    games: list[dict[str, Any]] = []
-    for row in rows:
-        hours_until = (row.commence_time - now).total_seconds() / 3600.0
-        games.append(
-            {
-                "game_pk": row.game_pk,
-                "commence_time": row.commence_time.isoformat(),
-                "home_team": row.home_team,
-                "away_team": row.away_team,
-                "home_pitcher_name": row.home_pitcher_name,
-                "home_pitcher_id": row.home_pitcher_id,
-                "away_pitcher_name": row.away_pitcher_name,
-                "away_pitcher_id": row.away_pitcher_id,
-                "fetched_at": row.fetched_at.isoformat(),
-                "hours_until_commence": round(hours_until, 3),
-            }
-        )
-
+    games = [_game_dict(row, now) for row in rows]
     return {
         "fetched_at": now.isoformat(),
         "lookahead_hours": lookahead_hours,

--- a/packages/odds-mcp/odds_mcp/tools/mlb.py
+++ b/packages/odds-mcp/odds_mcp/tools/mlb.py
@@ -7,7 +7,7 @@ namespace, so tool names are exposed verbatim to clients.
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from typing import Any, Literal
+from typing import Literal
 
 import httpx
 import structlog
@@ -89,7 +89,7 @@ class ProbablePitchersResponse(BaseModel):
 async def get_probable_pitchers(
     lookahead_hours: int = 48,
     refresh: bool = True,
-) -> dict[str, Any]:
+) -> ProbablePitchersResponse:
     """Return announced probable starting pitchers for upcoming MLB games.
 
     This tool is read-only: it never writes to ``mlb_probable_pitchers``. The
@@ -131,9 +131,11 @@ async def get_probable_pitchers(
             fetch and return the latest cached snapshot per game.
 
     Returns:
-        Dict with ``fetched_at``, ``lookahead_hours``, ``fetch_status``
-        (``"live"`` | ``"stale_db_only"`` | ``"db_only"``), and ``games``
-        (a list ordered by ``commence_time`` ascending; each entry carries
+        A :class:`ProbablePitchersResponse` (FastMCP advertises its schema as
+        the tool's structured output) carrying ``fetched_at``,
+        ``lookahead_hours``, ``fetch_status``
+        (``"live"`` | ``"stale_db_only"`` | ``"db_only"``), ``game_count``, and
+        ``games`` (ordered by ``commence_time`` ascending; each entry carries
         its own ``fetched_at`` indicating when that row was last refreshed).
     """
     lookahead_hours = max(1, min(int(lookahead_hours), 168))
@@ -147,8 +149,7 @@ async def get_probable_pitchers(
             async with MlbStatsFetcher() as fetcher:
                 records = await fetcher.fetch_dates(target_dates, fetched_at=now)
             selected = select_latest_in_window(records, now, end)
-            response = ProbablePitchersResponse.from_records(selected, now, lookahead_hours, "live")
-            return response.model_dump()
+            return ProbablePitchersResponse.from_records(selected, now, lookahead_hours, "live")
         except httpx.HTTPError as e:
             logger.warning(
                 "get_probable_pitchers_fetch_failed",
@@ -163,5 +164,4 @@ async def get_probable_pitchers(
         reader = MlbPitcherReader(session)
         records = await reader.get_latest_in_window(now, end)
 
-    response = ProbablePitchersResponse.from_records(records, now, lookahead_hours, fetch_status)
-    return response.model_dump()
+    return ProbablePitchersResponse.from_records(records, now, lookahead_hours, fetch_status)

--- a/packages/odds-mcp/odds_mcp/tools/mlb.py
+++ b/packages/odds-mcp/odds_mcp/tools/mlb.py
@@ -4,58 +4,85 @@ Mounted onto the parent ``odds-mcp`` server in :mod:`odds_mcp.server` without a
 namespace, so tool names are exposed verbatim to clients.
 """
 
+from __future__ import annotations
+
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 import structlog
 from fastmcp import FastMCP
 from odds_core.database import async_session_maker
-from odds_core.mlb_data_models import MlbProbablePitchersRecord
+from odds_core.mlb_data_models import MlbProbablePitchersRecord, select_latest_in_window
 from odds_lambda.mlb_stats_fetcher import MlbStatsFetcher, dates_for_window
 from odds_lambda.storage.mlb_pitcher_reader import MlbPitcherReader
+from pydantic import BaseModel
 
 logger = structlog.get_logger()
 
 mlb_mcp = FastMCP("odds-mcp-mlb")
 
-
-def _game_dict(row: Any, now: datetime) -> dict[str, Any]:
-    """Format a probable-pitcher row (live record or DB row) for the response."""
-    hours_until = (row.commence_time - now).total_seconds() / 3600.0
-    return {
-        "game_pk": row.game_pk,
-        "commence_time": row.commence_time.isoformat(),
-        "home_team": row.home_team,
-        "away_team": row.away_team,
-        "home_pitcher_name": row.home_pitcher_name,
-        "home_pitcher_id": row.home_pitcher_id,
-        "away_pitcher_name": row.away_pitcher_name,
-        "away_pitcher_id": row.away_pitcher_id,
-        "fetched_at": row.fetched_at.isoformat(),
-        "hours_until_commence": round(hours_until, 3),
-    }
+FetchStatus = Literal["live", "stale_db_only", "db_only"]
 
 
-def _latest_in_window(
-    records: list[MlbProbablePitchersRecord],
-    start: datetime,
-    end: datetime,
-) -> list[MlbProbablePitchersRecord]:
-    """Latest record per ``game_pk`` whose ``commence_time`` is in ``[start, end]``.
+class ProbablePitcherGame(BaseModel):
+    """One game's probable-pitcher state in the ``get_probable_pitchers`` response."""
 
-    Mirrors :meth:`MlbPitcherReader.get_latest_in_window` so live (unpersisted)
-    records and cached DB rows are filtered identically. Ordered by
-    ``commence_time`` ascending.
-    """
-    latest: dict[int, MlbProbablePitchersRecord] = {}
-    for record in records:
-        if not (start <= record.commence_time <= end):
-            continue
-        existing = latest.get(record.game_pk)
-        if existing is None or record.fetched_at > existing.fetched_at:
-            latest[record.game_pk] = record
-    return sorted(latest.values(), key=lambda r: r.commence_time)
+    game_pk: int
+    commence_time: str
+    home_team: str
+    away_team: str
+    home_pitcher_name: str | None
+    home_pitcher_id: int | None
+    away_pitcher_name: str | None
+    away_pitcher_id: int | None
+    fetched_at: str
+    hours_until_commence: float
+
+    @classmethod
+    def from_record(cls, record: MlbProbablePitchersRecord, now: datetime) -> ProbablePitcherGame:
+        """Serialize a domain record into the response shape, stamping freshness."""
+        hours_until = (record.commence_time - now).total_seconds() / 3600.0
+        return cls(
+            game_pk=record.game_pk,
+            commence_time=record.commence_time.isoformat(),
+            home_team=record.home_team,
+            away_team=record.away_team,
+            home_pitcher_name=record.home_pitcher_name,
+            home_pitcher_id=record.home_pitcher_id,
+            away_pitcher_name=record.away_pitcher_name,
+            away_pitcher_id=record.away_pitcher_id,
+            fetched_at=record.fetched_at.isoformat(),
+            hours_until_commence=round(hours_until, 3),
+        )
+
+
+class ProbablePitchersResponse(BaseModel):
+    """Validated contract for the ``get_probable_pitchers`` tool output."""
+
+    fetched_at: str
+    lookahead_hours: int
+    fetch_status: FetchStatus
+    game_count: int
+    games: list[ProbablePitcherGame]
+
+    @classmethod
+    def from_records(
+        cls,
+        records: list[MlbProbablePitchersRecord],
+        now: datetime,
+        lookahead_hours: int,
+        fetch_status: FetchStatus,
+    ) -> ProbablePitchersResponse:
+        """Build the response from already-selected, ordered domain records."""
+        games = [ProbablePitcherGame.from_record(r, now) for r in records]
+        return cls(
+            fetched_at=now.isoformat(),
+            lookahead_hours=lookahead_hours,
+            fetch_status=fetch_status,
+            game_count=len(games),
+            games=games,
+        )
 
 
 @mlb_mcp.tool()
@@ -113,19 +140,15 @@ async def get_probable_pitchers(
     now = datetime.now(UTC)
     end = now + timedelta(hours=lookahead_hours)
 
+    fetch_status: FetchStatus
     if refresh:
         target_dates = dates_for_window(now, lookahead_hours)
         try:
             async with MlbStatsFetcher() as fetcher:
                 records = await fetcher.fetch_dates(target_dates, fetched_at=now)
-            games = [_game_dict(r, now) for r in _latest_in_window(records, now, end)]
-            return {
-                "fetched_at": now.isoformat(),
-                "lookahead_hours": lookahead_hours,
-                "fetch_status": "live",
-                "game_count": len(games),
-                "games": games,
-            }
+            selected = select_latest_in_window(records, now, end)
+            response = ProbablePitchersResponse.from_records(selected, now, lookahead_hours, "live")
+            return response.model_dump()
         except httpx.HTTPError as e:
             logger.warning(
                 "get_probable_pitchers_fetch_failed",
@@ -138,13 +161,7 @@ async def get_probable_pitchers(
 
     async with async_session_maker() as session:
         reader = MlbPitcherReader(session)
-        rows = await reader.get_latest_in_window(now, end)
+        records = await reader.get_latest_in_window(now, end)
 
-    games = [_game_dict(row, now) for row in rows]
-    return {
-        "fetched_at": now.isoformat(),
-        "lookahead_hours": lookahead_hours,
-        "fetch_status": fetch_status,
-        "game_count": len(games),
-        "games": games,
-    }
+    response = ProbablePitchersResponse.from_records(records, now, lookahead_hours, fetch_status)
+    return response.model_dump()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -43,6 +43,7 @@ class TestSettings:
                 "daily-digest",
                 "fetch-espn-fixtures",
                 "fetch-betfair-exchange",
+                "fetch-mlb-probables",
             ]
             assert settings.data_quality.enable_validation is True
             assert settings.data_quality.reject_invalid_odds is False

--- a/tests/unit/test_mlb_probable_pitchers_tool.py
+++ b/tests/unit/test_mlb_probable_pitchers_tool.py
@@ -342,16 +342,16 @@ class TestGetProbablePitchersTool:
         assert list(result_db.scalars().all()) == []
 
         # Only the in-window game is returned, built straight from the live records.
-        assert result["lookahead_hours"] == 48
-        assert result["fetch_status"] == "live"
-        assert result["game_count"] == 1
-        game = result["games"][0]
-        assert game["game_pk"] == 1
-        assert game["home_pitcher_name"] == "Home Ace"
-        assert game["away_pitcher_name"] == "Away Ace"
+        assert result.lookahead_hours == 48
+        assert result.fetch_status == "live"
+        assert result.game_count == 1
+        game = result.games[0]
+        assert game.game_pk == 1
+        assert game.home_pitcher_name == "Home Ace"
+        assert game.away_pitcher_name == "Away Ace"
         # The fetcher re-stamps every live record with the tool's fetch time.
-        assert game["fetched_at"] == result["fetched_at"]
-        assert "hours_until_commence" in game
+        assert game.fetched_at == result.fetched_at
+        assert game.hours_until_commence is not None
 
     @pytest.mark.asyncio
     async def test_live_collapses_duplicate_game_pk(self, pglite_async_session) -> None:
@@ -383,8 +383,8 @@ class TestGetProbablePitchersTool:
         # Nothing persisted; the duplicate game_pk collapses to a single entry.
         result_db = await pglite_async_session.execute(select(MlbProbablePitchers))
         assert list(result_db.scalars().all()) == []
-        assert result["game_count"] == 1
-        assert result["games"][0]["game_pk"] == 42
+        assert result.game_count == 1
+        assert result.games[0].game_pk == 42
 
     @pytest.mark.asyncio
     async def test_refresh_false_skips_fetch_and_reads_db(self, pglite_async_session) -> None:
@@ -413,10 +413,10 @@ class TestGetProbablePitchersTool:
         ):
             result = await mlb_module.get_probable_pitchers(lookahead_hours=48, refresh=False)
 
-        assert result["fetch_status"] == "db_only"
-        assert result["game_count"] == 1
-        assert result["games"][0]["game_pk"] == 77
-        assert result["games"][0]["fetched_at"] == prior_fetch.isoformat()
+        assert result.fetch_status == "db_only"
+        assert result.game_count == 1
+        assert result.games[0].game_pk == 77
+        assert result.games[0].fetched_at == prior_fetch.isoformat()
         fetcher_factory.assert_not_called()
 
     @pytest.mark.asyncio
@@ -453,11 +453,11 @@ class TestGetProbablePitchersTool:
         ):
             result = await mlb_module.get_probable_pitchers(lookahead_hours=48)
 
-        assert result["fetch_status"] == "stale_db_only"
-        assert result["game_count"] == 1
-        assert result["games"][0]["game_pk"] == 99
+        assert result.fetch_status == "stale_db_only"
+        assert result.game_count == 1
+        assert result.games[0].game_pk == 99
         # The returned row carries the prior fetch's timestamp, not "now".
-        assert result["games"][0]["fetched_at"] == prior_fetch.isoformat()
+        assert result.games[0].fetched_at == prior_fetch.isoformat()
 
         # No new snapshot row written on the failed fetch.
         rows_db = await pglite_async_session.execute(select(MlbProbablePitchers))
@@ -495,4 +495,69 @@ class TestGetProbablePitchersTool:
         ):
             result = await mlb_module.get_probable_pitchers(lookahead_hours=48)
 
-        assert [g["game_pk"] for g in result["games"]] == [1, 2]
+        assert [g.game_pk for g in result.games] == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# get_probable_pitchers exposed through the FastMCP server — verifies the
+# Pydantic return type is advertised as a structured output schema and that
+# the structured content round-trips for a client.
+# ---------------------------------------------------------------------------
+
+
+class TestGetProbablePitchersViaMcp:
+    @pytest.mark.asyncio
+    async def test_advertises_structured_output_schema(self) -> None:
+        """The mounted tool exposes the ProbablePitchersResponse shape as its output schema."""
+        from fastmcp import Client
+        from odds_mcp.server import mcp as odds_mcp_server
+
+        async with Client(odds_mcp_server) as client:
+            tools = await client.list_tools()
+
+        tool = next(t for t in tools if t.name == "get_probable_pitchers")
+        schema = tool.outputSchema
+        assert schema is not None, "tool must advertise a structured output schema"
+        props = schema["properties"]
+        assert {"fetched_at", "lookahead_hours", "fetch_status", "game_count", "games"} <= set(
+            props
+        )
+        # The nested per-game shape is described on the games array's items.
+        game_defs = schema.get("$defs", {}).get("ProbablePitcherGame", props["games"]["items"])
+        assert {"game_pk", "home_pitcher_name", "hours_until_commence"} <= set(
+            game_defs["properties"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_call_returns_structured_content(self, pglite_async_session) -> None:
+        """A client call yields structured content that round-trips through the schema."""
+        from fastmcp import Client
+        from odds_mcp.server import mcp as odds_mcp_server
+        from odds_mcp.tools import mlb as mlb_module
+
+        in_window = datetime.now(UTC) + timedelta(hours=12)
+        prior_fetch = datetime.now(UTC) - timedelta(hours=6)
+        writer = MlbPitcherWriter(pglite_async_session)
+        await writer.insert_snapshots(
+            [_record(game_pk=77, fetched_at=prior_fetch, commence_time=in_window)]
+        )
+        await pglite_async_session.commit()
+
+        session_cm = MagicMock()
+        session_cm.__aenter__ = AsyncMock(return_value=pglite_async_session)
+        session_cm.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(mlb_module, "async_session_maker", return_value=session_cm):
+            async with Client(odds_mcp_server) as client:
+                result = await client.call_tool(
+                    "get_probable_pitchers",
+                    {"lookahead_hours": 48, "refresh": False},
+                )
+
+        assert not result.is_error
+        structured = result.structured_content
+        assert structured["fetch_status"] == "db_only"
+        assert structured["game_count"] == 1
+        assert structured["games"][0]["game_pk"] == 77
+        # FastMCP deserializes the structured content back into the typed shape.
+        assert result.data.games[0].game_pk == 77

--- a/tests/unit/test_mlb_probable_pitchers_tool.py
+++ b/tests/unit/test_mlb_probable_pitchers_tool.py
@@ -8,7 +8,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
-from odds_core.mlb_data_models import MlbProbablePitchers, MlbProbablePitchersRecord
+from odds_core.mlb_data_models import (
+    MlbProbablePitchers,
+    MlbProbablePitchersRecord,
+    select_latest_in_window,
+)
 from odds_lambda.storage.mlb_pitcher_reader import MlbPitcherReader
 from odds_lambda.storage.mlb_pitcher_writer import MlbPitcherWriter
 from sqlalchemy import select
@@ -138,6 +142,8 @@ class TestMlbPitcherReader:
         )
 
         assert len(rows) == 1
+        # The reader speaks in domain records — the SQLModel type stays in storage.
+        assert isinstance(rows[0], MlbProbablePitchersRecord)
         # Latest is the second_fetch row (pitcher announced).
         assert rows[0].fetched_at == second_fetch
         assert rows[0].home_pitcher_name == "Home Ace"
@@ -189,6 +195,61 @@ class TestMlbPitcherReader:
         )
 
         assert [r.game_pk for r in rows] == [1]
+
+
+class TestSelectLatestInWindow:
+    """The pure selection rule shared by the live and cached read paths."""
+
+    def test_drops_out_of_window_records(self) -> None:
+        now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+        fetched = datetime(2026, 4, 26, 6, 0, tzinfo=UTC)
+        records = [
+            _record(game_pk=1, fetched_at=fetched, commence_time=now + timedelta(hours=6)),
+            _record(game_pk=2, fetched_at=fetched, commence_time=now + timedelta(days=9)),
+        ]
+
+        selected = select_latest_in_window(records, now, now + timedelta(hours=48))
+
+        assert [r.game_pk for r in selected] == [1]
+
+    def test_keeps_newest_fetched_at_per_game(self) -> None:
+        now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+        commence = now + timedelta(hours=6)
+        records = [
+            _record(
+                game_pk=1,
+                fetched_at=datetime(2026, 4, 26, 6, 0, tzinfo=UTC),
+                commence_time=commence,
+                home_pitcher=None,
+                home_pitcher_id=None,
+            ),
+            _record(
+                game_pk=1,
+                fetched_at=datetime(2026, 4, 26, 10, 0, tzinfo=UTC),
+                commence_time=commence,
+            ),
+        ]
+
+        selected = select_latest_in_window(records, now, now + timedelta(hours=48))
+
+        assert len(selected) == 1
+        assert selected[0].home_pitcher_name == "Home Ace"
+
+    def test_orders_by_commence_time(self) -> None:
+        now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+        fetched = datetime(2026, 4, 26, 6, 0, tzinfo=UTC)
+        records = [
+            _record(game_pk=2, fetched_at=fetched, commence_time=now + timedelta(hours=20)),
+            _record(game_pk=1, fetched_at=fetched, commence_time=now + timedelta(hours=4)),
+        ]
+
+        selected = select_latest_in_window(records, now, now + timedelta(hours=48))
+
+        assert [r.game_pk for r in selected] == [1, 2]
+
+    def test_empty_input_returns_empty(self) -> None:
+        now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+        assert select_latest_in_window([], now, now + timedelta(hours=48)) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mlb_probable_pitchers_tool.py
+++ b/tests/unit/test_mlb_probable_pitchers_tool.py
@@ -192,7 +192,7 @@ class TestMlbPitcherReader:
 
 
 # ---------------------------------------------------------------------------
-# get_probable_pitchers MCP tool — full write-through path with mocked fetcher.
+# get_probable_pitchers MCP tool — read-only path with mocked fetcher.
 # ---------------------------------------------------------------------------
 
 
@@ -243,7 +243,7 @@ class _FakeFetcher:
 
 class TestGetProbablePitchersTool:
     @pytest.mark.asyncio
-    async def test_write_through_returns_persisted_rows(self, pglite_async_session) -> None:
+    async def test_live_returns_fetched_rows_without_writing(self, pglite_async_session) -> None:
         from odds_mcp.tools import mlb as mlb_module
 
         in_window = datetime.now(UTC) + timedelta(hours=12)
@@ -254,7 +254,7 @@ class TestGetProbablePitchersTool:
                 [
                     _record(
                         game_pk=1,
-                        fetched_at=datetime(1970, 1, 1, tzinfo=UTC),  # rewritten by tool
+                        fetched_at=datetime(1970, 1, 1, tzinfo=UTC),
                         commence_time=in_window,
                     ),
                     _record(
@@ -276,11 +276,11 @@ class TestGetProbablePitchersTool:
         ):
             result = await mlb_module.get_probable_pitchers(lookahead_hours=48)
 
-        # Both rows persisted, but only the in-window game is returned.
+        # Read-only: nothing is persisted on a live fetch.
         result_db = await pglite_async_session.execute(select(MlbProbablePitchers))
-        all_rows = list(result_db.scalars().all())
-        assert {r.game_pk for r in all_rows} == {1, 2}
+        assert list(result_db.scalars().all()) == []
 
+        # Only the in-window game is returned, built straight from the live records.
         assert result["lookahead_hours"] == 48
         assert result["fetch_status"] == "live"
         assert result["game_count"] == 1
@@ -288,63 +288,42 @@ class TestGetProbablePitchersTool:
         assert game["game_pk"] == 1
         assert game["home_pitcher_name"] == "Home Ace"
         assert game["away_pitcher_name"] == "Away Ace"
+        # The fetcher re-stamps every live record with the tool's fetch time.
+        assert game["fetched_at"] == result["fetched_at"]
         assert "hours_until_commence" in game
-        assert "fetched_at" in game
 
     @pytest.mark.asyncio
-    async def test_idempotent_recall_appends_new_fetched_at_row(self, pglite_async_session) -> None:
+    async def test_live_collapses_duplicate_game_pk(self, pglite_async_session) -> None:
+        """MLBAM's ±1-day over-fetch can return a game_pk twice; collapse to one entry."""
         from odds_mcp.tools import mlb as mlb_module
 
+        live_fetch = datetime.now(UTC)
         in_window = datetime.now(UTC) + timedelta(hours=12)
 
-        # First call: pitcher not yet announced. Second call: pitcher announced.
-        first_records = [
-            _record(
-                game_pk=42,
-                fetched_at=datetime(1970, 1, 1, tzinfo=UTC),
-                commence_time=in_window,
-                home_pitcher=None,
-                home_pitcher_id=None,
-            )
-        ]
-        second_records = [
-            _record(
-                game_pk=42,
-                fetched_at=datetime(1970, 1, 1, tzinfo=UTC),
-                commence_time=in_window,
-            )
-        ]
-        fake_fetcher_first = _FakeFetcher([first_records])
-        fake_fetcher_second = _FakeFetcher([second_records])
+        fake_fetcher = _FakeFetcher(
+            [
+                [
+                    _record(game_pk=42, fetched_at=live_fetch, commence_time=in_window),
+                    _record(game_pk=42, fetched_at=live_fetch, commence_time=in_window),
+                ]
+            ]
+        )
 
         session_cm = MagicMock()
         session_cm.__aenter__ = AsyncMock(return_value=pglite_async_session)
         session_cm.__aexit__ = AsyncMock(return_value=None)
 
         with (
-            patch.object(mlb_module, "MlbStatsFetcher", return_value=fake_fetcher_first),
+            patch.object(mlb_module, "MlbStatsFetcher", return_value=fake_fetcher),
             patch.object(mlb_module, "async_session_maker", return_value=session_cm),
         ):
-            first = await mlb_module.get_probable_pitchers(lookahead_hours=48)
+            result = await mlb_module.get_probable_pitchers(lookahead_hours=48)
 
-        with (
-            patch.object(mlb_module, "MlbStatsFetcher", return_value=fake_fetcher_second),
-            patch.object(mlb_module, "async_session_maker", return_value=session_cm),
-        ):
-            second = await mlb_module.get_probable_pitchers(lookahead_hours=48)
-
-        # Both calls returned a row for the same game.
-        assert first["game_count"] == 1
-        assert second["game_count"] == 1
-        assert first["games"][0]["home_pitcher_name"] is None
-        assert second["games"][0]["home_pitcher_name"] == "Home Ace"
-
-        # Two snapshot rows were persisted (different fetched_at values).
-        result_db = await pglite_async_session.execute(
-            select(MlbProbablePitchers).order_by(MlbProbablePitchers.fetched_at)
-        )
-        rows = list(result_db.scalars().all())
-        assert len(rows) == 2
+        # Nothing persisted; the duplicate game_pk collapses to a single entry.
+        result_db = await pglite_async_session.execute(select(MlbProbablePitchers))
+        assert list(result_db.scalars().all()) == []
+        assert result["game_count"] == 1
+        assert result["games"][0]["game_pk"] == 42
 
     @pytest.mark.asyncio
     async def test_refresh_false_skips_fetch_and_reads_db(self, pglite_async_session) -> None:


### PR DESCRIPTION
## Summary

Makes the MLB probable-pitcher data path read-only, then layers it cleanly. The MLB agent runs as the read-mostly `odds_agent` role with no INSERT on `mlb_probable_pitchers`, so the write-through `get_probable_pitchers` tool failed every MLB slate with `InsufficientPrivilegeError`. The fix is architectural: `mlb_probable_pitchers` is pipeline-ingested reference data the agent reads, not writes.

This PR carries three stacked layers (originally #379/#380 + #381 + a follow-on; the stack was collapsed into this single PR):

### 1. Read-only tool — closes #379

- **`packages/odds-mcp/odds_mcp/tools/mlb.py`** — tool is fully read-only. Dropped the writer, `insert_snapshots`, and `commit`. `refresh=True` read-throughs MLBAM live and returns current state per game without persisting; on `httpx.HTTPError` it falls back to the cached DB read (`stale_db_only`). `refresh=False` reads cached only (`db_only`).
- **`packages/odds-lambda/odds_lambda/jobs/fetch_mlb_probables.py`** — docstring declares the daily cron the sole writer of the snapshot table.
- **`tests/unit/test_config.py`** — added the missing `fetch-mlb-probables` entry to the expected `bootstrap_jobs` default (pre-existing CI failure from #377).

The issue's date-boundary concern was confirmed a non-issue: the window filter (`now <= commence_time <= end`) excludes prior-day games regardless of MLBAM's ±1-day over-fetch.

### 2. Repository pattern over the read path

Layers the path along its three real boundaries so the persistence type stops leaking outward and the live/cached read paths can't drift apart. This matches the project's Model Types convention (SQLModel = DB, Pydantic = API responses).

- **`packages/odds-core/odds_core/mlb_data_models.py`** — `select_latest_in_window`: the single latest-per-`game_pk` window-selection rule, as a pure function over domain records.
- **`packages/odds-lambda/odds_lambda/storage/mlb_pitcher_reader.py`** — `get_latest_in_window` returns `MlbProbablePitchersRecord` domain records (mapped at the storage boundary via `_to_record`) and delegates selection to `select_latest_in_window`. SQL only does the coarse `commence_time` window bound; the SQLModel type no longer escapes storage.
- **`packages/odds-mcp/odds_mcp/tools/mlb.py`** — ad-hoc response dict replaced by Pydantic `ProbablePitchersResponse` / `ProbablePitcherGame`; `fetch_status` is a validated `Literal`. Both the live and cached paths run records through the **same** `select_latest_in_window`, so results are identical *by construction*. Removes the interim `_game_dict(row: Any)` and `_latest_in_window` helpers.

This resolves the original review notes: the `Any` typing is gone (one concrete type past storage), the duplicated SQL-vs-Python "latest-in-window" logic collapses into one function, and the stringly-typed dict becomes a validated contract.

### 3. Structured MCP output schema (follow-on)

- **`packages/odds-mcp/odds_mcp/tools/mlb.py`** — the tool now returns `ProbablePitchersResponse` directly rather than `model_dump()`. FastMCP advertises the model as the tool's **structured output schema**, so agents/clients receive typed structured content instead of an opaque dict.
- **`tests/unit/test_mlb_probable_pitchers_tool.py`** — direct-call tests move to attribute access; adds MCP-level tests that drive the tool through the in-memory FastMCP client and assert (a) the advertised output schema and (b) round-tripped structured content.

## Test plan

- `uv run pytest tests/unit/test_mlb_probable_pitchers_tool.py tests/unit/test_mlb_stats_fetcher.py` — 28 passed.
- `ruff check` / `ruff format` clean; pre-commit hooks pass.

## Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
