### PR TITLE
Season-aware scheduling: gate forward jobs on next fixture proximity

### DIFF
--- a/packages/odds-core/odds_core/config.py
+++ b/packages/odds-core/odds_core/config.py
@@ -112,7 +112,7 @@ class SchedulerConfig(BaseSettings):
         description="Jobs to bootstrap when starting the local scheduler",
     )
 
-    def lead_days_for(self, sport_key: SportKey | str) -> int:
+    def lead_days_for(self, sport_key: SportKey) -> int:
         """Return the season-gate lead (days) for a sport, with default fallback."""
         return self.season_lead_days.get(sport_key, DEFAULT_SEASON_LEAD_DAYS)
 

--- a/packages/odds-core/odds_core/config.py
+++ b/packages/odds-core/odds_core/config.py
@@ -66,6 +66,12 @@ class DataCollectionConfig(BaseSettings):
     regions: list[str] = Field(default=["us"], description="Regions for odds data")
 
 
+# Fallback season lead (days) for sports without an explicit ``season_lead_days``
+# entry: forward collection jobs do real work only when the next kickoff is
+# within this many days, otherwise they sleep until ``next_kickoff − lead``.
+DEFAULT_SEASON_LEAD_DAYS = 7
+
+
 class SchedulerConfig(BaseSettings):
     """Scheduler backend configuration."""
 
@@ -85,6 +91,14 @@ class SchedulerConfig(BaseSettings):
         default=7,
         description="How many days ahead to check for games when scheduling",
     )
+    season_lead_days: dict[SportKey, int] = Field(
+        default_factory=dict,
+        description=(
+            "Per-sport lead time (days) for the forward season gate: collection "
+            "jobs do real work only when the next kickoff is within this many "
+            f"days. Sports absent from this map use {DEFAULT_SEASON_LEAD_DAYS}d."
+        ),
+    )
     bootstrap_jobs: list[str] = Field(
         default=[
             # "agent-run",
@@ -97,6 +111,10 @@ class SchedulerConfig(BaseSettings):
         ],
         description="Jobs to bootstrap when starting the local scheduler",
     )
+
+    def lead_days_for(self, sport_key: SportKey | str) -> int:
+        """Return the season-gate lead (days) for a sport, with default fallback."""
+        return self.season_lead_days.get(sport_key, DEFAULT_SEASON_LEAD_DAYS)
 
 
 class AWSConfig(BaseSettings):

--- a/packages/odds-lambda/odds_lambda/jobs/agent_run.py
+++ b/packages/odds-lambda/odds_lambda/jobs/agent_run.py
@@ -58,15 +58,13 @@ AGENT_RUN_LOG_KEEP = 50
 # payload) routinely exceeds it and would raise ``LimitOverrunError``.
 AGENT_STREAM_LINE_LIMIT = 8 * 1024 * 1024
 
-# Horizon for "no fixtures" classification (matches decide_forward lookahead).
-FIXTURE_HORIZON_DAYS = 7
-
 
 class ScheduleResult(NamedTuple):
     """Values computed by schedule_next(), reused by main() for overrides."""
 
     next_time: datetime
     compound_job_name: str
+    should_execute: bool
 
 
 def _preview_tool_input(d: dict[str, Any] | None, *, max_value_chars: int = 60) -> str | None:
@@ -266,9 +264,10 @@ async def schedule_next(sport: SportKey) -> ScheduleResult:
 
     Uses the unified decision engine to map fixture proximity to a wake
     interval (canonical FetchTier boundaries, agent ``CADENCE`` values) with
-    the sport's overnight suppression applied. The agent always wakes — the
-    decision's ``should_execute`` gate is ignored; only ``next_execution`` is
-    used.
+    the sport's overnight suppression applied. The returned ``should_execute``
+    is the season gate: ``False`` when the next fixture is beyond the lead
+    window (or absent), in which case the precise wake is scheduled and the
+    caller must skip launching the agent.
 
     This is the crash-safe pre-scheduling step — called both during bootstrap
     (without launching the agent) and at the start of a full agent run.
@@ -287,7 +286,7 @@ async def schedule_next(sport: SportKey) -> ScheduleResult:
         [sport],
         CADENCE,
         overnight=OVERNIGHT_WINDOWS[sport],
-        lookahead_days=FIXTURE_HORIZON_DAYS,
+        lookahead_days=settings.scheduler.lead_days_for(sport),
     )
     assert decision.next_execution is not None  # noqa: S101
     logger.info("agent_proximity", sport=sport, reason=decision.reason)
@@ -307,6 +306,7 @@ async def schedule_next(sport: SportKey) -> ScheduleResult:
     return ScheduleResult(
         next_time=decision.next_execution,
         compound_job_name=compound_job_name,
+        should_execute=decision.should_execute,
     )
 
 
@@ -321,6 +321,15 @@ async def main(ctx: JobContext) -> None:
 
     # --- Pre-schedule before work (crash-safe) ---
     result = await schedule_next(sport)
+
+    # --- Season gate: skip the agent run when no fixture is within the lead ---
+    if not result.should_execute:
+        logger.info(
+            "agent_run_season_gated",
+            sport=sport,
+            next_execution=result.next_time.isoformat(),
+        )
+        return
 
     # --- Run the agent ---
     exit_code = await _run_claude_agent(sport)

--- a/packages/odds-lambda/odds_lambda/jobs/daily_digest.py
+++ b/packages/odds-lambda/odds_lambda/jobs/daily_digest.py
@@ -345,12 +345,19 @@ async def main(ctx: JobContext) -> None:
     """Main job entry point."""
     from odds_core.alerts import job_alert_context
 
+    from odds_lambda.scheduling.helpers import within_lead
     from odds_lambda.scheduling.jobs import make_compound_job_name
 
     sport = ctx.sport
     sport_key = sport or DEFAULT_SPORT_KEY
     lookback_hours = ctx.lookback_hours
     lookahead_hours = ctx.lookahead_hours
+
+    # Season gate: skip in the offseason when no fixture is within the lead.
+    lead_days = get_settings().scheduler.lead_days_for(sport_key)
+    if not await within_lead(sport_key, lead_days):
+        logger.info("daily_digest_season_gated", sport_key=sport_key, lead_days=lead_days)
+        return
 
     async with job_alert_context(make_compound_job_name("daily-digest", sport)):
         logger.info(

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_betfair_exchange.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_betfair_exchange.py
@@ -229,7 +229,8 @@ async def main(ctx: JobContext) -> None:
     # per-sport path). Combined local runs span sports with different windows,
     # so no suppression is applied there.
     overnight = OVERNIGHT_WINDOWS.get(target_sports[0]) if len(target_sports) == 1 else None
-    # Most conservative lead across targeted sports (combined runs wake earliest).
+    # Combined runs use the minimum lead across targeted sports, so the gate
+    # opens no later than the shortest-lead sport requires.
     lead_days = min(settings.scheduler.lead_days_for(sk) for sk in target_sports)
 
     # Season-gated fetcher: skip the API fetch (and re-gate on every cron

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_betfair_exchange.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_betfair_exchange.py
@@ -229,11 +229,16 @@ async def main(ctx: JobContext) -> None:
     # per-sport path). Combined local runs span sports with different windows,
     # so no suppression is applied there.
     overnight = OVERNIGHT_WINDOWS.get(target_sports[0]) if len(target_sports) == 1 else None
+    # Most conservative lead across targeted sports (combined runs wake earliest).
+    lead_days = min(settings.scheduler.lead_days_for(sk) for sk in target_sports)
 
-    # Always-run fetcher (no execution gate): we only use the decision's
-    # proximity-derived next_execution, not should_execute.
+    # Season-gated fetcher: skip the API fetch (and re-gate on every cron
+    # safety-floor fire) when no fixture is within the lead window. The decision
+    # self-schedules the precise wake either way.
     async def _reschedule(label: str) -> ScheduleDecision:
-        decision = await decide_forward_resilient(target_sports, CADENCE, overnight=overnight)
+        decision = await decide_forward_resilient(
+            target_sports, CADENCE, overnight=overnight, lookahead_days=lead_days
+        )
         assert decision.next_execution is not None  # noqa: S101
         try:
             await self_schedule(
@@ -251,7 +256,17 @@ async def main(ctx: JobContext) -> None:
 
     # Pre-schedule before doing the work, so a crash mid-fetch doesn't break
     # the chain.
-    await _reschedule("pre-schedule")
+    decision = await _reschedule("pre-schedule")
+
+    # Season gate: no fixture within the lead window — skip the Betfair login/fetch.
+    if not decision.should_execute:
+        logger.info(
+            "betfair_season_gated",
+            sport=sport,
+            next_execution=decision.next_execution.isoformat(),
+            reason=decision.reason,
+        )
+        return
 
     snapshot_time = datetime.now(UTC)
     all_stats: list[IngestionStats] = []

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_betfair_exchange.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_betfair_exchange.py
@@ -260,10 +260,12 @@ async def main(ctx: JobContext) -> None:
 
     # Season gate: no fixture within the lead window — skip the Betfair login/fetch.
     if not decision.should_execute:
+        next_execution = decision.next_execution
+        assert next_execution is not None  # noqa: S101
         logger.info(
             "betfair_season_gated",
             sport=sport,
-            next_execution=decision.next_execution.isoformat(),
+            next_execution=next_execution.isoformat(),
             reason=decision.reason,
         )
         return

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_mlb_probables.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_mlb_probables.py
@@ -46,11 +46,20 @@ async def main(ctx: JobContext) -> None:
     """
     from odds_core.alerts import job_alert_context
 
+    from odds_lambda.scheduling.helpers import within_lead
+
     if ctx.sport is not None and ctx.sport != SPORT_KEY:
         raise ValueError(f"fetch-mlb-probables only supports {SPORT_KEY}, got sport={ctx.sport!r}")
 
     app_settings = get_settings()
     now = datetime.now(UTC)
+
+    # Season gate: skip in the offseason when no fixture is within the lead.
+    lead_days = app_settings.scheduler.lead_days_for(SPORT_KEY)
+    if not await within_lead(SPORT_KEY, lead_days, now=now):
+        logger.info("fetch_mlb_probables_season_gated", sport=SPORT_KEY, lead_days=lead_days)
+        return
+
     target_dates = dates_for_window(now, _LOOKAHEAD_HOURS)
 
     logger.info(

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
@@ -256,11 +256,16 @@ async def main(ctx: JobContext) -> None:
     primary_spec = specs[0]
     overnight = (primary_spec.overnight_start_utc, primary_spec.overnight_resume_utc)
     sport_keys = [s.sport_key for s in specs]
+    # Most conservative lead across targeted sports (combined runs wake earliest).
+    lead_days = min(settings.scheduler.lead_days_for(sk) for sk in sport_keys)
 
-    # This is a always-run scraper (no execution gate): we only use the
-    # decision's proximity-derived next_execution, not should_execute.
+    # Season-gated scraper: the decision's ``should_execute`` says whether the
+    # next fixture is within the lead window. When it is not we self-schedule the
+    # precise wake and skip all browser work (offseason / long mid-season break).
     async def _reschedule(label: str) -> ScheduleDecision:
-        decision = await decide_forward_resilient(sport_keys, CADENCE, overnight=overnight)
+        decision = await decide_forward_resilient(
+            sport_keys, CADENCE, overnight=overnight, lookahead_days=lead_days
+        )
         assert decision.next_execution is not None  # noqa: S101
         try:
             await self_schedule(
@@ -278,7 +283,17 @@ async def main(ctx: JobContext) -> None:
 
     # Pre-schedule before any browser work so the chain survives Lambda
     # timeouts or browser crashes.
-    await _reschedule("pre-schedule")
+    decision = await _reschedule("pre-schedule")
+
+    # Season gate: no fixture within the lead window — skip the 2 GB browser run.
+    if not decision.should_execute:
+        logger.info(
+            "fetch_oddsportal_season_gated",
+            sport=sport,
+            next_execution=decision.next_execution.isoformat(),
+            reason=decision.reason,
+        )
+        return
 
     async with job_alert_context(compound_job_name):
         logger.info(

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
@@ -287,10 +287,12 @@ async def main(ctx: JobContext) -> None:
 
     # Season gate: no fixture within the lead window — skip the 2 GB browser run.
     if not decision.should_execute:
+        next_execution = decision.next_execution
+        assert next_execution is not None  # noqa: S101
         logger.info(
             "fetch_oddsportal_season_gated",
             sport=sport,
-            next_execution=decision.next_execution.isoformat(),
+            next_execution=next_execution.isoformat(),
             reason=decision.reason,
         )
         return

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_oddsportal.py
@@ -256,7 +256,8 @@ async def main(ctx: JobContext) -> None:
     primary_spec = specs[0]
     overnight = (primary_spec.overnight_start_utc, primary_spec.overnight_resume_utc)
     sport_keys = [s.sport_key for s in specs]
-    # Most conservative lead across targeted sports (combined runs wake earliest).
+    # Combined runs use the minimum lead across targeted sports, so the gate
+    # opens no later than the shortest-lead sport requires.
     lead_days = min(settings.scheduler.lead_days_for(sk) for sk in sport_keys)
 
     # Season-gated scraper: the decision's ``should_execute`` says whether the

--- a/packages/odds-lambda/odds_lambda/scheduling/decision.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/decision.py
@@ -81,10 +81,12 @@ class CadenceConfig:
     interval values differ per job (e.g. a cheap API polls more aggressively
     than a browser-driven scrape).
 
-    ``no_game`` is the check-in interval used when there is no upcoming game
-    (off-season / fixtures not yet posted). ``db_fallback`` is the interval a
-    caller should use when the kickoff query itself fails (DB unreachable),
-    so scheduling never blocks on DB availability.
+    ``no_game`` is the deep-offseason heartbeat: the cheap DB-only recheck
+    cadence used when there is no upcoming fixture at all (before the next
+    season's fixtures publish). When a fixture exists but is beyond the season
+    lead, the gate instead wakes precisely at ``next_kickoff − lead_days``.
+    ``db_fallback`` is the interval a caller should use when the kickoff query
+    itself fails (DB unreachable), so scheduling never blocks on DB availability.
     """
 
     closing: float
@@ -141,14 +143,61 @@ def _decide_from_kickoff(
     """Classify an already-resolved kickoff into a decision (no DB access).
 
     Shared core of :func:`decide_forward` and :func:`decide_forward_resilient`:
-    gates ``should_execute=False`` when ``next_kickoff`` is absent or beyond
-    ``lookahead_days``; otherwise maps proximity to a ``FetchTier`` cadence.
+    gates ``should_execute=False`` when ``next_kickoff`` is absent or beyond the
+    season lead (``lookahead_days``); otherwise maps proximity to a ``FetchTier``
+    cadence.
+
+    The season gate computes a *precise* wake so a job sleeping through the
+    offseason re-arms exactly ``lead_days`` before the next kickoff rather than
+    polling on a fixed heartbeat:
+
+    - kickoff beyond lead -> wake at ``next_kickoff − lead_days`` (the next run
+      then lands inside the lead window and does real work),
+    - no future kickoff at all (deep offseason) -> fall back to a cheap DB-only
+      ``cadence.no_game`` recheck, re-arming within a bounded lag once discovery
+      publishes fixtures.
+
+    A structured ``season_gate_skip`` is logged on every gated skip.
     """
-    if next_kickoff is None or next_kickoff > now + timedelta(days=lookahead_days):
+    if next_kickoff is None:
+        next_execution = _next_time(now, cadence.no_game, overnight)
+        logger.info(
+            "season_gate_skip",
+            sport=sport_key,
+            next_kickoff=None,
+            next_execution=next_execution.isoformat(),
+            lead_days=lookahead_days,
+        )
         return ScheduleDecision(
             should_execute=False,
-            reason=f"No upcoming {sport_key} game within {lookahead_days}d",
-            next_execution=_next_time(now, cadence.no_game, overnight),
+            reason=f"No upcoming {sport_key} fixture — deep-offseason heartbeat",
+            next_execution=next_execution,
+            tier=None,
+        )
+
+    lead_start = next_kickoff - timedelta(days=lookahead_days)
+    if now < lead_start:
+        # Beyond the lead window: sleep until the gate opens. Apply the overnight
+        # skip so the wake doesn't land in a suppressed window.
+        if overnight is not None:
+            next_execution = apply_overnight_skip(
+                lead_start,
+                overnight_start_utc=overnight[0],
+                overnight_resume_utc=overnight[1],
+            )
+        else:
+            next_execution = lead_start
+        logger.info(
+            "season_gate_skip",
+            sport=sport_key,
+            next_kickoff=next_kickoff.isoformat(),
+            next_execution=next_execution.isoformat(),
+            lead_days=lookahead_days,
+        )
+        return ScheduleDecision(
+            should_execute=False,
+            reason=f"Next {sport_key} game beyond {lookahead_days}d lead",
+            next_execution=next_execution,
             tier=None,
         )
 
@@ -175,16 +224,19 @@ async def decide_forward(
 ) -> ScheduleDecision:
     """Forward-looking decision keyed off the next upcoming game for a sport.
 
-    Gates ``should_execute=False`` when no upcoming game exists within
-    ``lookahead_days``; otherwise classifies proximity into a ``FetchTier`` and
-    returns the matching cadence interval.
+    Gates ``should_execute=False`` when no upcoming game exists within the
+    season lead (``lookahead_days``); otherwise classifies proximity into a
+    ``FetchTier`` and returns the matching cadence interval. When gated, the
+    wake is precise: ``next_kickoff − lead_days`` (or a ``cadence.no_game``
+    recheck when no fixture exists yet).
 
     Args:
         sport_key: Sport to scope the next-game query to.
         cadence: Per-job intervals keyed by ``FetchTier``.
         overnight: Optional (start_utc, resume_utc) suppression window applied
             to ``next_execution``.
-        lookahead_days: How far ahead a game must be to count as "upcoming".
+        lookahead_days: Season lead (days) — how close the next kickoff must be
+            for the job to do real work.
         now: Injectable clock (defaults to ``datetime.now(UTC)``).
         next_kickoff: Pre-fetched kickoff to avoid a redundant query (used by
             callers that re-query after doing work). When omitted the kickoff is

--- a/packages/odds-lambda/odds_lambda/scheduling/helpers.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/helpers.py
@@ -35,6 +35,27 @@ async def get_next_kickoff(sport_key: str, *, now: datetime | None = None) -> da
         return result.scalar_one_or_none()
 
 
+async def within_lead(
+    sport_key: str,
+    lead_days: int,
+    *,
+    now: datetime | None = None,
+) -> bool:
+    """Whether the sport's next fixture is within ``lead_days`` of ``now``.
+
+    Cheap DB-only season gate for cron-driven forward jobs that have no
+    self-scheduling decision of their own (``daily_digest``,
+    ``fetch_mlb_probables``). Returns ``False`` in the offseason (no fixture, or
+    next fixture beyond the lead) so the caller can early-return before doing
+    expensive work; the cron re-fires and re-gates on the next tick.
+    """
+    now = now or datetime.now(UTC)
+    next_kickoff = await get_next_kickoff(sport_key, now=now)
+    if next_kickoff is None:
+        return False
+    return next_kickoff <= now + timedelta(days=lead_days)
+
+
 def apply_overnight_skip(
     next_time: datetime,
     *,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -36,6 +36,9 @@ class TestSettings:
             assert settings.scheduler.backend == "local"
             assert settings.scheduler.dry_run is False
             assert settings.scheduler.lookahead_days == 7
+            assert settings.scheduler.season_lead_days == {}
+            # Default lead falls back to DEFAULT_SEASON_LEAD_DAYS for any sport.
+            assert settings.scheduler.lead_days_for("soccer_epl") == 7
             assert settings.scheduler.bootstrap_jobs == [
                 # "agent-run",
                 "fetch-oddsportal",
@@ -75,6 +78,19 @@ class TestSettings:
             assert settings.scheduler.lookahead_days == 14
             assert settings.data_quality.enable_validation is False
             assert settings.logging.level == "DEBUG"
+
+    def test_season_lead_days_per_sport_override(self):
+        """Per-sport season lead overrides the default; absent sports fall back."""
+        with patch.dict(
+            os.environ,
+            {"ODDS_API_KEY": "test_key", "DATABASE_URL": "postgresql://test:test@localhost/test"},
+            clear=True,
+        ):
+            from odds_core.config import SchedulerConfig
+
+            cfg = SchedulerConfig(season_lead_days={"soccer_epl": 14})
+            assert cfg.lead_days_for("soccer_epl") == 14
+            assert cfg.lead_days_for("baseball_mlb") == 7
 
     def test_settings_bookmakers(self):
         """Test bookmaker configuration."""

--- a/tests/unit/test_decision.py
+++ b/tests/unit/test_decision.py
@@ -54,22 +54,55 @@ class TestDecideForward:
 
     @pytest.mark.asyncio
     async def test_no_game_gates_off(self) -> None:
+        """No future fixture (deep offseason) -> heartbeat recheck at no_game."""
         decision = await decide_forward("soccer_epl", CADENCE, now=NOW, next_kickoff=None)
         assert decision.should_execute is False
         assert decision.tier is None
         assert _hours_after(NOW, decision.next_execution) == CADENCE.no_game
 
     @pytest.mark.asyncio
-    async def test_game_beyond_lookahead_gates_off(self) -> None:
+    async def test_game_beyond_lookahead_gates_off_with_precise_wake(self) -> None:
+        """Fixture beyond the lead -> wake precisely at next_kickoff − lead_days."""
+        next_kickoff = NOW + timedelta(days=10)
         decision = await decide_forward(
             "soccer_epl",
             CADENCE,
             now=NOW,
             lookahead_days=7,
-            next_kickoff=NOW + timedelta(days=10),
+            next_kickoff=next_kickoff,
         )
         assert decision.should_execute is False
-        assert _hours_after(NOW, decision.next_execution) == CADENCE.no_game
+        assert decision.tier is None
+        # 10d kickoff, 7d lead -> wake 3d (72h) from now.
+        assert decision.next_execution == next_kickoff - timedelta(days=7)
+        assert _hours_after(NOW, decision.next_execution) == 72.0
+
+    @pytest.mark.asyncio
+    async def test_in_season_break_wakes_at_lead(self) -> None:
+        """A ~14d mid-season break does not suppress permanently: wakes at lead."""
+        next_kickoff = NOW + timedelta(days=14)
+        decision = await decide_forward(
+            "soccer_epl",
+            CADENCE,
+            now=NOW,
+            lookahead_days=7,
+            next_kickoff=next_kickoff,
+        )
+        assert decision.should_execute is False
+        assert decision.next_execution == next_kickoff - timedelta(days=7)
+
+    @pytest.mark.asyncio
+    async def test_fixture_within_lead_executes(self) -> None:
+        """A fixture inside the lead window runs (and is tier-classified)."""
+        decision = await decide_forward(
+            "soccer_epl",
+            CADENCE,
+            now=NOW,
+            lookahead_days=7,
+            next_kickoff=NOW + timedelta(days=5),
+        )
+        assert decision.should_execute is True
+        assert decision.tier is FetchTier.OPENING
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/unit/test_fetch_betfair_exchange.py
+++ b/tests/unit/test_fetch_betfair_exchange.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from odds_lambda.betfair.client import BetfairBook
 from odds_lambda.betfair.constants import SPORT_CONFIG
 from odds_lambda.fetch_tier import FetchTier
-from odds_lambda.jobs.fetch_betfair_exchange import CADENCE, _should_skip_book
+from odds_lambda.jobs.fetch_betfair_exchange import CADENCE, _should_skip_book, main
+from odds_lambda.scheduling.jobs import JobContext
 
 
 def _book(
@@ -78,3 +82,53 @@ class TestShouldSkipBook:
 
     def test_2way_for_2way_market_kept(self) -> None:
         assert not _should_skip_book(_book(runners_count=2), SPORT_CONFIG["baseball_mlb"])
+
+
+class TestBetfairSeasonGate:
+    """Verify the season gate skips the Betfair login/fetch when no fixture is near."""
+
+    @staticmethod
+    @asynccontextmanager
+    async def _noop_alert_context(name: str) -> AsyncIterator[None]:
+        yield
+
+    @pytest.mark.asyncio
+    async def test_season_gate_skips_fetch_when_no_fixture(self) -> None:
+        """Deep offseason (no fixture): pre-schedule fires, login/fetch is skipped."""
+        mock_backend = AsyncMock()
+        mock_backend.get_backend_name = Mock(return_value="test")
+
+        mock_client_cls = Mock()
+
+        with (
+            patch(
+                "odds_lambda.jobs.fetch_betfair_exchange.BetfairExchangeClient",
+                mock_client_cls,
+            ),
+            patch(
+                "odds_lambda.scheduling.helpers.get_scheduler_backend",
+                return_value=mock_backend,
+            ),
+            patch("odds_lambda.jobs.fetch_betfair_exchange.get_settings") as mock_settings,
+            patch(
+                "odds_lambda.jobs.fetch_betfair_exchange.job_alert_context",
+                side_effect=self._noop_alert_context,
+            ),
+            patch(
+                "odds_lambda.scheduling.decision.get_next_kickoff",
+                new_callable=AsyncMock,
+                # No upcoming fixture → the season gate stays shut.
+                return_value=None,
+            ),
+        ):
+            mock_settings.return_value.betfair.enabled = True
+            mock_settings.return_value.betfair.sports = ["soccer_epl"]
+            mock_settings.return_value.scheduler.dry_run = False
+            mock_settings.return_value.scheduler.lead_days_for = lambda _sport: 7
+
+            await main(JobContext(sport="soccer_epl"))
+
+        # Pre-schedule still fires so the chain survives the offseason.
+        assert mock_backend.schedule_next_execution.call_count == 1
+        # The Betfair client is never constructed and login never runs.
+        mock_client_cls.assert_not_called()

--- a/tests/unit/test_fetch_oddsportal_scheduling.py
+++ b/tests/unit/test_fetch_oddsportal_scheduling.py
@@ -71,10 +71,13 @@ class TestProximityScheduling:
             patch(
                 "odds_lambda.scheduling.decision.get_next_kickoff",
                 new_callable=AsyncMock,
-                return_value=None,
+                # Fixture within the 7d lead so the season gate opens and the
+                # scrape (and post-scrape reschedule) runs.
+                return_value=datetime.now(UTC) + timedelta(days=2),
             ),
         ):
             mock_settings.return_value.scheduler.dry_run = False
+            mock_settings.return_value.scheduler.lead_days_for = lambda _sport: 7
             await main(JobContext())
 
         assert call_order[0] == "schedule", (
@@ -101,12 +104,15 @@ class TestProximityScheduling:
             patch(
                 "odds_lambda.scheduling.decision.get_next_kickoff",
                 new_callable=AsyncMock,
-                return_value=None,
+                # Fixture within the 7d lead so the season gate opens and the
+                # scrape (and post-scrape reschedule) runs.
+                return_value=datetime.now(UTC) + timedelta(days=2),
             ),
         ):
             from odds_lambda.jobs.fetch_oddsportal import IngestionStats
 
             mock_settings.return_value.scheduler.dry_run = False
+            mock_settings.return_value.scheduler.lead_days_for = lambda _sport: 7
             mock_ingest.return_value = IngestionStats(
                 league="test", matches_scraped=5, snapshots_stored=3
             )
@@ -141,12 +147,15 @@ class TestProximityScheduling:
             patch(
                 "odds_lambda.scheduling.decision.get_next_kickoff",
                 new_callable=AsyncMock,
-                return_value=None,
+                # Fixture within the 7d lead so the season gate opens and the
+                # scrape (and post-scrape reschedule) runs.
+                return_value=datetime.now(UTC) + timedelta(days=2),
             ),
         ):
             from odds_lambda.jobs.fetch_oddsportal import IngestionStats
 
             mock_settings.return_value.scheduler.dry_run = False
+            mock_settings.return_value.scheduler.lead_days_for = lambda _sport: 7
             mock_ingest.return_value = IngestionStats(league="test", matches_scraped=0)
 
             await main(JobContext())
@@ -176,14 +185,48 @@ class TestProximityScheduling:
             patch(
                 "odds_lambda.scheduling.decision.get_next_kickoff",
                 new_callable=AsyncMock,
-                return_value=None,
+                # Fixture within the 7d lead so the season gate opens and the
+                # scrape (and post-scrape reschedule) runs.
+                return_value=datetime.now(UTC) + timedelta(days=2),
             ),
         ):
             mock_settings.return_value.scheduler.dry_run = False
+            mock_settings.return_value.scheduler.lead_days_for = lambda _sport: 7
             await main(JobContext())
 
         # Only the pre-schedule fires
         assert mock_backend.schedule_next_execution.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_season_gate_skips_scrape_when_no_fixture(self) -> None:
+        """Deep offseason (no fixture): pre-schedule fires, scrape is skipped."""
+        mock_backend = AsyncMock()
+        mock_backend.get_backend_name = Mock(return_value="test")
+
+        with (
+            patch(
+                "odds_lambda.jobs.fetch_oddsportal.ingest_league", new_callable=AsyncMock
+            ) as mock_ingest,
+            patch(
+                "odds_lambda.scheduling.helpers.get_scheduler_backend",
+                return_value=mock_backend,
+            ),
+            patch("odds_core.config.get_settings") as mock_settings,
+            patch("odds_core.alerts.job_alert_context", side_effect=self._noop_alert_context),
+            patch(
+                "odds_lambda.scheduling.decision.get_next_kickoff",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            mock_settings.return_value.scheduler.dry_run = False
+            mock_settings.return_value.scheduler.lead_days_for = lambda _sport: 7
+
+            await main(JobContext())
+
+        # Only the pre-schedule fires; the browser scrape never runs.
+        assert mock_backend.schedule_next_execution.call_count == 1
+        mock_ingest.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_db_failure_falls_back_to_1h(self) -> None:
@@ -214,6 +257,7 @@ class TestProximityScheduling:
             from odds_lambda.jobs.fetch_oddsportal import IngestionStats
 
             mock_settings.return_value.scheduler.dry_run = False
+            mock_settings.return_value.scheduler.lead_days_for = lambda _sport: 7
             mock_ingest.return_value = IngestionStats(
                 league="test", matches_scraped=5, snapshots_stored=3
             )
@@ -258,6 +302,7 @@ class TestProximityScheduling:
             from odds_lambda.jobs.fetch_oddsportal import IngestionStats
 
             mock_settings.return_value.scheduler.dry_run = False
+            mock_settings.return_value.scheduler.lead_days_for = lambda _sport: 7
             mock_ingest.return_value = IngestionStats(
                 league="test", matches_scraped=5, snapshots_stored=3
             )
@@ -302,6 +347,7 @@ class TestProximityScheduling:
             from odds_lambda.jobs.fetch_oddsportal import IngestionStats
 
             mock_settings.return_value.scheduler.dry_run = False
+            mock_settings.return_value.scheduler.lead_days_for = lambda _sport: 7
             mock_ingest.return_value = IngestionStats(
                 league="test", matches_scraped=5, snapshots_stored=3
             )

--- a/tests/unit/test_scheduling_helpers.py
+++ b/tests/unit/test_scheduling_helpers.py
@@ -7,7 +7,14 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from odds_lambda.scheduling.helpers import apply_overnight_skip, get_next_kickoff, self_schedule
+from odds_lambda.scheduling.helpers import (
+    apply_overnight_skip,
+    get_next_kickoff,
+    self_schedule,
+    within_lead,
+)
+
+NOW = datetime(2026, 6, 2, 12, 0, tzinfo=UTC)
 
 
 class TestApplyOvernightSkip:
@@ -76,6 +83,42 @@ class TestGetNextKickoff:
     def test_accepts_sport_key_param(self) -> None:
         sig = inspect.signature(get_next_kickoff)
         assert "sport_key" in sig.parameters
+
+
+class TestWithinLead:
+    """Cheap DB-only season gate for cron-driven forward jobs."""
+
+    @pytest.mark.asyncio
+    async def test_no_fixture_returns_false(self) -> None:
+        async def no_kickoff(sport_key: str, *, now: datetime) -> datetime | None:
+            return None
+
+        with patch("odds_lambda.scheduling.helpers.get_next_kickoff", no_kickoff):
+            assert await within_lead("baseball_mlb", 7, now=NOW) is False
+
+    @pytest.mark.asyncio
+    async def test_fixture_within_lead_returns_true(self) -> None:
+        async def soon(sport_key: str, *, now: datetime) -> datetime:
+            return NOW + timedelta(days=3)
+
+        with patch("odds_lambda.scheduling.helpers.get_next_kickoff", soon):
+            assert await within_lead("soccer_epl", 7, now=NOW) is True
+
+    @pytest.mark.asyncio
+    async def test_fixture_beyond_lead_returns_false(self) -> None:
+        async def far(sport_key: str, *, now: datetime) -> datetime:
+            return NOW + timedelta(days=14)
+
+        with patch("odds_lambda.scheduling.helpers.get_next_kickoff", far):
+            assert await within_lead("soccer_epl", 7, now=NOW) is False
+
+    @pytest.mark.asyncio
+    async def test_fixture_exactly_at_lead_boundary_returns_true(self) -> None:
+        async def boundary(sport_key: str, *, now: datetime) -> datetime:
+            return NOW + timedelta(days=7)
+
+        with patch("odds_lambda.scheduling.helpers.get_next_kickoff", boundary):
+            assert await within_lead("soccer_epl", 7, now=NOW) is True
 
 
 class TestSelfSchedule:


### PR DESCRIPTION
## Summary

Forward collection jobs previously ran expensive work year-round even with no fixtures (the 2 GB OddsPortal browser Lambda, Betfair fetch, agent runs, daily digest, MLB probables). This change gates those jobs on proximity to the next discovered fixture, built on top of the unified `decide_forward` engine from #385.

- **`decision.py`** — extended the season gate in `_decide_from_kickoff`. Kickoff beyond the configured lead now wakes *precisely* at `next_kickoff − lead_days` (overnight-skip applied); no fixture at all falls back to the cheap per-job `cadence.no_game` heartbeat. Emits a structured `season_gate_skip` log on every gated skip. Threads through `decide_forward` / `decide_forward_resilient`.
- **`config.py`** — added per-sport `SchedulerConfig.season_lead_days: dict[SportKey, int]` with a module-level `DEFAULT_SEASON_LEAD_DAYS = 7` fallback exposed via `lead_days_for(sport)`.
- **Self-scheduling jobs** (`fetch_oddsportal`, `fetch_betfair_exchange`, `agent_run`) — pre-schedule the precise wake (crash-safe) then early-return before any browser/API/agent work when gated. Combined local multi-sport runs use the minimum lead across targeted sports.
- **Cron jobs** (`daily_digest`, `fetch_mlb_probables`) — early-return via a new DB-only `within_lead(sport, lead_days)` helper in `helpers.py`; each cron tick re-gates (covers Betfair's `*/30` safety-floor path).
- **Untouched** — discovery (`fetch_odds` EventSync, `fetch_espn_fixtures`) and backward jobs (`fetch_scores`, `fetch_oddsportal_results`) are unaffected, so `next_kickoff` stays fresh and season-end scores/results still collect.

## Tests

Added/updated class-based tests covering deep offseason (no fixture), pre-season beyond lead (precise-wake assertion), in-season break, in-season within lead, `within_lead` boundaries, per-sport lead override, and season-gate skip assertions for both the OddsPortal and Betfair jobs (verifying the scrape/fetch is not invoked while pre-scheduling still fires).

## Notes

- Dropped the issue's proposed standalone `deep_offseason_heartbeat_days` constant — the existing per-job `CadenceConfig.no_game` already serves as the deep-offseason heartbeat and is per-job tuned, so a separate global knob would be redundant.
- `season_lead_days` defaults to `{}` (every sport uses 7d); set per-sport via config/env when a longer lead is wanted (e.g. scraper catching early opening lines).

## Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)