### PR TITLE
Apply repository pattern to MLB probable-pitcher reads

### DIFF
--- a/packages/odds-core/odds_core/mlb_data_models.py
+++ b/packages/odds-core/odds_core/mlb_data_models.py
@@ -34,6 +34,29 @@ class MlbProbablePitchersRecord:
     away_pitcher_id: int | None = None
 
 
+def select_latest_in_window(
+    records: list[MlbProbablePitchersRecord],
+    start: datetime,
+    end: datetime,
+) -> list[MlbProbablePitchersRecord]:
+    """Latest record per ``game_pk`` whose ``commence_time`` is in ``[start, end]``.
+
+    The single selection rule shared by the live read-through path (records
+    straight from MLBAM) and the cached read path (records mapped from persisted
+    snapshots), so both produce identically shaped results. Records outside the
+    window are dropped; among records for the same ``game_pk`` the newest
+    ``fetched_at`` wins. Ordered by ``commence_time`` ascending.
+    """
+    latest: dict[int, MlbProbablePitchersRecord] = {}
+    for record in records:
+        if not (start <= record.commence_time <= end):
+            continue
+        existing = latest.get(record.game_pk)
+        if existing is None or record.fetched_at > existing.fetched_at:
+            latest[record.game_pk] = record
+    return sorted(latest.values(), key=lambda r: r.commence_time)
+
+
 class MlbProbablePitchers(SQLModel, table=True):
     """Snapshot of MLBAM's probable-pitcher state for a single game.
 

--- a/packages/odds-lambda/odds_lambda/storage/mlb_pitcher_reader.py
+++ b/packages/odds-lambda/odds_lambda/storage/mlb_pitcher_reader.py
@@ -5,11 +5,35 @@ from __future__ import annotations
 from datetime import datetime
 
 import structlog
-from odds_core.mlb_data_models import MlbProbablePitchers
+from odds_core.mlb_data_models import (
+    MlbProbablePitchers,
+    MlbProbablePitchersRecord,
+    select_latest_in_window,
+)
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = structlog.get_logger(__name__)
+
+
+def _to_record(row: MlbProbablePitchers) -> MlbProbablePitchersRecord:
+    """Map a persisted snapshot row to the in-memory domain record.
+
+    Keeps the SQLModel persistence type from escaping the storage layer — the
+    reader speaks in domain records, the same type the fetcher produces.
+    """
+    return MlbProbablePitchersRecord(
+        game_pk=row.game_pk,
+        commence_time=row.commence_time,
+        fetched_at=row.fetched_at,
+        home_team=row.home_team,
+        away_team=row.away_team,
+        game_type=row.game_type,
+        home_pitcher_name=row.home_pitcher_name,
+        home_pitcher_id=row.home_pitcher_id,
+        away_pitcher_name=row.away_pitcher_name,
+        away_pitcher_id=row.away_pitcher_id,
+    )
 
 
 class MlbPitcherReader:
@@ -22,34 +46,30 @@ class MlbPitcherReader:
         self,
         start: datetime,
         end: datetime,
-    ) -> list[MlbProbablePitchers]:
-        """Return the latest snapshot per ``game_pk`` whose ``commence_time`` falls in ``[start, end]``.
+    ) -> list[MlbProbablePitchersRecord]:
+        """Return the latest snapshot per ``game_pk`` whose ``commence_time`` is in ``[start, end]``.
 
-        Uses ``DISTINCT ON (game_pk)`` against an ordering that picks the
-        newest ``fetched_at`` per ``game_pk``, then re-sorts by
-        ``commence_time`` ascending so the caller sees games in kickoff order.
+        SQL bounds the rows transferred to the commence-time window; the
+        latest-per-``game_pk`` selection and ordering are delegated to
+        :func:`select_latest_in_window` so the cached read path and the live
+        read-through path apply one identical rule. Returns domain records,
+        ordered by ``commence_time`` ascending.
         """
         if start > end:
             raise ValueError("start must be <= end")
 
-        # DISTINCT ON requires the leading ORDER BY column to match.
-        inner = (
+        stmt = (
             select(MlbProbablePitchers)
             .where(MlbProbablePitchers.commence_time >= start)
             .where(MlbProbablePitchers.commence_time <= end)
-            .distinct(MlbProbablePitchers.game_pk)
-            .order_by(
-                MlbProbablePitchers.game_pk,
-                MlbProbablePitchers.fetched_at.desc(),
-            )
         )
-        result = await self.session.execute(inner)
-        rows = list(result.scalars().all())
-        rows.sort(key=lambda r: r.commence_time)
+        result = await self.session.execute(stmt)
+        records = [_to_record(row) for row in result.scalars().all()]
+        selected = select_latest_in_window(records, start, end)
         logger.info(
             "mlb_probable_pitchers_loaded",
-            count=len(rows),
+            count=len(selected),
             start=start.isoformat(),
             end=end.isoformat(),
         )
-        return rows
+        return selected

--- a/packages/odds-mcp/odds_mcp/tools/mlb.py
+++ b/packages/odds-mcp/odds_mcp/tools/mlb.py
@@ -4,58 +4,85 @@ Mounted onto the parent ``odds-mcp`` server in :mod:`odds_mcp.server` without a
 namespace, so tool names are exposed verbatim to clients.
 """
 
+from __future__ import annotations
+
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 import structlog
 from fastmcp import FastMCP
 from odds_core.database import async_session_maker
-from odds_core.mlb_data_models import MlbProbablePitchersRecord
+from odds_core.mlb_data_models import MlbProbablePitchersRecord, select_latest_in_window
 from odds_lambda.mlb_stats_fetcher import MlbStatsFetcher, dates_for_window
 from odds_lambda.storage.mlb_pitcher_reader import MlbPitcherReader
+from pydantic import BaseModel
 
 logger = structlog.get_logger()
 
 mlb_mcp = FastMCP("odds-mcp-mlb")
 
-
-def _game_dict(row: Any, now: datetime) -> dict[str, Any]:
-    """Format a probable-pitcher row (live record or DB row) for the response."""
-    hours_until = (row.commence_time - now).total_seconds() / 3600.0
-    return {
-        "game_pk": row.game_pk,
-        "commence_time": row.commence_time.isoformat(),
-        "home_team": row.home_team,
-        "away_team": row.away_team,
-        "home_pitcher_name": row.home_pitcher_name,
-        "home_pitcher_id": row.home_pitcher_id,
-        "away_pitcher_name": row.away_pitcher_name,
-        "away_pitcher_id": row.away_pitcher_id,
-        "fetched_at": row.fetched_at.isoformat(),
-        "hours_until_commence": round(hours_until, 3),
-    }
+FetchStatus = Literal["live", "stale_db_only", "db_only"]
 
 
-def _latest_in_window(
-    records: list[MlbProbablePitchersRecord],
-    start: datetime,
-    end: datetime,
-) -> list[MlbProbablePitchersRecord]:
-    """Latest record per ``game_pk`` whose ``commence_time`` is in ``[start, end]``.
+class ProbablePitcherGame(BaseModel):
+    """One game's probable-pitcher state in the ``get_probable_pitchers`` response."""
 
-    Mirrors :meth:`MlbPitcherReader.get_latest_in_window` so live (unpersisted)
-    records and cached DB rows are filtered identically. Ordered by
-    ``commence_time`` ascending.
-    """
-    latest: dict[int, MlbProbablePitchersRecord] = {}
-    for record in records:
-        if not (start <= record.commence_time <= end):
-            continue
-        existing = latest.get(record.game_pk)
-        if existing is None or record.fetched_at > existing.fetched_at:
-            latest[record.game_pk] = record
-    return sorted(latest.values(), key=lambda r: r.commence_time)
+    game_pk: int
+    commence_time: str
+    home_team: str
+    away_team: str
+    home_pitcher_name: str | None
+    home_pitcher_id: int | None
+    away_pitcher_name: str | None
+    away_pitcher_id: int | None
+    fetched_at: str
+    hours_until_commence: float
+
+    @classmethod
+    def from_record(cls, record: MlbProbablePitchersRecord, now: datetime) -> ProbablePitcherGame:
+        """Serialize a domain record into the response shape, stamping freshness."""
+        hours_until = (record.commence_time - now).total_seconds() / 3600.0
+        return cls(
+            game_pk=record.game_pk,
+            commence_time=record.commence_time.isoformat(),
+            home_team=record.home_team,
+            away_team=record.away_team,
+            home_pitcher_name=record.home_pitcher_name,
+            home_pitcher_id=record.home_pitcher_id,
+            away_pitcher_name=record.away_pitcher_name,
+            away_pitcher_id=record.away_pitcher_id,
+            fetched_at=record.fetched_at.isoformat(),
+            hours_until_commence=round(hours_until, 3),
+        )
+
+
+class ProbablePitchersResponse(BaseModel):
+    """Validated contract for the ``get_probable_pitchers`` tool output."""
+
+    fetched_at: str
+    lookahead_hours: int
+    fetch_status: FetchStatus
+    game_count: int
+    games: list[ProbablePitcherGame]
+
+    @classmethod
+    def from_records(
+        cls,
+        records: list[MlbProbablePitchersRecord],
+        now: datetime,
+        lookahead_hours: int,
+        fetch_status: FetchStatus,
+    ) -> ProbablePitchersResponse:
+        """Build the response from already-selected, ordered domain records."""
+        games = [ProbablePitcherGame.from_record(r, now) for r in records]
+        return cls(
+            fetched_at=now.isoformat(),
+            lookahead_hours=lookahead_hours,
+            fetch_status=fetch_status,
+            game_count=len(games),
+            games=games,
+        )
 
 
 @mlb_mcp.tool()
@@ -113,19 +140,15 @@ async def get_probable_pitchers(
     now = datetime.now(UTC)
     end = now + timedelta(hours=lookahead_hours)
 
+    fetch_status: FetchStatus
     if refresh:
         target_dates = dates_for_window(now, lookahead_hours)
         try:
             async with MlbStatsFetcher() as fetcher:
                 records = await fetcher.fetch_dates(target_dates, fetched_at=now)
-            games = [_game_dict(r, now) for r in _latest_in_window(records, now, end)]
-            return {
-                "fetched_at": now.isoformat(),
-                "lookahead_hours": lookahead_hours,
-                "fetch_status": "live",
-                "game_count": len(games),
-                "games": games,
-            }
+            selected = select_latest_in_window(records, now, end)
+            response = ProbablePitchersResponse.from_records(selected, now, lookahead_hours, "live")
+            return response.model_dump()
         except httpx.HTTPError as e:
             logger.warning(
                 "get_probable_pitchers_fetch_failed",
@@ -138,13 +161,7 @@ async def get_probable_pitchers(
 
     async with async_session_maker() as session:
         reader = MlbPitcherReader(session)
-        rows = await reader.get_latest_in_window(now, end)
+        records = await reader.get_latest_in_window(now, end)
 
-    games = [_game_dict(row, now) for row in rows]
-    return {
-        "fetched_at": now.isoformat(),
-        "lookahead_hours": lookahead_hours,
-        "fetch_status": fetch_status,
-        "game_count": len(games),
-        "games": games,
-    }
+    response = ProbablePitchersResponse.from_records(records, now, lookahead_hours, fetch_status)
+    return response.model_dump()

--- a/tests/unit/test_mlb_probable_pitchers_tool.py
+++ b/tests/unit/test_mlb_probable_pitchers_tool.py
@@ -8,7 +8,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
-from odds_core.mlb_data_models import MlbProbablePitchers, MlbProbablePitchersRecord
+from odds_core.mlb_data_models import (
+    MlbProbablePitchers,
+    MlbProbablePitchersRecord,
+    select_latest_in_window,
+)
 from odds_lambda.storage.mlb_pitcher_reader import MlbPitcherReader
 from odds_lambda.storage.mlb_pitcher_writer import MlbPitcherWriter
 from sqlalchemy import select
@@ -138,6 +142,8 @@ class TestMlbPitcherReader:
         )
 
         assert len(rows) == 1
+        # The reader speaks in domain records — the SQLModel type stays in storage.
+        assert isinstance(rows[0], MlbProbablePitchersRecord)
         # Latest is the second_fetch row (pitcher announced).
         assert rows[0].fetched_at == second_fetch
         assert rows[0].home_pitcher_name == "Home Ace"
@@ -189,6 +195,61 @@ class TestMlbPitcherReader:
         )
 
         assert [r.game_pk for r in rows] == [1]
+
+
+class TestSelectLatestInWindow:
+    """The pure selection rule shared by the live and cached read paths."""
+
+    def test_drops_out_of_window_records(self) -> None:
+        now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+        fetched = datetime(2026, 4, 26, 6, 0, tzinfo=UTC)
+        records = [
+            _record(game_pk=1, fetched_at=fetched, commence_time=now + timedelta(hours=6)),
+            _record(game_pk=2, fetched_at=fetched, commence_time=now + timedelta(days=9)),
+        ]
+
+        selected = select_latest_in_window(records, now, now + timedelta(hours=48))
+
+        assert [r.game_pk for r in selected] == [1]
+
+    def test_keeps_newest_fetched_at_per_game(self) -> None:
+        now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+        commence = now + timedelta(hours=6)
+        records = [
+            _record(
+                game_pk=1,
+                fetched_at=datetime(2026, 4, 26, 6, 0, tzinfo=UTC),
+                commence_time=commence,
+                home_pitcher=None,
+                home_pitcher_id=None,
+            ),
+            _record(
+                game_pk=1,
+                fetched_at=datetime(2026, 4, 26, 10, 0, tzinfo=UTC),
+                commence_time=commence,
+            ),
+        ]
+
+        selected = select_latest_in_window(records, now, now + timedelta(hours=48))
+
+        assert len(selected) == 1
+        assert selected[0].home_pitcher_name == "Home Ace"
+
+    def test_orders_by_commence_time(self) -> None:
+        now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+        fetched = datetime(2026, 4, 26, 6, 0, tzinfo=UTC)
+        records = [
+            _record(game_pk=2, fetched_at=fetched, commence_time=now + timedelta(hours=20)),
+            _record(game_pk=1, fetched_at=fetched, commence_time=now + timedelta(hours=4)),
+        ]
+
+        selected = select_latest_in_window(records, now, now + timedelta(hours=48))
+
+        assert [r.game_pk for r in selected] == [1, 2]
+
+    def test_empty_input_returns_empty(self) -> None:
+        now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+        assert select_latest_in_window([], now, now + timedelta(hours=48)) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up refactor to #380, applying the **repository pattern** to the MLB probable-pitcher data path. #380 made the `get_probable_pitchers` tool read-only; this layers the path along its three real boundaries so the persistence type stops leaking outward and the live/cached read paths can no longer drift apart.

This matches the project's own Model Types convention (SQLModel = DB, Pydantic = API responses, dataclass = containers), which the path previously violated by returning SQLModel rows to the formatter and emitting an ad-hoc stringly-typed dict.

**Stacked on `issue-379-probable-pitchers-read-only` (#380).** Base it on `main` after #380 merges (or merge #380 first).

## Changes

- **`packages/odds-core/odds_core/mlb_data_models.py`** — add `select_latest_in_window`: the single latest-per-`game_pk` window-selection rule, as a pure function over domain records.
- **`packages/odds-lambda/odds_lambda/storage/mlb_pitcher_reader.py`** — `get_latest_in_window` now returns `MlbProbablePitchersRecord` domain records (mapped from rows at the storage boundary via `_to_record`) and delegates selection to `select_latest_in_window`. SQL only does the coarse `commence_time` window bound. The SQLModel type no longer escapes storage.
- **`packages/odds-mcp/odds_mcp/tools/mlb.py`** — replace the ad-hoc response dict with Pydantic `ProbablePitchersResponse` / `ProbablePitcherGame`; `fetch_status` is now a `Literal` validated at construction. Both the live read-through and the cached-fallback path run records through the **same** `select_latest_in_window`, so results are identical *by construction* rather than by hand-mirroring the SQL reader. Removes the `_game_dict(row: Any)` and `_latest_in_window` helpers #380 added (this supersedes them).
- **`tests/unit/test_mlb_probable_pitchers_tool.py`** — add `TestSelectLatestInWindow` (window filter, latest-per-game, ordering, empty) and assert the reader returns domain records (locks "SQLModel stays in storage").

## What this resolves from the #380 review

- **`_game_dict(row: Any)` typing** — gone. The polymorphism it papered over is removed: nothing past storage sees a SQLModel row, so there's one concrete type and no `Any`.
- **Duplicated "latest-in-window" logic** — the SQL `DISTINCT ON` reader and the in-memory `_latest_in_window` that "mirrored" it are collapsed into one pure function used by both paths.
- **Stringly-typed dict response** — replaced by a validated Pydantic contract.

## Deliberate scoping

- **External tool output is unchanged** — the tool returns `response.model_dump()`, preserving the exact dict contract (and all #380 tool tests pass unchanged). Returning the Pydantic model directly to advertise a structured MCP output schema is a reasonable next step but is a wire-format change best done deliberately with MCP-level testing; out of scope here.
- **Selection moved to Python** — the reader transfers in-window rows and dedups in memory rather than via `DISTINCT ON`. At this data scale (days × ~15 games × snapshots) that's trivial, and it buys provably-identical live/cached behavior. If the timing series grows large, invert it: treat the pure function as the spec and keep `DISTINCT ON` as an optimization pinned by a shared test.

## Test plan

- `uv run pytest tests/unit/test_mlb_probable_pitchers_tool.py tests/unit/test_mlb_stats_fetcher.py` — 26 passed.
- `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
