### PR TITLE
Run full job bodies under a RunPolicy during scheduler smoke

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -27,11 +27,14 @@ uv sync
 echo "==> alembic upgrade head"
 uv run alembic upgrade head
 
-# Smoke runs with SCHEDULER_DRY_RUN=true so self-scheduling is a no-op: jobs do
-# their real work (gated by their cadence) but write nothing to the live
-# schedule store. The running scheduler keeps serving old code until smoke passes.
-echo "==> scheduler smoke (SCHEDULER_DRY_RUN=true)"
-SCHEDULER_DRY_RUN=true uv run odds scheduler smoke
+# Smoke runs every bootstrapped job's full body end-to-end under a no-side-effect
+# policy: the cadence gate is bypassed (so the real fetch+ingest body runs even
+# when not "due"), nothing is written to the live schedule store, and every
+# outward call (Discord posts, agent paper bets) is suppressed at its sink. The
+# running scheduler keeps serving old code until smoke passes — so "smoke passed"
+# means "the changed code runs green" and the deploy is safe.
+echo "==> scheduler smoke (no side effects)"
+uv run odds scheduler smoke
 
 # Only reached when migrate + smoke both succeed (set -e aborts otherwise).
 echo "==> restarting odds-scheduler"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -260,21 +260,29 @@ journalctl -u odds-scheduler -f              # follow logs
 
 ### Smoke check
 
-`odds scheduler smoke` runs each bootstrapped job once (derived from
-`scheduler.bootstrap_jobs`, per-sport expanded — the same source `start` uses)
-and prints a pass/fail table, exiting non-zero (exit code = number of failed
-jobs) if any job fails.
+`odds scheduler smoke` runs every bootstrapped job's **full body** once (job set
+derived from `scheduler.bootstrap_jobs`, per-sport expanded — the same source
+`start` uses) and prints a pass/fail table, exiting non-zero (exit code = number
+of failed jobs) if any job fails.
 
-- `agent-run` is skipped by default (never places paper bets during a deploy
-  check); pass `--include-agent` to run it.
-- `daily-digest` posts to Discord; pass `--no-side-effects` to drop it.
+Smoke runs under `RunPolicy(respect_gate=False, self_schedule=False,
+commit_external=False)` so each body executes end-to-end with **zero outward
+side effects**:
+
+- the **cadence gate is bypassed**, so the real fetch+ingest body runs even when
+  a job is not "due" at deploy time (closing the prior coverage gap where most
+  data jobs only ran their decision/schema path);
+- **nothing is written to the schedule store** — the live schedule is untouched
+  until the scheduler restarts;
+- every **outward call is suppressed at its sink** — Discord posts (including
+  failure alerts and the daily digest) and agent paper bets — so a deploy check
+  never escapes to a shared channel or the live portfolio. Suppression is
+  universal, not a per-job tag, so a new posting job can never be forgotten.
+
+- `agent-run` is skipped by default only because it is **expensive** (LLM +
+  web-search spend, multi-minute subprocess) — not because it is unsafe; pass
+  `--include-agent` to run it (its paper bets are still suppressed).
 - `--only`/`--exclude` accept base or compound job names (repeatable).
-- Run with `SCHEDULER_DRY_RUN=true` so self-scheduling is a no-op and the live
-  schedule store is left untouched.
-
-Coverage caveat: smoke always exercises each job's import/config/decision/schema
-path, but the full fetch+ingest body only runs when the job's cadence gate
-(`decision.should_execute`) says execute.
 
 ### deploy.sh
 
@@ -285,10 +293,12 @@ path, but the full fetch+ingest body only runs when the job's cadence gate
 ```
 
 It runs: `git pull` → `uv sync` → `alembic upgrade head` →
-`SCHEDULER_DRY_RUN=true odds scheduler smoke` → `sudo systemctl restart
-odds-scheduler` → `systemctl status` + `odds scheduler list-jobs`. If migration
-or smoke fails it aborts **before** the restart, so the running scheduler keeps
-serving the old code untouched until the new code passes smoke.
+`odds scheduler smoke` → `sudo systemctl restart odds-scheduler` →
+`systemctl status` + `odds scheduler list-jobs`. Smoke runs every bootstrapped
+job's full body with zero outward side effects (see above), so "smoke passed"
+means "the changed code runs green." If migration or smoke fails it aborts
+**before** the restart, so the running scheduler keeps serving the old code
+untouched until the new code passes smoke.
 
 Migration ordering: `alembic upgrade head` runs before the restart, so the
 still-running old scheduler briefly sees the new schema. Safe for additive

--- a/packages/odds-cli/odds_cli/commands/scheduler.py
+++ b/packages/odds-cli/odds_cli/commands/scheduler.py
@@ -334,14 +334,9 @@ def smoke(
     include_agent: bool = typer.Option(
         False,
         "--include-agent",
-        help="Also run smoke-unsafe jobs (agent-run). Off by default so a deploy "
-        "check never places paper bets.",
-    ),
-    no_side_effects: bool = typer.Option(
-        False,
-        "--no-side-effects",
-        help="Drop outward-posting jobs (daily-digest) so the check stays silent "
-        "on shared channels.",
+        help="Also run agent-run. Off by default because it is expensive (LLM + "
+        "web-search spend, multi-minute subprocess), not because it is unsafe — "
+        "paper bets are suppressed during smoke.",
     ),
     only: list[str] | None = typer.Option(  # noqa: B008 — typer option idiom
         None,
@@ -355,39 +350,43 @@ def smoke(
     ),
 ) -> None:
     """
-    Run each bootstrapped job once and report pass/fail (deploy validation).
+    Run every bootstrapped job's full body once and report pass/fail.
 
     Derives the job set from ``scheduler.bootstrap_jobs`` (the same single
     source of truth ``start`` uses), expands per-sport jobs into one run per
     configured sport, runs each once, and prints a per-job pass/fail table.
     Exits non-zero (exit code = number of failed jobs) if any job fails.
 
-    ``agent-run`` is skipped by default (never place paper bets during a deploy
-    check); pass ``--include-agent`` to run it. ``daily-digest`` posts to Discord;
-    pass ``--no-side-effects`` to drop it.
+    Runs under ``RunPolicy(respect_gate=False, self_schedule=False,
+    commit_external=False)`` so each job's full body executes end-to-end with
+    zero outward side effects:
 
-    Run with ``SCHEDULER_DRY_RUN=true`` (as ``deploy.sh`` does) so self-scheduling
-    is a no-op and the live schedule store is untouched.
+    - the cadence gate is bypassed, so the real fetch+ingest body runs even
+      when a job is not "due" at deploy time;
+    - nothing is written to the schedule store (the live schedule is untouched
+      until the scheduler restarts);
+    - every outward call is suppressed at its sink — Discord posts (including
+      failure alerts and the daily digest) and agent paper bets — so a deploy
+      check never escapes to a shared channel or the live portfolio.
 
-    Coverage caveat: smoke always exercises each job's import / config / decision /
-    schema path, but the full fetch+ingest body only runs when the job's cadence
-    gate (``decision.should_execute``) says execute. A ``--force`` gate bypass is
-    out of scope.
+    ``agent-run`` is skipped by default only because it is expensive; pass
+    ``--include-agent`` to run it (its paper bets are still suppressed).
 
     Usage:
-        SCHEDULER_DRY_RUN=true odds scheduler smoke
-        odds scheduler smoke --no-side-effects
+        odds scheduler smoke
         odds scheduler smoke --only fetch-oddsportal --only fetch-espn-fixtures
         odds scheduler smoke --include-agent
     """
     app_settings = get_settings()
 
+    from odds_core.alerts import commit_external
+    from odds_lambda.scheduling.backends import suppress_scheduling
     from odds_lambda.scheduling.jobs import (
+        SMOKE_POLICY,
         JobContext,
         expected_compound_job_names,
         get_job_function,
-        is_outward_posting,
-        is_smoke_unsafe,
+        is_smoke_expensive,
         resolve_job_name,
     )
 
@@ -398,12 +397,6 @@ def smoke(
     if not candidates:
         console.print("[yellow]No jobs to smoke — bootstrap_jobs is empty.[/yellow]")
         return
-
-    if not app_settings.scheduler.dry_run:
-        console.print(
-            "[yellow]⚠ SCHEDULER_DRY_RUN is not set — jobs may write real schedules "
-            "to the store. Set SCHEDULER_DRY_RUN=true (deploy.sh does this).[/yellow]"
-        )
 
     base_of = {c: resolve_job_name(c)[0] for c in candidates}
 
@@ -448,33 +441,31 @@ def smoke(
     for name in sorted(selected):
         if name in excluded_names:
             skipped.append((name, "excluded (--exclude)"))
-        elif is_smoke_unsafe(name) and not include_agent:
-            skipped.append((name, "smoke-unsafe (pass --include-agent)"))
-        elif is_outward_posting(name) and no_side_effects:
-            skipped.append((name, "outward-posting (--no-side-effects)"))
+        elif is_smoke_expensive(name) and not include_agent:
+            skipped.append((name, "expensive (pass --include-agent)"))
         else:
             to_run.append(name)
 
-    console.print("[bold blue]Smoke-testing bootstrapped jobs...[/bold blue]")
-    console.print(
-        f"[dim]Backend: {app_settings.scheduler.backend} | "
-        f"dry_run: {app_settings.scheduler.dry_run}[/dim]\n"
-    )
+    console.print("[bold blue]Smoke-testing bootstrapped jobs (no side effects)...[/bold blue]")
+    console.print(f"[dim]Backend: {app_settings.scheduler.backend}[/dim]\n")
 
     async def _run_all() -> list[tuple[str, bool, str]]:
         results: list[tuple[str, bool, str]] = []
-        for name in to_run:
-            base_name, sport = resolve_job_name(name)
-            ctx = JobContext(sport=sport) if sport else JobContext()
-            try:
-                job_func = get_job_function(base_name)
-                await job_func(ctx)
-                results.append((name, True, ""))
-                console.print(f"[green]  ✓ {name}[/green]")
-            except Exception as e:  # noqa: BLE001 — one failure must not abort the rest
-                logger.error("smoke_job_failed", job=name, error=str(e), exc_info=True)
-                results.append((name, False, str(e)))
-                console.print(f"[red]  ✗ {name}: {e}[/red]")
+        # Force full bodies (SMOKE_POLICY.respect_gate=False) while suppressing
+        # self-scheduling and outward delivery for the whole batch.
+        with suppress_scheduling(), commit_external(False):
+            for name in to_run:
+                base_name, sport = resolve_job_name(name)
+                ctx = JobContext(sport=sport, policy=SMOKE_POLICY)
+                try:
+                    job_func = get_job_function(base_name)
+                    await job_func(ctx)
+                    results.append((name, True, ""))
+                    console.print(f"[green]  ✓ {name}[/green]")
+                except Exception as e:  # noqa: BLE001 — one failure must not abort the rest
+                    logger.error("smoke_job_failed", job=name, error=str(e), exc_info=True)
+                    results.append((name, False, str(e)))
+                    console.print(f"[red]  ✗ {name}: {e}[/red]")
         return results
 
     results = asyncio.run(_run_all()) if to_run else []

--- a/packages/odds-cli/odds_cli/commands/scheduler.py
+++ b/packages/odds-cli/odds_cli/commands/scheduler.py
@@ -379,11 +379,10 @@ def smoke(
     """
     app_settings = get_settings()
 
-    from odds_core.alerts import commit_external
-    from odds_lambda.scheduling.backends import suppress_scheduling
     from odds_lambda.scheduling.jobs import (
         SMOKE_POLICY,
         JobContext,
+        apply_run_policy,
         expected_compound_job_names,
         get_job_function,
         is_smoke_expensive,
@@ -452,8 +451,10 @@ def smoke(
     async def _run_all() -> list[tuple[str, bool, str]]:
         results: list[tuple[str, bool, str]] = []
         # Force full bodies (SMOKE_POLICY.respect_gate=False) while suppressing
-        # self-scheduling and outward delivery for the whole batch.
-        with suppress_scheduling(), commit_external(False):
+        # self-scheduling and outward delivery for the whole batch. A single
+        # ``apply_run_policy`` opens both scopes from the policy's fields so the
+        # gate, scheduling, and delivery never drift apart.
+        with apply_run_policy(SMOKE_POLICY):
             for name in to_run:
                 base_name, sport = resolve_job_name(name)
                 ctx = JobContext(sport=sport, policy=SMOKE_POLICY)

--- a/packages/odds-core/odds_core/alerts.py
+++ b/packages/odds-core/odds_core/alerts.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager, contextmanager
+from contextvars import ContextVar
 from datetime import UTC, datetime, timedelta
 
 import aiohttp
@@ -13,6 +14,40 @@ import structlog
 from odds_core.config import Settings, get_settings
 
 logger = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# External-delivery policy (the ``commit_external`` seam)
+# ---------------------------------------------------------------------------
+#
+# A single process-local switch that suppresses every outward side effect
+# (Discord posts here; paper bets at their own writer). Default is ``True``
+# (live). The scheduler ``smoke`` command flips it off for the duration of a
+# validation run so a deploy check can exercise full job bodies without
+# anything escaping to a shared channel. Because suppression lives at the
+# delivery sink, no registry of "which jobs post" is needed — any outward call
+# is suppressed automatically.
+_commit_external: ContextVar[bool] = ContextVar("odds_commit_external", default=True)
+
+
+def commit_external_enabled() -> bool:
+    """Whether outward delivery (Discord, paper bets) is currently permitted."""
+    return _commit_external.get()
+
+
+@contextmanager
+def commit_external(enabled: bool) -> Iterator[None]:
+    """Scope outward delivery on/off for the duration of the ``with`` block.
+
+    Used by ``scheduler smoke`` with ``enabled=False`` so job bodies run but
+    deliver nothing. Restores the previous value on exit, so nested or
+    per-task runs stay isolated.
+    """
+    token = _commit_external.set(enabled)
+    try:
+        yield
+    finally:
+        _commit_external.reset(token)
 
 
 class AlertBase(ABC):
@@ -122,6 +157,10 @@ class AlertManager:
         Note:
             Only sends if alerts are enabled in configuration
         """
+        if not commit_external_enabled():
+            logger.debug("alert_suppressed_commit_external", message=message)
+            return
+
         if not self.enabled:
             logger.debug("alert_skipped_disabled", message=message)
             return
@@ -138,6 +177,10 @@ class AlertManager:
 
     async def send_embed(self, embed: dict) -> None:
         """Send a raw embed to all configured channels."""
+        if not commit_external_enabled():
+            logger.debug("embed_suppressed_commit_external")
+            return
+
         if not self.enabled:
             logger.debug("embed_skipped_disabled")
             return
@@ -246,7 +289,11 @@ async def job_alert_context(job_name: str) -> AsyncIterator[None]:
         yield
     except Exception as e:
         alert_type = f"job_failure:{job_name}"
-        if alert_manager.enabled and await check_rate_limit(alert_type):
+        if (
+            commit_external_enabled()
+            and alert_manager.enabled
+            and await check_rate_limit(alert_type)
+        ):
             msg = f"🚨 Job {job_name} failed: {type(e).__name__}: {e}"
             await alert_manager.alert(msg, "critical")
             await record_to_alert_history(alert_type, "critical", msg)
@@ -268,6 +315,8 @@ async def send_job_warning(alert_type: str, message: str) -> bool:
 
     Returns True if the alert was sent, False if disabled or rate-limited.
     """
+    if not commit_external_enabled():
+        return False
     if not alert_manager.enabled:
         return False
     if not await check_rate_limit(alert_type):

--- a/packages/odds-lambda/odds_lambda/health_monitor.py
+++ b/packages/odds-lambda/odds_lambda/health_monitor.py
@@ -142,9 +142,18 @@ class HealthMonitor:
             return False
 
         # Send via alert system
-        from odds_core.alerts import alert_manager
+        from odds_core.alerts import alert_manager, commit_external_enabled
 
         await alert_manager.alert(message, severity)
+
+        # Under suppression (e.g. ``scheduler smoke``) ``alert_manager.alert`` is
+        # a no-op, so persisting an AlertHistory row would falsely claim the
+        # alert was sent and pollute rate-limiting/heartbeat state. Mirror the
+        # ``commit_external_enabled`` guard used by ``job_alert_context`` and
+        # ``send_job_warning``: skip the record (and report not-sent) when
+        # outward delivery is suppressed.
+        if not commit_external_enabled():
+            return False
 
         # Record in database
         await self._record_alert(alert_type, severity, message, context)

--- a/packages/odds-lambda/odds_lambda/jobs/agent_run.py
+++ b/packages/odds-lambda/odds_lambda/jobs/agent_run.py
@@ -144,6 +144,16 @@ def _build_agent_subprocess_env() -> dict[str, str]:
                 "write-capable DSN (security control disabled)"
             ),
         )
+
+    # ``commit_external`` is a process-local contextvar that cannot cross the
+    # subprocess boundary, so bridge it via an env var the MCP ``paper_bet``
+    # tool checks. Under a smoke run (commit_external=False) the agent still
+    # researches and reasons but its paper bets are suppressed at the writer.
+    from odds_core.alerts import commit_external_enabled
+
+    if not commit_external_enabled():
+        env["ODDS_SUPPRESS_PAPER_BET"] = "true"
+
     return env
 
 

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_odds.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_odds.py
@@ -125,7 +125,8 @@ async def main(ctx: JobContext) -> None:
     # Pre-schedule before any work so the chain survives crashes.
     await _schedule(decision, label="pre-schedule")
 
-    if not decision.should_execute:
+    # ``respect_gate=False`` (deploy smoke) forces the full body even when not due.
+    if not decision.should_execute and ctx.policy.respect_gate:
         logger.info(
             "fetch_odds_skipped",
             reason=decision.reason,

--- a/packages/odds-lambda/odds_lambda/jobs/fetch_scores.py
+++ b/packages/odds-lambda/odds_lambda/jobs/fetch_scores.py
@@ -95,7 +95,8 @@ async def main(ctx: JobContext) -> None:
     # Pre-schedule before any work so the chain survives crashes.
     await _schedule(decision, label="pre-schedule")
 
-    if not decision.should_execute:
+    # ``respect_gate=False`` (deploy smoke) forces the full body even when not due.
+    if not decision.should_execute and ctx.policy.respect_gate:
         logger.info(
             "fetch_scores_skipped",
             reason=decision.reason,

--- a/packages/odds-lambda/odds_lambda/jobs/update_status.py
+++ b/packages/odds-lambda/odds_lambda/jobs/update_status.py
@@ -89,7 +89,8 @@ async def main(ctx: JobContext) -> None:
     # Pre-schedule before any work so the chain survives crashes.
     await _schedule(decision, label="pre-schedule")
 
-    if not decision.should_execute:
+    # ``respect_gate=False`` (deploy smoke) forces the full body even when not due.
+    if not decision.should_execute and ctx.policy.respect_gate:
         logger.info(
             "update_status_skipped",
             reason=decision.reason,

--- a/packages/odds-lambda/odds_lambda/scheduling/backends/__init__.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/backends/__init__.py
@@ -1,5 +1,9 @@
 """Scheduler backend implementations."""
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
 from odds_lambda.scheduling.backends.base import (
     BackendHealth,
     JobStatus,
@@ -16,6 +20,40 @@ from odds_lambda.scheduling.exceptions import (
     SchedulerBackendError,
     SchedulingFailedError,
 )
+
+# ---------------------------------------------------------------------------
+# Self-scheduling policy (the ``self_schedule`` seam)
+# ---------------------------------------------------------------------------
+#
+# Process-local switch that forces every backend constructed via
+# ``get_scheduler_backend`` into dry-run, so no rows are written to the
+# schedule store regardless of the ``dry_run`` a caller passes. Default is
+# ``True`` (scheduling permitted). The scheduler ``smoke`` command flips it off
+# so a validation run exercises full job bodies — including their self-schedule
+# call — while leaving the live schedule store untouched. Enforcing it at the
+# single backend-construction chokepoint means no per-job knowledge of which
+# jobs self-schedule is needed. Blast radius stays on the local scheduler: the
+# Lambda/EventBridge dispatch path never enters this context.
+_scheduling_enabled: ContextVar[bool] = ContextVar("odds_scheduling_enabled", default=True)
+
+
+def scheduling_enabled() -> bool:
+    """Whether self-scheduling (writes to the schedule store) is permitted."""
+    return _scheduling_enabled.get()
+
+
+@contextmanager
+def suppress_scheduling(suppressed: bool = True) -> Iterator[None]:
+    """Scope self-scheduling off for the duration of the ``with`` block.
+
+    Used by ``scheduler smoke`` so job bodies run without persisting any
+    schedule. Restores the previous value on exit.
+    """
+    token = _scheduling_enabled.set(not suppressed)
+    try:
+        yield
+    finally:
+        _scheduling_enabled.reset(token)
 
 
 def get_scheduler_backend(
@@ -69,6 +107,10 @@ def get_scheduler_backend(
     settings = get_settings()
     backend = backend_type or settings.scheduler.backend.lower()
 
+    # A ``suppress_scheduling`` scope (set by ``scheduler smoke``) forces dry-run
+    # at this single chokepoint so no job can write to the schedule store.
+    dry_run = dry_run or not scheduling_enabled()
+
     if backend == "aws":
         from odds_lambda.scheduling.backends.aws import AWSEventBridgeBackend
 
@@ -119,4 +161,7 @@ __all__ = [
     "JobNotFoundError",
     # Factory function
     "get_scheduler_backend",
+    # Self-scheduling policy seam
+    "scheduling_enabled",
+    "suppress_scheduling",
 ]

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Iterable, Sequence
+from collections.abc import Awaitable, Callable, Iterable, Iterator, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass, field, fields
 from importlib import import_module
 
@@ -27,12 +28,21 @@ class RunPolicy:
 
     Enforcement lives at three chokepoints rather than per-job:
 
-    - ``respect_gate`` — read at each cadence-gate site (``if not
-      should_execute and ctx.policy.respect_gate: return``).
-    - ``self_schedule`` — translated to a ``suppress_scheduling`` scope around
-      the run, enforced where backends are constructed.
-    - ``commit_external`` — translated to a ``commit_external`` scope around the
-      run, enforced inside ``AlertManager`` and the paper-bet writer.
+    - ``respect_gate`` — read directly at each cadence-gate site (``if not
+      should_execute and ctx.policy.respect_gate: return``). It needs no
+      surrounding scope.
+    - ``self_schedule`` — when ``False``, ``apply_run_policy`` opens a
+      ``suppress_scheduling`` scope so no rows are written to the schedule
+      store (enforced where backends are constructed).
+    - ``commit_external`` — when ``False``, ``apply_run_policy`` opens a
+      ``commit_external(False)`` scope so outward delivery is dropped at its
+      sinks (``AlertManager`` and the paper-bet writer).
+
+    ``apply_run_policy(policy)`` is the single translator from these fields to
+    the contextvar scopes; callers should never open the underlying scopes
+    independently. Constructing a ``JobContext`` with a non-default policy and
+    running the body without entering ``apply_run_policy`` would silently
+    bypass only the gate while leaving delivery and scheduling live.
     """
 
     respect_gate: bool = True
@@ -43,6 +53,28 @@ class RunPolicy:
 # Preset for deploy-validation runs: force every body, persist nothing, deliver
 # nothing.
 SMOKE_POLICY = RunPolicy(respect_gate=False, self_schedule=False, commit_external=False)
+
+
+@contextmanager
+def apply_run_policy(policy: RunPolicy) -> Iterator[None]:
+    """Open the contextvar scopes implied by a ``RunPolicy``'s fields.
+
+    This is the single source of truth for translating a policy into the
+    suppression scopes that actually enforce it: ``self_schedule=False`` opens
+    a ``suppress_scheduling`` scope and ``commit_external=False`` opens a
+    ``commit_external(False)`` scope. ``respect_gate`` is consulted directly in
+    job bodies and needs no scope. A live ``RunPolicy()`` leaves both scopes at
+    their permissive defaults, so wrapping a live run is a harmless no-op.
+
+    Enter this around any run that uses a non-default policy (e.g. ``scheduler
+    smoke`` with ``SMOKE_POLICY``); do not open the underlying scopes by hand.
+    """
+    from odds_core.alerts import commit_external
+
+    from odds_lambda.scheduling.backends import suppress_scheduling
+
+    with suppress_scheduling(not policy.self_schedule), commit_external(policy.commit_external):
+        yield
 
 
 @dataclass

--- a/packages/odds-lambda/odds_lambda/scheduling/jobs.py
+++ b/packages/odds-lambda/odds_lambda/scheduling/jobs.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Iterable, Sequence
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, field, fields
 from importlib import import_module
 
 import structlog
@@ -12,6 +12,37 @@ from odds_core.sports import SportKey
 from odds_lambda.betfair.constants import SPORT_CONFIG as BETFAIR_SPORT_CONFIG
 
 logger = structlog.get_logger()
+
+
+@dataclass(frozen=True)
+class RunPolicy:
+    """How a job run treats its cadence gate, self-scheduling, and side effects.
+
+    The default is a live run: respect the cadence gate, write the next
+    schedule, and commit outward side effects (Discord posts, paper bets).
+    ``scheduler smoke`` uses ``RunPolicy(False, False, False)`` so every
+    bootstrapped body runs end-to-end while nothing escapes — the gate is
+    bypassed (forcing the full body), the schedule store is left untouched, and
+    outward delivery is suppressed at its sinks.
+
+    Enforcement lives at three chokepoints rather than per-job:
+
+    - ``respect_gate`` — read at each cadence-gate site (``if not
+      should_execute and ctx.policy.respect_gate: return``).
+    - ``self_schedule`` — translated to a ``suppress_scheduling`` scope around
+      the run, enforced where backends are constructed.
+    - ``commit_external`` — translated to a ``commit_external`` scope around the
+      run, enforced inside ``AlertManager`` and the paper-bet writer.
+    """
+
+    respect_gate: bool = True
+    self_schedule: bool = True
+    commit_external: bool = True
+
+
+# Preset for deploy-validation runs: force every body, persist nothing, deliver
+# nothing.
+SMOKE_POLICY = RunPolicy(respect_gate=False, self_schedule=False, commit_external=False)
 
 
 @dataclass
@@ -35,14 +66,19 @@ class JobContext:
     lookback_hours: float = 24
     lookahead_hours: float = 48
 
+    # Execution policy — defaults to a live run. Not sourced from the event
+    # payload (scheduled re-runs are always live); ``smoke`` sets it explicitly.
+    policy: RunPolicy = field(default_factory=RunPolicy)
+
     @classmethod
     def from_payload(cls, payload: dict[str, object]) -> JobContext:
         """Construct a ``JobContext`` from a raw event/scheduler payload.
 
         Known keys are mapped to dataclass fields; unknown keys are
-        logged and ignored.
+        logged and ignored. ``policy`` is never taken from a payload — a
+        reconstructed scheduled run is always live.
         """
-        known_fields = {f.name for f in fields(cls)}
+        known_fields = {f.name for f in fields(cls)} - {"policy"}
         known: dict[str, object] = {}
         for k, v in payload.items():
             if k in known_fields:
@@ -89,16 +125,12 @@ _SPORT_SUFFIX_MAP: dict[str, SportKey] = {
     "mlb": "baseball_mlb",
 }
 
-# Jobs that must never run during a deploy smoke check, even when listed in
-# ``bootstrap_jobs``. ``agent-run`` places paper bets — executing it as part of
-# a pre-restart validation would pollute the live portfolio. The smoke command
-# skips these by default and only runs them under an explicit opt-in.
-_SMOKE_UNSAFE_JOBS: frozenset[str] = frozenset({"agent-run"})
-
-# Jobs that post to outward channels (e.g. Discord) on every run. The smoke
-# command drops these under ``--no-side-effects`` so a validation run can stay
-# silent on shared channels.
-_OUTWARD_POSTING_JOBS: frozenset[str] = frozenset({"daily-digest"})
+# Jobs that are skipped by default during a deploy smoke check for *cost*, not
+# safety. Under ``RunPolicy.commit_external=False`` ``agent-run`` writes no
+# paper bet, so it is no longer unsafe — only expensive (LLM + web-search
+# spend, plus a multi-minute subprocess). The smoke command skips these by
+# default and runs them only under an explicit ``--include-agent`` opt-in.
+_SMOKE_EXPENSIVE_JOBS: frozenset[str] = frozenset({"agent-run"})
 
 # Jobs that accept a sport parameter. When invoked with a sport suffix
 # (e.g. "fetch-odds-epl"), the sport_key is extracted and passed as a kwarg.
@@ -264,22 +296,13 @@ def is_per_sport_job(job_name: str) -> bool:
     return job_name in _PER_SPORT_JOBS
 
 
-def is_smoke_unsafe(job_name: str) -> bool:
-    """Whether a job must never run during a deploy smoke check.
+def is_smoke_expensive(job_name: str) -> bool:
+    """Whether a job is skipped by default in smoke for cost (not safety).
 
     Accepts a compound (sport-suffixed) or base job name.
     """
     base_name, _ = resolve_job_name(job_name)
-    return base_name in _SMOKE_UNSAFE_JOBS
-
-
-def is_outward_posting(job_name: str) -> bool:
-    """Whether a job posts to outward channels (e.g. Discord) on every run.
-
-    Accepts a compound (sport-suffixed) or base job name.
-    """
-    base_name, _ = resolve_job_name(job_name)
-    return base_name in _OUTWARD_POSTING_JOBS
+    return base_name in _SMOKE_EXPENSIVE_JOBS
 
 
 def resolve_target_sports(job_name: str, configured_sports: Sequence[SportKey]) -> list[SportKey]:

--- a/packages/odds-mcp/odds_mcp/server.py
+++ b/packages/odds-mcp/odds_mcp/server.py
@@ -7,6 +7,7 @@ All tools are stateless and use async_session_maker() for DB access.
 import asyncio
 import json
 import math
+import os
 import statistics
 from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
@@ -38,6 +39,21 @@ from odds_mcp.tools.epl import epl_mcp
 from odds_mcp.tools.mlb import mlb_mcp
 
 logger = structlog.get_logger()
+
+# Truthy env values for the paper-bet suppression bridge.
+_TRUTHY_ENV = frozenset({"1", "true", "yes", "on"})
+
+
+def _paper_bets_suppressed() -> bool:
+    """Whether paper bets are suppressed for this process.
+
+    Set by the agent-run job (via ``ODDS_SUPPRESS_PAPER_BET``) during a deploy
+    smoke run so the agent can be exercised end-to-end without polluting the
+    live portfolio. The flag is inherited by this MCP server because it is a
+    child of the agent subprocess.
+    """
+    return os.environ.get("ODDS_SUPPRESS_PAPER_BET", "").strip().lower() in _TRUTHY_ENV
+
 
 MarketKey = Literal["h2h", "1x2", "totals", "spreads"]
 
@@ -589,6 +605,13 @@ async def paper_bet(
     Returns:
         Dict with the placed trade details.
     """
+    if _paper_bets_suppressed():
+        logger.info("paper_bet_suppressed", event_id=event_id, selection=selection, stake=stake)
+        return {
+            "status": "suppressed",
+            "reason": "paper bets suppressed for this run (deploy smoke / commit_external=False)",
+        }
+
     async with async_session_maker() as session:
         event_result = await session.execute(select(Event).where(Event.id == event_id))
         event = event_result.scalar_one_or_none()

--- a/tests/unit/test_agent_run.py
+++ b/tests/unit/test_agent_run.py
@@ -455,6 +455,31 @@ class TestBuildAgentSubprocessEnv:
         mock_logger.warning.assert_called_once()
         assert mock_logger.warning.call_args[0][0] == "agent_database_url_not_set"
 
+    def test_sets_suppress_flag_under_commit_external_false(self) -> None:
+        """A smoke run (commit_external=False) bridges suppression to the subprocess."""
+        from odds_core.alerts import commit_external
+
+        parent_env = {"DATABASE_URL": "postgresql://parent:pw@host/db", "PATH": "/usr/bin"}
+        with (
+            patch.dict("os.environ", parent_env, clear=True),
+            patch("odds_lambda.jobs.agent_run.logger"),
+        ):
+            with commit_external(False):
+                env = _build_agent_subprocess_env()
+
+        assert env["ODDS_SUPPRESS_PAPER_BET"] == "true"
+
+    def test_no_suppress_flag_when_live(self) -> None:
+        """A live run leaves the suppression bridge unset."""
+        parent_env = {"DATABASE_URL": "postgresql://parent:pw@host/db", "PATH": "/usr/bin"}
+        with (
+            patch.dict("os.environ", parent_env, clear=True),
+            patch("odds_lambda.jobs.agent_run.logger"),
+        ):
+            env = _build_agent_subprocess_env()
+
+        assert "ODDS_SUPPRESS_PAPER_BET" not in env
+
     def test_returned_env_is_a_copy(self) -> None:
         """Mutating the returned env dict must not affect ``os.environ``."""
         import os

--- a/tests/unit/test_alerts.py
+++ b/tests/unit/test_alerts.py
@@ -6,9 +6,12 @@ import pytest
 from odds_core.alerts import (
     AlertManager,
     DiscordAlert,
+    commit_external,
+    commit_external_enabled,
     job_alert_context,
     send_critical,
     send_error,
+    send_job_warning,
     send_warning,
 )
 from odds_core.config import AlertConfig, Settings
@@ -87,6 +90,92 @@ class TestAlertManager:
 
             # Should call send because enabled=True
             mock_send.assert_called_once_with("Test message", "warning")
+
+
+class TestCommitExternalSeam:
+    """The ``commit_external`` switch suppresses all outward delivery at the sink."""
+
+    def test_default_is_live(self) -> None:
+        assert commit_external_enabled() is True
+
+    def test_context_manager_scopes_and_restores(self) -> None:
+        assert commit_external_enabled() is True
+        with commit_external(False):
+            assert commit_external_enabled() is False
+        assert commit_external_enabled() is True
+
+    @pytest.mark.asyncio
+    async def test_alert_suppressed_when_commit_external_false(self) -> None:
+        """An outward alert during commit_external=False must not hit delivery."""
+        settings = MagicMock(spec=Settings)
+        settings.alerts = AlertConfig(
+            alert_enabled=True, discord_webhook_url="https://discord.com/api/webhooks/test"
+        )
+        manager = AlertManager(config=settings)
+
+        with patch.object(manager.channels[0], "send", new_callable=AsyncMock) as mock_send:
+            with commit_external(False):
+                await manager.alert("Test message", "warning")
+            mock_send.assert_not_called()
+
+            # Restored outside the scope: delivery happens again.
+            await manager.alert("Test message", "warning")
+            mock_send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_embed_suppressed_when_commit_external_false(self) -> None:
+        settings = MagicMock(spec=Settings)
+        settings.alerts = AlertConfig(
+            alert_enabled=True, discord_webhook_url="https://discord.com/api/webhooks/test"
+        )
+        manager = AlertManager(config=settings)
+
+        with patch.object(manager.channels[0], "send_embed", new_callable=AsyncMock) as mock_embed:
+            with commit_external(False):
+                await manager.send_embed({"title": "digest"})
+            mock_embed.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("odds_core.alerts.record_to_alert_history", new_callable=AsyncMock)
+    @patch("odds_core.alerts.check_rate_limit", new_callable=AsyncMock, return_value=True)
+    @patch("odds_core.alerts.alert_manager")
+    async def test_job_failure_alert_suppressed_under_commit_external_false(
+        self,
+        mock_manager: MagicMock,
+        mock_rate_limit: AsyncMock,
+        mock_record: AsyncMock,
+    ) -> None:
+        """A failing job under smoke re-raises but pings nothing and records no row."""
+        mock_manager.enabled = True
+        mock_manager.alert = AsyncMock()
+
+        with pytest.raises(ValueError):
+            with commit_external(False):
+                async with job_alert_context("test-job"):
+                    raise ValueError("boom")
+
+        mock_manager.alert.assert_not_called()
+        mock_record.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("odds_core.alerts.record_to_alert_history", new_callable=AsyncMock)
+    @patch("odds_core.alerts.check_rate_limit", new_callable=AsyncMock, return_value=True)
+    @patch("odds_core.alerts.alert_manager")
+    async def test_send_job_warning_suppressed_under_commit_external_false(
+        self,
+        mock_manager: MagicMock,
+        mock_rate_limit: AsyncMock,
+        mock_record: AsyncMock,
+    ) -> None:
+        mock_manager.enabled = True
+        mock_manager.alert = AsyncMock()
+
+        with commit_external(False):
+            sent = await send_job_warning("soft:test", "empty scrape")
+
+        assert sent is False
+        mock_manager.alert.assert_not_called()
+        mock_record.assert_not_called()
 
 
 class TestDiscordAlert:

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -620,6 +620,61 @@ class TestPaperBetValidation:
             assert "nonexistent" in result["error"]
 
 
+class TestPaperBetSuppression:
+    """Paper bets are suppressed when the agent runs under a smoke policy.
+
+    ``agent-run`` exports ``ODDS_SUPPRESS_PAPER_BET`` to its subprocess (and
+    thus the MCP server it spawns) so a deploy check can exercise the agent
+    end-to-end without writing to the live portfolio.
+    """
+
+    @pytest.mark.asyncio
+    async def test_suppressed_returns_without_db_write(self, monkeypatch) -> None:
+        from odds_mcp.server import paper_bet
+
+        monkeypatch.setenv("ODDS_SUPPRESS_PAPER_BET", "true")
+
+        with patch("odds_mcp.server.async_session_maker") as mock_session_maker:
+            result = await paper_bet(
+                event_id="evt-1",
+                market="h2h",
+                selection="home",
+                odds=-110,
+                stake=10.0,
+            )
+
+        assert result["status"] == "suppressed"
+        # The writer is never reached — no session is opened.
+        mock_session_maker.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_not_suppressed_when_env_unset(self, monkeypatch) -> None:
+        from odds_mcp.server import paper_bet
+
+        monkeypatch.delenv("ODDS_SUPPRESS_PAPER_BET", raising=False)
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("odds_mcp.server.async_session_maker") as mock_session_maker:
+            mock_session_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_maker.return_value.__aexit__ = AsyncMock()
+
+            result = await paper_bet(
+                event_id="nonexistent",
+                market="h2h",
+                selection="home",
+                odds=-110,
+                stake=10.0,
+            )
+
+        # Falls through to the normal path (event lookup), not suppressed.
+        assert result.get("status") != "suppressed"
+        mock_session_maker.assert_called_once()
+
+
 class TestFindRetailEdges:
     """Unit tests for the ``find_retail_edges`` MCP tool."""
 

--- a/tests/unit/test_scheduler_cli.py
+++ b/tests/unit/test_scheduler_cli.py
@@ -78,12 +78,14 @@ class _JobRecorder:
     def __init__(self, fail_bases: set[str] | None = None) -> None:
         self.fail_bases = fail_bases or set()
         self.ran: list[tuple[str, str | None]] = []
+        self.policies: list[object] = []
 
     def __call__(self, base_name: str):
         recorder = self
 
         async def _job(ctx) -> None:
             recorder.ran.append((base_name, ctx.sport))
+            recorder.policies.append(ctx.policy)
             if base_name in recorder.fail_bases:
                 raise RuntimeError(f"{base_name} boom")
 
@@ -134,14 +136,21 @@ class TestSmokeCommand:
         assert result.exit_code == 0
         assert "daily-digest" in recorder.ran_bases
 
-    def test_no_side_effects_drops_daily_digest(self) -> None:
-        settings = _settings(["fetch-oddsportal", "daily-digest"], ["soccer_epl"])
+    def test_jobs_run_under_smoke_policy(self) -> None:
+        """Each job receives the no-side-effect policy (gate off, nothing escapes)."""
+        from odds_lambda.scheduling.jobs import SMOKE_POLICY
+
+        settings = _settings(["fetch-oddsportal", "fetch-scores"], ["soccer_epl"])
         recorder = _JobRecorder()
-        result = _invoke_smoke(["--no-side-effects"], settings, recorder)
+        result = _invoke_smoke([], settings, recorder)
 
         assert result.exit_code == 0
-        assert "fetch-oddsportal" in recorder.ran_bases
-        assert "daily-digest" not in recorder.ran_bases
+        assert recorder.policies, "no jobs ran"
+        for policy in recorder.policies:
+            assert policy == SMOKE_POLICY
+            assert policy.respect_gate is False
+            assert policy.self_schedule is False
+            assert policy.commit_external is False
 
     def test_only_by_base_name_matches_all_compounds(self) -> None:
         settings = _settings(["fetch-oddsportal", "fetch-scores"], ["soccer_epl", "baseball_mlb"])

--- a/tests/unit/test_scheduling_helpers.py
+++ b/tests/unit/test_scheduling_helpers.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from odds_lambda.scheduling.decision import ScheduleDecision
 from odds_lambda.scheduling.helpers import apply_overnight_skip, get_next_kickoff, self_schedule
 
 
@@ -169,6 +170,55 @@ class TestSuppressScheduling:
 
         backend = get_scheduler_backend(backend_type="local", dry_run=False)
         assert backend.dry_run is False
+
+
+class TestGateBypass:
+    """Under ``SMOKE_POLICY`` (respect_gate=False) the body runs even when the
+    cadence decision says ``should_execute=False``.
+
+    This is the property that makes ``scheduler smoke`` exercise the real
+    fetch+ingest body of gated jobs that are not "due" at deploy time.
+    """
+
+    @staticmethod
+    def _not_due_decision() -> ScheduleDecision:
+        return ScheduleDecision(
+            should_execute=False,
+            reason="no upcoming game",
+            next_execution=datetime.now(UTC) + timedelta(hours=6),
+            tier=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_smoke_policy_runs_body_when_not_due(self) -> None:
+        from odds_lambda.jobs import fetch_scores
+        from odds_lambda.scheduling.jobs import SMOKE_POLICY, JobContext
+
+        body = AsyncMock()
+        with (
+            patch.object(fetch_scores, "_scores_decision", return_value=self._not_due_decision()),
+            patch.object(fetch_scores, "self_schedule", new=AsyncMock()),
+            patch.object(fetch_scores, "_fetch_and_update_scores", new=body),
+        ):
+            await fetch_scores.main(JobContext(sport="soccer_epl", policy=SMOKE_POLICY))
+
+        body.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_live_policy_skips_body_when_not_due(self) -> None:
+        from odds_lambda.jobs import fetch_scores
+        from odds_lambda.scheduling.jobs import JobContext
+
+        body = AsyncMock()
+        with (
+            patch.object(fetch_scores, "_scores_decision", return_value=self._not_due_decision()),
+            patch.object(fetch_scores, "self_schedule", new=AsyncMock()),
+            patch.object(fetch_scores, "_fetch_and_update_scores", new=body),
+        ):
+            # Default JobContext policy is live (respect_gate=True).
+            await fetch_scores.main(JobContext(sport="soccer_epl"))
+
+        body.assert_not_awaited()
 
 
 class TestSmokeTags:

--- a/tests/unit/test_scheduling_helpers.py
+++ b/tests/unit/test_scheduling_helpers.py
@@ -137,25 +137,57 @@ class TestSelfSchedule:
         assert call_kwargs["payload"] is None
 
 
+class TestSuppressScheduling:
+    """The ``suppress_scheduling`` scope forces every backend into dry-run.
+
+    This is the single chokepoint that guarantees no rows are written to the
+    schedule store during a smoke run, regardless of which job self-schedules.
+    """
+
+    def test_default_allows_scheduling(self) -> None:
+        from odds_lambda.scheduling.backends import scheduling_enabled
+
+        assert scheduling_enabled() is True
+
+    def test_scope_disables_and_restores(self) -> None:
+        from odds_lambda.scheduling.backends import scheduling_enabled, suppress_scheduling
+
+        with suppress_scheduling():
+            assert scheduling_enabled() is False
+        assert scheduling_enabled() is True
+
+    def test_backend_forced_dry_run_under_scope(self) -> None:
+        from odds_lambda.scheduling.backends import get_scheduler_backend, suppress_scheduling
+
+        # Even with an explicit dry_run=False, the scope forces dry-run.
+        with suppress_scheduling():
+            backend = get_scheduler_backend(backend_type="local", dry_run=False)
+            assert backend.dry_run is True
+
+    def test_backend_live_outside_scope(self) -> None:
+        from odds_lambda.scheduling.backends import get_scheduler_backend
+
+        backend = get_scheduler_backend(backend_type="local", dry_run=False)
+        assert backend.dry_run is False
+
+
 class TestSmokeTags:
-    """Tags distinguishing smoke-unsafe and outward-posting jobs."""
+    """Tag distinguishing the cost-excluded (expensive) jobs from the rest.
 
-    def test_agent_run_is_smoke_unsafe(self) -> None:
-        from odds_lambda.scheduling.jobs import is_smoke_unsafe
+    There is no longer an outward-posting tag: outward side effects are
+    suppressed universally at their delivery sinks during a smoke run, so no
+    per-job registry can be "forgotten".
+    """
 
-        assert is_smoke_unsafe("agent-run")
+    def test_agent_run_is_smoke_expensive(self) -> None:
+        from odds_lambda.scheduling.jobs import is_smoke_expensive
+
+        assert is_smoke_expensive("agent-run")
         # Compound (sport-suffixed) names resolve to the same base.
-        assert is_smoke_unsafe("agent-run-epl")
+        assert is_smoke_expensive("agent-run-epl")
 
-    def test_daily_digest_is_outward_posting(self) -> None:
-        from odds_lambda.scheduling.jobs import is_outward_posting
-
-        assert is_outward_posting("daily-digest")
-        assert is_outward_posting("daily-digest-epl")
-
-    def test_data_jobs_are_neither(self) -> None:
-        from odds_lambda.scheduling.jobs import is_outward_posting, is_smoke_unsafe
+    def test_data_jobs_are_not_expensive(self) -> None:
+        from odds_lambda.scheduling.jobs import is_smoke_expensive
 
         for job in ("fetch-oddsportal", "fetch-espn-fixtures", "fetch-betfair-exchange"):
-            assert not is_smoke_unsafe(job)
-            assert not is_outward_posting(job)
+            assert not is_smoke_expensive(job)


### PR DESCRIPTION
## Summary
- Make `scheduler smoke` run every bootstrapped job's full body end-to-end while suppressing all outward side effects, driven by a single `RunPolicy(respect_gate, self_schedule, commit_external)` (`SMOKE_POLICY` preset) on `JobContext` rather than per-job knowledge of "which jobs post".
- **Cadence gate**: `fetch_odds`, `fetch_scores`, `update_status` early-return only when the decision is not due **and** `ctx.policy.respect_gate` — so smoke forces the real fetch/ingest body even when not "due".
- **Single source of truth**: `apply_run_policy(policy)` context manager translates the policy's `self_schedule`/`commit_external` fields into the `suppress_scheduling()` and `commit_external(False)` scopes; the smoke CLI enters `apply_run_policy(SMOKE_POLICY)` instead of hardcoding scopes. A live (default) policy is a true no-op.
- **Self-scheduling seam**: `suppress_scheduling` contextvar ORs into `get_scheduler_backend`'s `dry_run`, guaranteeing no schedule-store writes during smoke at a single chokepoint (local scope only; Lambda path unaffected).
- **External-delivery seam**: `commit_external` contextvar gates `AlertManager.alert`/`send_embed`, the `job_alert_context` failure alert, `send_job_warning`, and `HealthMonitor` alert recording — covering every Discord path and preventing phantom `AlertHistory` rows during smoke.
- **Paper bets**: agent-run exports `ODDS_SUPPRESS_PAPER_BET` across the subprocess boundary; the MCP `paper_bet` tool returns `{"status": "suppressed"}` when set.
- Removed the now-redundant `_OUTWARD_POSTING_JOBS`/`is_outward_posting`/`--no-side-effects` machinery; renamed `_SMOKE_UNSAFE_JOBS` → `_SMOKE_EXPENSIVE_JOBS` (agent-run is a cost exclusion, not unsafe). Updated `deploy.sh` and `docs/DEPLOYMENT.md` to drop the `SCHEDULER_DRY_RUN=true` prefix and document the "full body, zero side effects" guarantee.
- Added class-based tests for each suppression seam, the gate-bypass behavior, the paper-bet env bridge, and `SMOKE_POLICY` wiring.

## Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)