### PR TITLE
Anchor live-event tests to now() instead of static dates

### DIFF
--- a/tests/unit/test_team_normalization.py
+++ b/tests/unit/test_team_normalization.py
@@ -165,7 +165,7 @@ class TestFindOrCreateEventOnWriter:
         event_id, created = await writer.find_or_create_event(
             home_team="Arsenal",
             away_team="Chelsea",
-            match_date=datetime(2030, 4, 15, 15, 0, tzinfo=UTC),
+            match_date=datetime.now(UTC) + timedelta(days=7),
             sport_key="soccer_epl",
             sport_title="EPL",
         )
@@ -210,7 +210,7 @@ class TestFindOrCreateEventOnWriter:
         from odds_lambda.storage.writers import OddsWriter
 
         writer = OddsWriter(test_session)
-        match_date = datetime(2030, 4, 15, 15, 0, tzinfo=UTC)
+        match_date = datetime.now(UTC) + timedelta(days=7)
 
         event_id_1, created_1 = await writer.find_or_create_event(
             home_team="Arsenal",
@@ -248,8 +248,11 @@ class TestFindOrCreateEventMatchWindow:
 
         writer = OddsWriter(test_session)
 
-        day_one = datetime(2026, 6, 10, 23, 10, tzinfo=UTC)
-        day_two = datetime(2026, 6, 11, 23, 10, tzinfo=UTC)
+        # Anchor to the future so the live-event stale guardrail never trips.
+        day_one = (datetime.now(UTC) + timedelta(days=1)).replace(
+            hour=23, minute=10, second=0, microsecond=0
+        )
+        day_two = day_one + timedelta(days=1)
 
         event_id_1, created_1 = await writer.find_or_create_event(
             home_team="New York Yankees",
@@ -279,8 +282,11 @@ class TestFindOrCreateEventMatchWindow:
 
         writer = OddsWriter(test_session)
 
-        game_one = datetime(2026, 7, 4, 13, 0, tzinfo=UTC)
-        game_two = datetime(2026, 7, 4, 18, 0, tzinfo=UTC)
+        # Anchor to the future so the live-event stale guardrail never trips.
+        game_one = (datetime.now(UTC) + timedelta(days=1)).replace(
+            hour=13, minute=0, second=0, microsecond=0
+        )
+        game_two = game_one + timedelta(hours=5)
 
         event_id_1, created_1 = await writer.find_or_create_event(
             home_team="Chicago Cubs",
@@ -310,9 +316,12 @@ class TestFindOrCreateEventMatchWindow:
 
         writer = OddsWriter(test_session)
 
-        first_scrape = datetime(2026, 6, 10, 23, 10, tzinfo=UTC)
+        # Anchor to the future so the live-event stale guardrail never trips.
+        first_scrape = (datetime.now(UTC) + timedelta(days=1)).replace(
+            hour=23, minute=10, second=0, microsecond=0
+        )
         # Source occasionally re-reports commence_time within a small window.
-        second_scrape = datetime(2026, 6, 10, 23, 45, tzinfo=UTC)
+        second_scrape = first_scrape + timedelta(minutes=35)
 
         event_id_1, created_1 = await writer.find_or_create_event(
             home_team="New York Yankees",


### PR DESCRIPTION
## Problem

The CI `Test` workflow was red on `main`: five create-path tests in `test_team_normalization.py` fed **hardcoded absolute dates** into `OddsWriter.find_or_create_event`, which rejects `op_live_*` events whose `match_date` is older than `now - LIVE_EVENT_STALE_THRESHOLD` (1h). As the wall clock advanced past those dates the guardrail started firing:

- `test_same_teams_consecutive_days_are_distinct_events` (2026-06-10/11) — failing
- `test_re_scrape_same_match_is_idempotent` (2026-06-10) — failing
- `test_same_day_doubleheader_games_are_distinct_events` (2026-07-04) — fuse, fails after Jul 4
- `test_creates_event_when_none_exists` / `test_idempotent_create` (2030) — same anti-pattern, later fuse

## Fix

Anchor each create-path date to `datetime.now(UTC) + offset` so the tests are clock-independent while preserving their original semantics (consecutive days, 5h-apart doubleheader, ±35min re-scrape jitter). The "finds existing" tests that pre-insert a row and look it up never hit the guardrail and were left as-is.

## Verification

- `test_team_normalization.py`: 46 passed
- Swept the rest of the source/test tree for the same pattern (static date fed into a `datetime.now()`-relative comparison) — no other time bombs; other suites use `now=` injection or far-past/future sentinels.
- Full unit suite: the only remaining failures are pre-existing and unrelated (`test_config::test_settings_defaults` local Discord-webhook env leak, and a test-ordering pollution in `test_fetch_oddsportal_results` that passes in isolation and in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)