### PR TITLE
Add deploy-with-confidence tooling for the local scheduler (smoke + deploy.sh + systemd)

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Deploy-with-confidence for the always-on local scheduler.
+#
+# Pulls the latest code, syncs dependencies, applies migrations, smoke-tests
+# the bootstrapped jobs, and only then restarts the systemd-managed scheduler.
+# If migration or smoke fails, the script aborts BEFORE the restart, leaving the
+# running scheduler untouched on the old code.
+#
+# Run from the repo root on the host running odds-scheduler.service:
+#   ./deploy.sh
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$REPO_ROOT"
+
+echo "==> git pull"
+git pull --ff-only
+
+echo "==> uv sync"
+uv sync
+
+# Migration ordering: alembic runs before the restart, so the still-running old
+# scheduler briefly sees the new schema. This is safe for additive migrations
+# (the norm). If a migration is destructive, take the scheduler down first.
+echo "==> alembic upgrade head"
+uv run alembic upgrade head
+
+# Smoke runs with SCHEDULER_DRY_RUN=true so self-scheduling is a no-op: jobs do
+# their real work (gated by their cadence) but write nothing to the live
+# schedule store. The running scheduler keeps serving old code until smoke passes.
+echo "==> scheduler smoke (SCHEDULER_DRY_RUN=true)"
+SCHEDULER_DRY_RUN=true uv run odds scheduler smoke
+
+# Only reached when migrate + smoke both succeed (set -e aborts otherwise).
+echo "==> restarting odds-scheduler"
+sudo systemctl restart odds-scheduler
+
+echo "==> systemctl status"
+systemctl status odds-scheduler --no-pager || true
+
+echo "==> scheduled jobs"
+uv run odds scheduler list-jobs
+
+echo "==> deploy complete"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -236,6 +236,64 @@ docker-compose up -d
 uv run odds status show
 ```
 
+## Always-On Local Scheduler (systemd + deploy.sh)
+
+The local scheduler can run as an always-on service on a mini-PC, supervised by
+systemd and redeployed with a single script that proves the changed jobs run
+green before it cycles the process.
+
+### systemd unit
+
+`odds-scheduler.service` (repo root) runs `odds scheduler start` under systemd
+with `Restart=always`, so the scheduler comes back after a crash or host reboot.
+Edit `User`, `WorkingDirectory`, `EnvironmentFile`, and the absolute `uv` path in
+`ExecStart` to match the host, then install it:
+
+```bash
+sudo cp odds-scheduler.service /etc/systemd/system/odds-scheduler.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now odds-scheduler   # start now + on every boot
+
+systemctl status odds-scheduler              # check state
+journalctl -u odds-scheduler -f              # follow logs
+```
+
+### Smoke check
+
+`odds scheduler smoke` runs each bootstrapped job once (derived from
+`scheduler.bootstrap_jobs`, per-sport expanded — the same source `start` uses)
+and prints a pass/fail table, exiting non-zero (exit code = number of failed
+jobs) if any job fails.
+
+- `agent-run` is skipped by default (never places paper bets during a deploy
+  check); pass `--include-agent` to run it.
+- `daily-digest` posts to Discord; pass `--no-side-effects` to drop it.
+- `--only`/`--exclude` accept base or compound job names (repeatable).
+- Run with `SCHEDULER_DRY_RUN=true` so self-scheduling is a no-op and the live
+  schedule store is left untouched.
+
+Coverage caveat: smoke always exercises each job's import/config/decision/schema
+path, but the full fetch+ingest body only runs when the job's cadence gate
+(`decision.should_execute`) says execute.
+
+### deploy.sh
+
+`deploy.sh` (repo root) is the redeploy entry point:
+
+```bash
+./deploy.sh
+```
+
+It runs: `git pull` → `uv sync` → `alembic upgrade head` →
+`SCHEDULER_DRY_RUN=true odds scheduler smoke` → `sudo systemctl restart
+odds-scheduler` → `systemctl status` + `odds scheduler list-jobs`. If migration
+or smoke fails it aborts **before** the restart, so the running scheduler keeps
+serving the old code untouched until the new code passes smoke.
+
+Migration ordering: `alembic upgrade head` runs before the restart, so the
+still-running old scheduler briefly sees the new schema. Safe for additive
+migrations (the norm); for a destructive migration, stop the service first.
+
 ## Expected Costs
 
 ### The Odds API

--- a/odds-scheduler.service
+++ b/odds-scheduler.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Odds pipeline local scheduler (APScheduler)
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Replace with the deploying user and the absolute repo path on the host.
+User=andrew
+WorkingDirectory=/home/andrew/code/odds
+EnvironmentFile=/home/andrew/code/odds/.env
+# systemd requires an absolute path to the executable; adjust if uv lives elsewhere
+# (`which uv` — e.g. ~/.local/bin/uv).
+ExecStart=/home/andrew/.cargo/bin/uv run odds scheduler start
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/odds-cli/odds_cli/commands/scheduler.py
+++ b/packages/odds-cli/odds_cli/commands/scheduler.py
@@ -329,6 +329,179 @@ def run_once(
         raise typer.Exit(1) from e
 
 
+@app.command("smoke")
+def smoke(
+    include_agent: bool = typer.Option(
+        False,
+        "--include-agent",
+        help="Also run smoke-unsafe jobs (agent-run). Off by default so a deploy "
+        "check never places paper bets.",
+    ),
+    no_side_effects: bool = typer.Option(
+        False,
+        "--no-side-effects",
+        help="Drop outward-posting jobs (daily-digest) so the check stays silent "
+        "on shared channels.",
+    ),
+    only: list[str] | None = typer.Option(  # noqa: B008 — typer option idiom
+        None,
+        "--only",
+        help="Run only these jobs (base or compound name). Repeatable.",
+    ),
+    exclude: list[str] | None = typer.Option(  # noqa: B008 — typer option idiom
+        None,
+        "--exclude",
+        help="Skip these jobs (base or compound name). Repeatable.",
+    ),
+) -> None:
+    """
+    Run each bootstrapped job once and report pass/fail (deploy validation).
+
+    Derives the job set from ``scheduler.bootstrap_jobs`` (the same single
+    source of truth ``start`` uses), expands per-sport jobs into one run per
+    configured sport, runs each once, and prints a per-job pass/fail table.
+    Exits non-zero (exit code = number of failed jobs) if any job fails.
+
+    ``agent-run`` is skipped by default (never place paper bets during a deploy
+    check); pass ``--include-agent`` to run it. ``daily-digest`` posts to Discord;
+    pass ``--no-side-effects`` to drop it.
+
+    Run with ``SCHEDULER_DRY_RUN=true`` (as ``deploy.sh`` does) so self-scheduling
+    is a no-op and the live schedule store is untouched.
+
+    Coverage caveat: smoke always exercises each job's import / config / decision /
+    schema path, but the full fetch+ingest body only runs when the job's cadence
+    gate (``decision.should_execute``) says execute. A ``--force`` gate bypass is
+    out of scope.
+
+    Usage:
+        SCHEDULER_DRY_RUN=true odds scheduler smoke
+        odds scheduler smoke --no-side-effects
+        odds scheduler smoke --only fetch-oddsportal --only fetch-espn-fixtures
+        odds scheduler smoke --include-agent
+    """
+    app_settings = get_settings()
+
+    from odds_lambda.scheduling.jobs import (
+        JobContext,
+        expected_compound_job_names,
+        get_job_function,
+        is_outward_posting,
+        is_smoke_unsafe,
+        resolve_job_name,
+    )
+
+    bootstrap_jobs = app_settings.scheduler.bootstrap_jobs
+    configured_sports = app_settings.data_collection.sports
+    candidates = sorted(expected_compound_job_names(bootstrap_jobs, configured_sports))
+
+    if not candidates:
+        console.print("[yellow]No jobs to smoke — bootstrap_jobs is empty.[/yellow]")
+        return
+
+    if not app_settings.scheduler.dry_run:
+        console.print(
+            "[yellow]⚠ SCHEDULER_DRY_RUN is not set — jobs may write real schedules "
+            "to the store. Set SCHEDULER_DRY_RUN=true (deploy.sh does this).[/yellow]"
+        )
+
+    base_of = {c: resolve_job_name(c)[0] for c in candidates}
+
+    def _match_tokens(tokens: list[str]) -> tuple[set[str], list[str]]:
+        """Resolve ``--only``/``--exclude`` tokens against the candidate set.
+
+        A token matches a candidate when it equals the compound name or the
+        base name. Returns (matched compound names, unknown tokens).
+        """
+        matched: set[str] = set()
+        unknown: list[str] = []
+        for token in tokens:
+            hits = [c for c in candidates if c == token or base_of[c] == token]
+            if hits:
+                matched.update(hits)
+            else:
+                unknown.append(token)
+        return matched, unknown
+
+    unknown_tokens: list[str] = []
+    if only:
+        only_set, unknown = _match_tokens(only)
+        unknown_tokens.extend(unknown)
+        selected = only_set
+    else:
+        selected = set(candidates)
+
+    excluded_names: set[str] = set()
+    if exclude:
+        exclude_set, unknown = _match_tokens(exclude)
+        unknown_tokens.extend(unknown)
+        excluded_names = exclude_set
+
+    if unknown_tokens:
+        console.print(f"[bold red]Error:[/bold red] Unknown job(s): {', '.join(unknown_tokens)}")
+        console.print(f"[dim]Available: {', '.join(candidates)}[/dim]")
+        raise typer.Exit(1)
+
+    # Classify each candidate into run / skip with a reason.
+    to_run: list[str] = []
+    skipped: list[tuple[str, str]] = []
+    for name in sorted(selected):
+        if name in excluded_names:
+            skipped.append((name, "excluded (--exclude)"))
+        elif is_smoke_unsafe(name) and not include_agent:
+            skipped.append((name, "smoke-unsafe (pass --include-agent)"))
+        elif is_outward_posting(name) and no_side_effects:
+            skipped.append((name, "outward-posting (--no-side-effects)"))
+        else:
+            to_run.append(name)
+
+    console.print("[bold blue]Smoke-testing bootstrapped jobs...[/bold blue]")
+    console.print(f"[dim]Backend: {app_settings.scheduler.backend} | ", end="")
+    console.print(f"dry_run: {app_settings.scheduler.dry_run}[/dim]\n")
+
+    async def _run_all() -> list[tuple[str, bool, str]]:
+        results: list[tuple[str, bool, str]] = []
+        for name in to_run:
+            base_name, sport = resolve_job_name(name)
+            ctx = JobContext(sport=sport) if sport else JobContext()
+            try:
+                job_func = get_job_function(base_name)
+                await job_func(ctx)
+                results.append((name, True, ""))
+                console.print(f"[green]  ✓ {name}[/green]")
+            except Exception as e:  # noqa: BLE001 — one failure must not abort the rest
+                logger.error("smoke_job_failed", job=name, error=str(e), exc_info=True)
+                results.append((name, False, str(e)))
+                console.print(f"[red]  ✗ {name}: {e}[/red]")
+        return results
+
+    results = asyncio.run(_run_all()) if to_run else []
+
+    # Render results table.
+    console.print()
+    table = Table(show_header=True, header_style="bold cyan")
+    table.add_column("Job", style="white")
+    table.add_column("Result", style="white")
+    table.add_column("Detail", style="dim")
+    for name, ok, detail in results:
+        result_cell = "[green]PASS[/green]" if ok else "[red]FAIL[/red]"
+        table.add_row(name, result_cell, detail)
+    for name, reason in skipped:
+        table.add_row(name, "[yellow]SKIP[/yellow]", reason)
+    console.print(table)
+
+    failed = [name for name, ok, _ in results if not ok]
+    passed = len(results) - len(failed)
+    console.print(f"\n[bold]{passed} passed, {len(failed)} failed, {len(skipped)} skipped[/bold]")
+
+    if failed:
+        console.print(f"[bold red]✗ Smoke check failed: {', '.join(failed)}[/bold red]")
+        # Exit code = number of failed jobs (clamped to a valid 1-255 range).
+        raise typer.Exit(min(len(failed), 255))
+
+    console.print("[bold green]✓ Smoke check passed[/bold green]")
+
+
 @app.command("info")
 def info():
     app_settings = get_settings()

--- a/packages/odds-cli/odds_cli/commands/scheduler.py
+++ b/packages/odds-cli/odds_cli/commands/scheduler.py
@@ -456,8 +456,10 @@ def smoke(
             to_run.append(name)
 
     console.print("[bold blue]Smoke-testing bootstrapped jobs...[/bold blue]")
-    console.print(f"[dim]Backend: {app_settings.scheduler.backend} | ", end="")
-    console.print(f"dry_run: {app_settings.scheduler.dry_run}[/dim]\n")
+    console.print(
+        f"[dim]Backend: {app_settings.scheduler.backend} | "
+        f"dry_run: {app_settings.scheduler.dry_run}[/dim]\n"
+    )
 
     async def _run_all() -> list[tuple[str, bool, str]]:
         results: list[tuple[str, bool, str]] = []

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -89,6 +89,17 @@ _SPORT_SUFFIX_MAP: dict[str, str] = {
     "mlb": "baseball_mlb",
 }
 
+# Jobs that must never run during a deploy smoke check, even when listed in
+# ``bootstrap_jobs``. ``agent-run`` places paper bets — executing it as part of
+# a pre-restart validation would pollute the live portfolio. The smoke command
+# skips these by default and only runs them under an explicit opt-in.
+_SMOKE_UNSAFE_JOBS: frozenset[str] = frozenset({"agent-run"})
+
+# Jobs that post to outward channels (e.g. Discord) on every run. The smoke
+# command drops these under ``--no-side-effects`` so a validation run can stay
+# silent on shared channels.
+_OUTWARD_POSTING_JOBS: frozenset[str] = frozenset({"daily-digest"})
+
 # Jobs that accept a sport parameter. When invoked with a sport suffix
 # (e.g. "fetch-odds-epl"), the sport_key is extracted and passed as a kwarg.
 _PER_SPORT_JOBS: frozenset[str] = frozenset(
@@ -251,6 +262,24 @@ def get_job_function(job_name: str) -> Callable[[JobContext], Awaitable[None]]:
 def is_per_sport_job(job_name: str) -> bool:
     """Check whether a job accepts a sport parameter."""
     return job_name in _PER_SPORT_JOBS
+
+
+def is_smoke_unsafe(job_name: str) -> bool:
+    """Whether a job must never run during a deploy smoke check.
+
+    Accepts a compound (sport-suffixed) or base job name.
+    """
+    base_name, _ = resolve_job_name(job_name)
+    return base_name in _SMOKE_UNSAFE_JOBS
+
+
+def is_outward_posting(job_name: str) -> bool:
+    """Whether a job posts to outward channels (e.g. Discord) on every run.
+
+    Accepts a compound (sport-suffixed) or base job name.
+    """
+    base_name, _ = resolve_job_name(job_name)
+    return base_name in _OUTWARD_POSTING_JOBS
 
 
 def resolve_target_sports(job_name: str, configured_sports: Sequence[SportKey]) -> list[SportKey]:

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -84,7 +84,7 @@ _JOB_BOOTSTRAP_MAP: dict[str, tuple[str, str]] = {
 
 # Maps sport suffix to sport_key for per-sport job routing.
 # e.g. "fetch-odds-epl" resolves to ("fetch-odds", "soccer_epl")
-_SPORT_SUFFIX_MAP: dict[str, str] = {
+_SPORT_SUFFIX_MAP: dict[str, SportKey] = {
     "epl": "soccer_epl",
     "mlb": "baseball_mlb",
 }
@@ -208,7 +208,7 @@ def make_compound_job_name(base_job_name: str, sport: str | None) -> str:
     return base_job_name
 
 
-def resolve_job_name(compound_name: str) -> tuple[str, str | None]:
+def resolve_job_name(compound_name: str) -> tuple[str, SportKey | None]:
     """Resolve a potentially sport-suffixed job name.
 
     Args:

--- a/tests/unit/test_scheduler_cli.py
+++ b/tests/unit/test_scheduler_cli.py
@@ -1,12 +1,17 @@
-"""Unit tests for scheduler CLI rendering helpers."""
+"""Unit tests for scheduler CLI rendering helpers and the smoke command."""
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
 
-from odds_cli.commands.scheduler import _print_scheduled_jobs
+import typer
+from odds_cli.commands.scheduler import _print_scheduled_jobs, smoke
 from odds_lambda.scheduling.backends.base import JobStatus, ScheduledJob
 from rich.console import Console
+from typer.testing import CliRunner
+
+runner = CliRunner()
 
 
 def _render(jobs: list[ScheduledJob]) -> str:
@@ -45,3 +50,166 @@ class TestPrintScheduledJobs:
     def test_empty_jobs_message(self) -> None:
         out = _render([])
         assert "No jobs currently scheduled" in out
+
+
+def _settings(
+    bootstrap_jobs: list[str],
+    sports: list[str],
+    *,
+    dry_run: bool = True,
+    backend: str = "local",
+) -> MagicMock:
+    """Build a settings double controlling the job-set derivation inputs."""
+    settings = MagicMock()
+    settings.scheduler.bootstrap_jobs = bootstrap_jobs
+    settings.scheduler.dry_run = dry_run
+    settings.scheduler.backend = backend
+    settings.data_collection.sports = sports
+    return settings
+
+
+class _JobRecorder:
+    """Stand-in for ``get_job_function`` that records runs without touching the DB.
+
+    Returns an async job that appends ``(base_name, ctx.sport)`` on execution and
+    raises for any base name in ``fail_bases`` (to exercise failure exit codes).
+    """
+
+    def __init__(self, fail_bases: set[str] | None = None) -> None:
+        self.fail_bases = fail_bases or set()
+        self.ran: list[tuple[str, str | None]] = []
+
+    def __call__(self, base_name: str):
+        recorder = self
+
+        async def _job(ctx) -> None:
+            recorder.ran.append((base_name, ctx.sport))
+            if base_name in recorder.fail_bases:
+                raise RuntimeError(f"{base_name} boom")
+
+        return _job
+
+    @property
+    def ran_bases(self) -> set[str]:
+        return {base for base, _ in self.ran}
+
+
+def _invoke_smoke(args: list[str], settings: MagicMock, recorder: _JobRecorder):
+    """Invoke the smoke command in isolation with patched settings and job runner."""
+    test_app = typer.Typer()
+    test_app.command()(smoke)
+    with (
+        patch("odds_cli.commands.scheduler.get_settings", return_value=settings),
+        patch("odds_lambda.scheduling.jobs.get_job_function", new=recorder),
+    ):
+        return runner.invoke(test_app, args)
+
+
+class TestSmokeCommand:
+    """Behaviour of ``odds scheduler smoke`` job selection and exit codes."""
+
+    def test_default_run_skips_agent_run(self) -> None:
+        settings = _settings(["fetch-oddsportal", "agent-run"], ["soccer_epl"])
+        recorder = _JobRecorder()
+        result = _invoke_smoke([], settings, recorder)
+
+        assert result.exit_code == 0
+        assert "fetch-oddsportal" in recorder.ran_bases
+        assert "agent-run" not in recorder.ran_bases
+        assert "SKIP" in result.output
+
+    def test_include_agent_runs_agent(self) -> None:
+        settings = _settings(["fetch-oddsportal", "agent-run"], ["soccer_epl"])
+        recorder = _JobRecorder()
+        result = _invoke_smoke(["--include-agent"], settings, recorder)
+
+        assert result.exit_code == 0
+        assert "agent-run" in recorder.ran_bases
+
+    def test_daily_digest_runs_by_default(self) -> None:
+        settings = _settings(["fetch-oddsportal", "daily-digest"], ["soccer_epl"])
+        recorder = _JobRecorder()
+        result = _invoke_smoke([], settings, recorder)
+
+        assert result.exit_code == 0
+        assert "daily-digest" in recorder.ran_bases
+
+    def test_no_side_effects_drops_daily_digest(self) -> None:
+        settings = _settings(["fetch-oddsportal", "daily-digest"], ["soccer_epl"])
+        recorder = _JobRecorder()
+        result = _invoke_smoke(["--no-side-effects"], settings, recorder)
+
+        assert result.exit_code == 0
+        assert "fetch-oddsportal" in recorder.ran_bases
+        assert "daily-digest" not in recorder.ran_bases
+
+    def test_only_by_base_name_matches_all_compounds(self) -> None:
+        settings = _settings(["fetch-oddsportal", "fetch-scores"], ["soccer_epl", "baseball_mlb"])
+        recorder = _JobRecorder()
+        result = _invoke_smoke(["--only", "fetch-oddsportal"], settings, recorder)
+
+        assert result.exit_code == 0
+        # Jobs run in sorted compound-name order: -epl before -mlb.
+        assert recorder.ran == [
+            ("fetch-oddsportal", "soccer_epl"),
+            ("fetch-oddsportal", "baseball_mlb"),
+        ]
+
+    def test_only_by_compound_name_matches_single(self) -> None:
+        settings = _settings(["fetch-oddsportal", "fetch-scores"], ["soccer_epl", "baseball_mlb"])
+        recorder = _JobRecorder()
+        result = _invoke_smoke(["--only", "fetch-oddsportal-epl"], settings, recorder)
+
+        assert result.exit_code == 0
+        assert recorder.ran == [("fetch-oddsportal", "soccer_epl")]
+
+    def test_exclude_removes_job(self) -> None:
+        settings = _settings(["fetch-oddsportal", "fetch-scores"], ["soccer_epl"])
+        recorder = _JobRecorder()
+        result = _invoke_smoke(["--exclude", "fetch-scores"], settings, recorder)
+
+        assert result.exit_code == 0
+        assert "fetch-oddsportal" in recorder.ran_bases
+        assert "fetch-scores" not in recorder.ran_bases
+
+    def test_unknown_only_token_errors(self) -> None:
+        settings = _settings(["fetch-oddsportal"], ["soccer_epl"])
+        recorder = _JobRecorder()
+        result = _invoke_smoke(["--only", "no-such-job"], settings, recorder)
+
+        assert result.exit_code != 0
+        assert "Unknown job" in result.output
+        assert recorder.ran == []
+
+    def test_unknown_exclude_token_errors(self) -> None:
+        settings = _settings(["fetch-oddsportal"], ["soccer_epl"])
+        recorder = _JobRecorder()
+        result = _invoke_smoke(["--exclude", "no-such-job"], settings, recorder)
+
+        assert result.exit_code != 0
+        assert "Unknown job" in result.output
+        assert recorder.ran == []
+
+    def test_failing_job_yields_nonzero_exit(self) -> None:
+        settings = _settings(["fetch-oddsportal", "fetch-scores"], ["soccer_epl"])
+        recorder = _JobRecorder(fail_bases={"fetch-scores"})
+        result = _invoke_smoke([], settings, recorder)
+
+        assert result.exit_code == 1
+        assert "FAIL" in result.output
+
+    def test_exit_code_counts_failures(self) -> None:
+        settings = _settings(["fetch-scores"], ["soccer_epl", "baseball_mlb"])
+        recorder = _JobRecorder(fail_bases={"fetch-scores"})
+        result = _invoke_smoke([], settings, recorder)
+
+        # Both per-sport expansions fail -> exit code equals the failure count.
+        assert result.exit_code == 2
+
+    def test_clean_run_exits_zero(self) -> None:
+        settings = _settings(["fetch-oddsportal", "fetch-scores"], ["soccer_epl"])
+        recorder = _JobRecorder()
+        result = _invoke_smoke([], settings, recorder)
+
+        assert result.exit_code == 0
+        assert recorder.ran_bases == {"fetch-oddsportal", "fetch-scores"}

--- a/tests/unit/test_scheduling_helpers.py
+++ b/tests/unit/test_scheduling_helpers.py
@@ -135,3 +135,27 @@ class TestSelfSchedule:
 
         call_kwargs = mock_backend.schedule_next_execution.call_args.kwargs
         assert call_kwargs["payload"] is None
+
+
+class TestSmokeTags:
+    """Tags distinguishing smoke-unsafe and outward-posting jobs."""
+
+    def test_agent_run_is_smoke_unsafe(self) -> None:
+        from odds_lambda.scheduling.jobs import is_smoke_unsafe
+
+        assert is_smoke_unsafe("agent-run")
+        # Compound (sport-suffixed) names resolve to the same base.
+        assert is_smoke_unsafe("agent-run-epl")
+
+    def test_daily_digest_is_outward_posting(self) -> None:
+        from odds_lambda.scheduling.jobs import is_outward_posting
+
+        assert is_outward_posting("daily-digest")
+        assert is_outward_posting("daily-digest-epl")
+
+    def test_data_jobs_are_neither(self) -> None:
+        from odds_lambda.scheduling.jobs import is_outward_posting, is_smoke_unsafe
+
+        for job in ("fetch-oddsportal", "fetch-espn-fixtures", "fetch-betfair-exchange"):
+            assert not is_smoke_unsafe(job)
+            assert not is_outward_posting(job)


### PR DESCRIPTION
## Summary

Makes redeploying the always-on mini-PC scheduler safe and repeatable: a redeploy now proves the changed jobs run green before it restarts, or refuses to restart and leaves the working scheduler untouched.

- **`scheduler smoke` CLI command** (`packages/odds-cli/odds_cli/commands/scheduler.py`): runs each bootstrapped job once and prints a per-job PASS/FAIL/SKIP table, exiting non-zero (exit code = number of failed jobs, clamped) if any fail. Job set is derived from `app_settings.scheduler.bootstrap_jobs` and expanded per-sport via `expected_compound_job_names()` — the same single source `start` uses, no parallel list. `agent-run` is skipped by default (never place paper bets during a deploy check); `daily-digest` is dropped under `--no-side-effects`. Flags: `--include-agent`, `--no-side-effects`, `--only`, `--exclude` (the latter two validate against the registry and error on unknown names). `--help` carries the coverage caveat (smoke always exercises the import/config/decision/schema path; the full job body only runs when the cadence gate says execute).
- **Registry tags** (`packages/odds-lambda/odds_lambda/scheduling/jobs.py`): `_SMOKE_UNSAFE_JOBS` / `_OUTWARD_POSTING_JOBS` frozensets plus `is_smoke_unsafe()` / `is_outward_posting()` helpers (accept compound or base names). Also tightened `resolve_job_name`'s return type to `tuple[str, SportKey | None]`.
- **`deploy.sh`** (repo root): `git pull --ff-only → uv sync → alembic upgrade head → SCHEDULER_DRY_RUN=true odds scheduler smoke → sudo systemctl restart odds-scheduler → status + list-jobs`. `set -euo pipefail` aborts before the restart if migrate or smoke fails, so the running scheduler keeps serving old code until the new code passes smoke.
- **`odds-scheduler.service`** systemd unit (`Restart=always`, host-reboot persistence) plus a new "Always-On Local Scheduler" section in `docs/DEPLOYMENT.md` documenting install + the deploy flow.

## Safety property

Smoke runs with `SCHEDULER_DRY_RUN=true`, which makes `self_schedule` a no-op (`backends/local.py` early-returns), so it writes nothing to the APScheduler schedule store. The live scheduler is untouched until the restart, and fires purely from persisted schedules afterward.

## Tests

Added `TestSmokeTags` (tag helpers) and `TestSmokeCommand` (12 `CliRunner` tests: default agent-run skip, `--include-agent`, `--no-side-effects` digest drop, `--only`/`--exclude` by base and compound name, unknown-token errors, and exit-code semantics). These caught a markup crash in the smoke banner that is fixed here. Targeted suites + full CI green.

## Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)